### PR TITLE
Fix misconfiguration: gtag plugin expects analytics id

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -85,7 +85,7 @@ const config = {
         },
         gtag: {
           // don't be evil
-          trackingID: 'GTM-5BC4HH7',
+          trackingID: 'G-LGRGXBVYMC',
           anonymizeIP: true,
         },
       }),


### PR DESCRIPTION
Fix misconfiguration: gtag plugin expects analytics id instead of tag manager. This led to "TypeError: window.gtag is not a function" in developer mode.
