### PR TITLE
Remove Discord link from "Get Involved" section

### DIFF
--- a/src/components/Layout/FollowCardano/index.js
+++ b/src/components/Layout/FollowCardano/index.js
@@ -11,7 +11,6 @@ import {
   FaTelegram,
   FaStackExchange,
   FaLinkedin,
-  FaDiscord,
 } from "react-icons/fa6";
 
 // Overview: https://react-icons.github.io/react-icons/, for consistency stick to font awesome 6 (fa6)
@@ -55,11 +54,6 @@ const socialLinks = [
     icon: <FaLinkedin />,
     url: "https://www.linkedin.com/company/cardano-community",
     label: "Cardano on LinkedIn",
-  },
-  {
-    icon: <FaDiscord />,
-    url: "https://discord.com/invite/3MTpDhMS3n",
-    label: "Cardano on Discord",
   },
 ];
 


### PR DESCRIPTION
**Description:**

The invite link for the Community Discord has been deactivated. The Discord link will be temporarily disabled until a secure environment for the community can be ensured.

This pull request will update the Cardano.org website by:
1.  **Removing the Discord social media link** from the "Follow Cardano" component.
    -   Files/Directories affected: `src/components/Layout/FollowCardano/index.js`
2.  **Deleting the code block** that contained the Discord icon, URL, and label from the `socialLinks` array.

---

**Testing:**
- Built the site locally to ensure the change renders correctly.
- Visually verified that the Discord icon and link no longer appear in the "Get Involved" section.
