### PR TITLE
Update external Link create-a-news-article.md

### DIFF
--- a/docs/tutorial/create-a-news-article.md
+++ b/docs/tutorial/create-a-news-article.md
@@ -38,7 +38,7 @@ This guideline ensures that readers receive a concise and informative preview of
 
 :::tip
 
-Have a relevant news article but not the technical know-how to create a pull request yourself? No problem! Just [fill out our form](https://cardanocommunity.typeform.com/to/u7hcc7Ix), and we will review your suggestion. Please note that we only accept submissions that comply with the guidelines mentioned on this page.
+Have a relevant news article, meetup recap, or blog post but not the technical know-how to create a pull request yourself? No problem! Just [fill out our form](https://cardanocommunity.typeform.com/news-submission), and we will review your suggestion. Please note that we only accept submissions that comply with the guidelines mentioned on this page.
 
 :::
 


### PR DESCRIPTION
Description:
Changing the external link for the news article submission form.

Files/Directories affected: docs/tutorial/create-a-news-article.md

Updating the tip text to be more inclusive, mentioning "meetup recap" and "blog post" in addition to "news article."

Testing:

Built the site locally to ensure the updated tip text renders correctly.
Verified that the new link https://cardanocommunity.typeform.com/news-submission is functional and leads to the correct form.