### PR TITLE
Disable announcementBar in docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,7 @@ import 'dotenv/config';
 const vars = require('./variables')
 
 // enable or disable the announcement header bar (see 'announcementBar' section below)
-const isAnnouncementActive = true;
+const isAnnouncementActive = false;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {


### PR DESCRIPTION
This pull request modifies the docusaurus.config.js file to disable the announcement bar by setting the isAnnouncementActive variable from true to false.

Testing:

- Local Testing: The change was tested locally to ensure that the announcement bar no longer appears on the website.
- Code Review: The modification was reviewed to confirm that only the intended variable was altered, with no unintended side effects.

Additional Notes:
Please review the changes.