### PR TITLE
feat: add custom 404 page by swizzling NotFound/Content

### DIFF
--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -82,28 +82,11 @@ export default function NotFoundContent({ className }) {
           Try the search bar above or head back to familiar ground.
         </Translate>
       </p>
-      <div
-        style={{
-          display: "flex",
-          gap: "0.75rem",
-          flexWrap: "wrap",
-          justifyContent: "center",
-        }}
-      >
-        <Link className="button button--primary button--lg" to="/">
-          <Translate id="notFound.button.homepage" description="404 page homepage button">
-            Go to Homepage
-          </Translate>
-        </Link>
-        <Link
-          className="button button--secondary button--lg"
-          to="/docs/get-involved/"
-        >
-          <Translate id="notFound.button.docs" description="404 page docs button">
-            Browse Documentation
-          </Translate>
-        </Link>
-      </div>
+      <Link className="button button--primary button--lg" to="/">
+        <Translate id="notFound.button.homepage" description="404 page homepage button">
+          Go to Homepage
+        </Translate>
+      </Link>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a custom 404 page by swizzling `@theme/NotFound/Content`
- Uses inline styles with existing Infima CSS variables, so no new CSS files are introduced

### Misc details relevant for localization

- All user-facing strings wrapped with `<Translate>` for i18n support
- Reuses existing `theme.NotFound.title` translation ID so the heading is already
  translated in all four locales
- Four new translation IDs (`notFound.description`, `notFound.hint`,
  `notFound.button.homepage`, `notFound.button.docs`) will need Crowdin translation

## Preview

| Before | After (English) | After (German) |
|--------|---------|--------|
| <img width="839" height="426" alt="Before 404 page" src="https://github.com/user-attachments/assets/02dc1a7e-d701-4e28-8c01-444a947821d3" /> | <img width="692" height="469" alt="English 404 page" src="https://github.com/user-attachments/assets/5e98445b-ae2d-43e1-a7ba-d1a6ae3e2469" /> | <img width="760" height="479" alt="German 404 page" src="https://github.com/user-attachments/assets/d0642c6b-af27-4e8e-8032-7ea7998db9ec" /> |