### PR TITLE
feat: transaction leaderboard improvements

### DIFF
--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -1256,6 +1256,7 @@ export const Showcases = [
     preview: require("./app-images/usdm.png"),
     icon: "/img/app-icons/usdm.jpeg",
     statsLabel: "$usdm",
+    statsNote: "mint/burn only",
     website: "https://moneta.global/",
     source: null,
     tags: ["stablecoin"],
@@ -1429,6 +1430,7 @@ function ensureShowcaseValid(showcase) {
       "tags",
       "icon",
       "statsLabel",
+      "statsNote",
     ];
     const unknownKeys = difference(keys, validKeys);
     if (unknownKeys.length > 0) {

--- a/src/pages/apps/leaderboard.js
+++ b/src/pages/apps/leaderboard.js
@@ -179,7 +179,8 @@ const categoryColors = {
   'Bridge': '#FFC107',
   'Minting': '#42A5F5',
   'Notary': '#26A69A',
-  'Not Listed': '#757575'
+  'Not Listed': '#757575',
+  'Other': '#9E9E9E'
 };
 
 // Horizontal Bar Chart Component for Top Apps
@@ -469,15 +470,19 @@ function AppRow({ app, rank, appDetails }) {
         )}
         <div className={styles.appDetails}>
           <h4 className={styles.appName}>{app.displayName}</h4>
-          {app.isMetadata && (
-            <span className={styles.typeBadge}>Standard</span>
-          )}
-          <span
-            className={styles.categoryTag}
-            style={{ backgroundColor: categoryColors[category] + '20', color: categoryColors[category] }}
-          >
-            {category}
-          </span>
+          <div className={styles.tagRow}>
+            <span
+              className={styles.categoryTag}
+              style={{ backgroundColor: categoryColors[category] + '20', color: categoryColors[category] }}
+            >
+              {category}
+            </span>
+            {app.isMetadata && (
+              <span className={styles.categoryTag} style={{ backgroundColor: '#75757520', color: '#757575' }}>
+                Standard
+              </span>
+            )}
+          </div>
         </div>
       </div>
       <div className={styles.txCount}>
@@ -487,7 +492,7 @@ function AppRow({ app, rank, appDetails }) {
           <span className={styles.statsNote}>{appDetails.statsNote}</span>
         )}
       </div>
-      {appDetails?.website && (
+      {appDetails?.website ? (
         <a
           href={appDetails.website}
           target="_blank"
@@ -496,13 +501,15 @@ function AppRow({ app, rank, appDetails }) {
         >
           Visit
         </a>
+      ) : (
+        <span className={styles.visitLinkSpacer} />
       )}
     </div>
   );
 }
 
 // Category Card Component
-function CategoryCard({ category, txCount, totalTx, appCount }) {
+function CategoryCard({ category, txCount, totalTx, appCount, includes }) {
   const percentage = ((txCount / totalTx) * 100).toFixed(1);
   const tagSlug = category.toLowerCase().replace(/\s+/g, '-');
 
@@ -536,11 +543,13 @@ function CategoryCard({ category, txCount, totalTx, appCount }) {
       <div className={styles.categoryStats}>
         <span className={styles.categoryTx}>{formatNumber(txCount)} tx</span>
       </div>
-      {linkTag && (
+      {includes ? (
+        <span className={styles.categoryIncludes}>{includes.join(', ')}</span>
+      ) : linkTag ? (
         <Link to={`/apps?tags=${linkTag}`} className={styles.categoryLink}>
           View {category} apps
         </Link>
-      )}
+      ) : null}
     </div>
   );
 }
@@ -593,9 +602,21 @@ export default function LeaderboardPage() {
       stats[category].txCount += entry.txCount;
       stats[category].appCount += 1;
     });
-    return Object.entries(stats)
+    const sorted = Object.entries(stats)
       .map(([name, data]) => ({ name, ...data }))
       .sort((a, b) => b.txCount - a.txCount);
+
+    const top = sorted.slice(0, 5);
+    const rest = sorted.slice(5);
+    if (rest.length > 0) {
+      top.push({
+        name: 'Other',
+        txCount: rest.reduce((sum, c) => sum + c.txCount, 0),
+        appCount: rest.reduce((sum, c) => sum + c.appCount, 0),
+        includes: rest.map(c => c.name),
+      });
+    }
+    return top;
   }, [unifiedData]);
 
   // Metadata labels sorted by tx count (verified only, ungrouped)
@@ -737,7 +758,7 @@ export default function LeaderboardPage() {
             <Divider text="Top On-Chain Activity" id="top-apps" />
             <TitleWithText
               description={[
-                `The top 10 entries by transaction count over the last ${period === '30d' ? '30 days' : 'year'}. This includes apps, protocols, and on-chain standards. Bars are colored by category.`
+                `The top 10 entries by transaction count over the last ${period === '30d' ? '30 days' : 'year'}. This includes apps, protocols, and on-chain standards (labeled "Standard"). Bars are colored by category.`
               ]}
               headingDot={false}
             />
@@ -775,13 +796,14 @@ export default function LeaderboardPage() {
 
             {/* Category Cards */}
             <div className={styles.categoryGrid}>
-              {categoryStats.slice(0, 6).map(cat => (
+              {categoryStats.map(cat => (
                 <CategoryCard
                   key={cat.name}
                   category={cat.name}
                   txCount={cat.txCount}
                   totalTx={totalTrackedTx}
                   appCount={cat.appCount}
+                  includes={cat.includes}
                 />
               ))}
             </div>

--- a/src/pages/apps/leaderboard.js
+++ b/src/pages/apps/leaderboard.js
@@ -206,7 +206,7 @@ function TopAppsChart({ data }) {
   const option = useMemo(() => {
     if (!data || !data.length) return null;
 
-    // Top 10 apps
+    // Top 10 entries
     const topApps = data.slice(0, 10);
     const categories = topApps.map(d => d.displayName);
     const values = topApps.map(d => d.txCount);
@@ -469,6 +469,9 @@ function AppRow({ app, rank, appDetails }) {
         )}
         <div className={styles.appDetails}>
           <h4 className={styles.appName}>{app.displayName}</h4>
+          {app.isMetadata && (
+            <span className={styles.typeBadge}>Standard</span>
+          )}
           <span
             className={styles.categoryTag}
             style={{ backgroundColor: categoryColors[category] + '20', color: categoryColors[category] }}
@@ -480,6 +483,9 @@ function AppRow({ app, rank, appDetails }) {
       <div className={styles.txCount}>
         <span className={styles.txValue}>{formatNumber(app.txCount)}</span>
         <span className={styles.txLabel}>transactions</span>
+        {appDetails?.statsNote && (
+          <span className={styles.statsNote}>{appDetails.statsNote}</span>
+        )}
       </div>
       {appDetails?.website && (
         <a
@@ -654,13 +660,13 @@ export default function LeaderboardPage() {
 
   return (
     <Layout
-      title="App Leaderboard | cardano.org"
-      description="See which apps are driving Cardano transactions. Explore the top apps by transaction count and discover hot categories."
+      title="Transaction Leaderboard | cardano.org"
+      description="See what's driving on-chain activity on Cardano. Explore apps, standards, and protocols ranked by transaction count."
     >
       <OpenGraphInfo pageName="transaction-leaderboard" />
       <SiteHero
-        title="App Leaderboard"
-        description={["See which apps are driving Cardano transactions"]}
+        title="Transaction Leaderboard"
+        description={["See what's driving on-chain activity on Cardano"]}
         bannerType="fluidBlue"
       />
       <main>
@@ -699,7 +705,7 @@ export default function LeaderboardPage() {
               </div>
               <div className={styles.statCard}>
                 <span className={styles.statValue}>{unifiedData.length}</span>
-                <span className={styles.statLabel}>Tracked Apps</span>
+                <span className={styles.statLabel}>Apps & Standards</span>
                 <span className={styles.statPeriod}>On-chain identifiable</span>
               </div>
               <div className={styles.statCard}>
@@ -727,11 +733,11 @@ export default function LeaderboardPage() {
 
             <SpacerBox size="small" />
 
-            {/* Top Apps Section */}
-            <Divider text="Top Apps by Transaction Count" id="top-apps" />
+            {/* Top On-Chain Activity Section */}
+            <Divider text="Top On-Chain Activity" id="top-apps" />
             <TitleWithText
               description={[
-                `The top 10 apps by transaction count over the last ${period === '30d' ? '30 days' : 'year'}. Bars are colored by category.`
+                `The top 10 entries by transaction count over the last ${period === '30d' ? '30 days' : 'year'}. This includes apps, protocols, and on-chain standards. Bars are colored by category.`
               ]}
               headingDot={false}
             />

--- a/src/pages/apps/leaderboard.module.css
+++ b/src/pages/apps/leaderboard.module.css
@@ -191,15 +191,10 @@
   text-overflow: ellipsis;
 }
 
-.typeBadge {
-  display: inline-block;
-  font-size: 0.65rem;
-  font-weight: 500;
-  padding: 0.1rem 0.4rem;
-  border-radius: 4px;
-  background: var(--ifm-color-emphasis-200);
-  color: var(--ifm-color-emphasis-700);
-  width: fit-content;
+.tagRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
 }
 
 .categoryTag {
@@ -219,6 +214,8 @@
   align-items: flex-end;
   gap: 0.125rem;
   flex-shrink: 0;
+  margin-left: auto;
+  min-width: 100px;
 }
 
 .txValue {
@@ -258,6 +255,12 @@
   background: var(--ifm-color-primary);
   color: white;
   text-decoration: none;
+}
+
+.visitLinkSpacer {
+  display: inline-block;
+  width: 62px;
+  flex-shrink: 0;
 }
 
 /* Category Grid */
@@ -322,6 +325,11 @@
 
 .categoryLink::after {
   content: " \2192";
+}
+
+.categoryIncludes {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
 }
 
 /* Metadata Labels Table */
@@ -458,12 +466,15 @@
 
   .txCount {
     order: 2;
-    flex: 1;
-    align-items: flex-start;
+    margin-left: auto;
   }
 
   .visitLink {
     order: 3;
+  }
+
+  .visitLinkSpacer {
+    display: none;
   }
 
   .categoryGrid {

--- a/src/pages/apps/leaderboard.module.css
+++ b/src/pages/apps/leaderboard.module.css
@@ -191,6 +191,17 @@
   text-overflow: ellipsis;
 }
 
+.typeBadge {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 500;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-700);
+  width: fit-content;
+}
+
 .categoryTag {
   display: inline-block;
   font-size: 0.7rem;
@@ -221,6 +232,12 @@
   color: var(--ifm-color-emphasis-600);
   text-transform: uppercase;
   letter-spacing: 0.5px;
+}
+
+.statsNote {
+  font-size: 0.7rem;
+  color: var(--ifm-color-emphasis-500);
+  font-style: italic;
 }
 
 .visitLink {


### PR DESCRIPTION
- Rename "Top Apps" to "Top On-Chain Activity" to reflect mixed content
- Add "Standard" badge for metadata-based entries (CIP-25, Oracle, etc.)
- Add statsNote field to apps.js for contextual hints (e.g. "mint/burn only")
- Show statsNote under tx count in leaderboard rows (used for USDM)
- Update hero, meta description, and stat labels accordingly
- Fix tx count alignment with visitLink spacer for consistent layout
- Group small categories into "Other" card listing included categories
- Keep tx count right-aligned on both desktop and mobile
- Add Standard badge using consistent categoryTag style