### PR TITLE
fix: resolve dark mode section caret color overridden by CSS minifier

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -684,18 +684,18 @@ img {
 
 :root {
   --section-caret-fill-color: #ffffff;
-  /* white caret fill for light mode */
 }
 
-/* Override the fill color for dark mode */
 [data-theme="dark"] {
   --section-caret-fill-color: #1b1b1d;
-  /* black for dark mode */
 }
 
-/* Apply the variable to the polygon fill */
 .sectionCaret polygon {
-  fill: var(--section-caret-fill-color);
+  fill: #ffffff;
+}
+
+[data-theme="dark"] .sectionCaret polygon {
+  fill: #1b1b1d;
 }
 
 .sectionCaret {


### PR DESCRIPTION
fix: resolve dark mode section caret color overridden by CSS minifier
<img width="720" height="166" alt="image_720" src="https://github.com/user-attachments/assets/2718d844-64fa-4edf-88ef-2145ba56d829" />

