### PR TITLE
Update Yoroi Wallet Link

### DIFF
--- a/src/components/WalletSection/index.js
+++ b/src/components/WalletSection/index.js
@@ -32,7 +32,7 @@ const WalletItemList = [
     text: "A user-friendly, [open-source](https://github.com/Emurgo/yoroi-frontend) Cardano wallet with a browser-based interface, providing a convenient way to manage ada holdings securely. Yoroi is also available as mobile app.",
     subtext: "Browser extension and app for iOS and Android",
     label: "Get Yoroi",
-    link: "https://yoroi-wallet.com/",
+    link: "https://yoroiwallet.com/",
   },
   {
     title: "Eternl Wallet",


### PR DESCRIPTION
Unfortunately, there is currently a Cloudflare security warning on yoroi-wallet.com, which is why the link to yoroiwallet.com has been changed after the official Yoroi X account now also links to it.

changed File: /src/components/WalletSection/index.js