### PR TITLE
chore: enable Algolia contextualSearch for multi-language support

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -168,8 +168,8 @@ const config = {
       algolia: {
         appId: '2GOYNZM2J1',
         apiKey: 'b3ea5bee26e2b95a6c6446489bdc6adf',
-        indexName: 'cardano_org_pages',
-        contextualSearch: false,
+        indexName: 'staging_pages',
+        contextualSearch: true,
         searchPagePath: 'search',
         // Search UI translations moved to i18n/*/docusaurus-theme-classic/theme.json
       },


### PR DESCRIPTION
Enable Algolia contextualSearch for multi-language support, this comes with a new search index.