### PR TITLE
fix gap on ada mobile hero banner

### DIFF
--- a/src/components/Layout/SiteHero/styles.module.css
+++ b/src/components/Layout/SiteHero/styles.module.css
@@ -479,3 +479,10 @@ html[data-theme="dark"] .heroBannerBraidBlack::before {
     background-size: 6800px;
   }
 }
+
+@media screen and (max-width: 576px) {
+  .heroBannerAda {
+    background-position: right 50% bottom 30px;
+  }
+}
+


### PR DESCRIPTION
# Fixes issue #111.

## Tested on device on iPhone 12:
### Before:
![iphon12_before](https://github.com/user-attachments/assets/46c01239-35c4-4df8-8e6e-b00067684a81)

### After:
![iphone12_after](https://github.com/user-attachments/assets/df957825-f8cd-45fd-b7ed-55d29d91548e)

## Tested using dev tools for Galaxy S8+:
### Before:
![galaxys8+_before](https://github.com/user-attachments/assets/6e4f6338-6ebf-45f4-8fa4-bedc60fde542)

### After:
![galaxys8+_after](https://github.com/user-attachments/assets/76eb4fe0-69b7-4f6c-b77d-59061ff02b62)

