### PR TITLE
feat: add anchor link indicator to insights section headers

### DIFF
--- a/src/components/Layout/Divider/index.js
+++ b/src/components/Layout/Divider/index.js
@@ -51,7 +51,7 @@ export default function Divider({ text, id, white = false }) {
       <>
         <br />
         <div className={headerClass}>
-          <h6>{text}</h6>
+          <h6>{text}{id && <a className="hash-link" href={`#${id}`}>&#8203;</a>}</h6>
           <div className={styles.horizontalBar}></div>
         </div>
       </>

--- a/src/components/Layout/Divider/styles.module.css
+++ b/src/components/Layout/Divider/styles.module.css
@@ -45,6 +45,11 @@
   background-color: #ffffff !important; 
 }
 
+.header h6 :global(.hash-link) {
+  color: inherit;
+  text-decoration: none;
+}
+
 /* Responsive styles */
 @media (max-width: 599px) {
   .horizontalBar {


### PR DESCRIPTION
Adds a minor QoL improvement, where a `#` link appears on hover next to headers on insights pages, making it easy to copy and share direct links to specific data graphs while exploring the page (e.g. `/insights/transactions/#avg-fee`).

## Preview

| Before | After |
|--------|-------|
| <img width="1261" alt="before" src="https://github.com/user-attachments/assets/34044d90-d19b-464a-b41b-9a5a7c84a742" /> | <img width="1265" alt="after" src="https://github.com/user-attachments/assets/1baca66c-7fe1-43d2-9b27-d93c134fb81c" /> |

> Link next to header on hover
