### PR TITLE
Update Docusaurus to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.1.1",
-    "@docusaurus/preset-classic": "3.1.1",
+    "@docusaurus/core": "^3.2.0",
+    "@docusaurus/preset-classic": "^3.2.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@mdx-js/react": "^3.0.0",
@@ -28,8 +28,8 @@
     "react-tabs": "^6.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.1.1",
-    "@docusaurus/types": "3.1.1"
+    "@docusaurus/module-type-aliases": "^3.2.0",
+    "@docusaurus/types": "^3.2.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Update Docusaurus to version 3.2.0. Lot of performance improvements. Cold builds are 30% and incremental builds now 60% faster.

Details on https://docusaurus.io/blog/releases/3.2