### PR TITLE
Add Operator Notification Signup

### DIFF
--- a/src/data/signal-contentmap.js
+++ b/src/data/signal-contentmap.js
@@ -6,4 +6,11 @@ export default {
     bannerType: 'fluidBlue',
     openGraph: 'signal-governance',
   },
+    "operator": {
+    title: 'Signal your interest in Stake Pool Operations',
+    formId: 8,
+    description: 'Stay informed about everything related to running a Stake Pool and technical updates.',
+    bannerType: 'fluidBlue',
+    openGraph: 'signal-operator-notification',
+  },
 };

--- a/src/pages/signal-operator-notification.js
+++ b/src/pages/signal-operator-notification.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useLocation } from '@docusaurus/router';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Layout from "@theme/Layout";
+import SiteHero from "@site/src/components/Layout/SiteHero";
+import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
+import Divider from "@site/src/components/Layout/Divider";
+import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
+import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
+import MauticForm  from "@site/src/components/MauticForm";
+
+// map interestIds to Mautic forms
+import contentMap from '../data/signal-contentmap.js';
+
+// use id parameter for the different forms, make sure to have a valid one
+// note: this can't be set by an URL parameter because at the time Docusaurus renders
+//       the open graph preview, URL parameter is null.
+const interestId = "operator";
+
+  export default function Home() {
+  const { siteConfig } = useDocusaurusContext();
+  const location = useLocation();
+
+  const isValidInterest = Object.keys(contentMap).includes(interestId);
+  const content = isValidInterest ? contentMap[interestId] : contentMap["operator"];
+  const siteTitle = `${content.title} | ${siteConfig.title}`;
+
+  return (
+    <Layout
+      title={siteTitle}
+      description={content.description}
+    >
+      <OpenGraphInfo pageName={content.openGraph} title={content.title} description={content.description} />
+      <SiteHero
+        title={content.title}
+        description={content.description}
+        bannerType={content.bannerType}
+      />
+
+      <BackgroundWrapper backgroundType={"zoom"}>
+        <BoundaryBox>
+          <Divider text={isValidInterest ? interestId : 'operator'} />
+          <MauticForm id={content.formId} />
+        </BoundaryBox>
+      </BackgroundWrapper>
+
+       
+    </Layout>
+  );
+}


### PR DESCRIPTION
This pull request will update the Cardano.org website by:

1. Implementing a new public page (`/signal-operator-notification`)** for Stake Pool Operators to sign up for technical notifications.
2. Adding the necessary configuration and metadata** for the new signup form.
3. Integrating Mautic Form ID 8** to capture new operator signups with the title: "Signal your interest in Stake Pool Operations."

---

**Testing:**
- Built the site locally and verified that the new page `/signal-operator-notification` renders correctly.
- Confirmed that the Mautic form is displayed and functional on the page.


