### PR TITLE
Prevent "window.gtag is not a function"-errors in dev mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,6 +73,12 @@ const config = {
         content: '1E8DDBC2D1ADF529',
       },
     },
+    {
+      // Stub gtag for dev mode to prevent "window.gtag is not a function" errors
+      tagName: 'script',
+      attributes: {},
+      innerHTML: 'window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);}',
+    },
   ],
 
   presets: [


### PR DESCRIPTION
Add a stub gtag function for dev mode to prevent "window.gtag is not a function"-errors