### PR TITLE
feat: expand brand-assets page with colors, typography and usage guidelines

### DIFF
--- a/src/components/BrandAssetsSection/ColorPalette.js
+++ b/src/components/BrandAssetsSection/ColorPalette.js
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import styles from "./styles.module.css";
+import Divider from "@site/src/components/Layout/Divider";
+import { translate } from "@docusaurus/Translate";
+
+const coreColors = [
+  { name: "Blue", hex: "#0033AD", rgb: "0 / 51 / 173", pantone: "286" },
+  { name: "Black", hex: "#000000", rgb: "0 / 0 / 0", pantone: "Process Black" },
+  { name: "White", hex: "#FFFFFF", rgb: "255 / 255 / 255", pantone: "—", needsBorder: true },
+  { name: "Paper", hex: "#f8f8f5", rgb: "248 / 248 / 245", pantone: "—", needsBorder: true },
+];
+
+const secondaryColors = [
+  { name: "Red", hex: "#ff5553", rgb: "255 / 85 / 83", pantone: "178" },
+  { name: "Green", hex: "#3b7982", rgb: "59 / 121 / 130", pantone: "569" },
+];
+
+function Swatch({ color }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    if (typeof window !== "undefined" && navigator.clipboard) {
+      navigator.clipboard.writeText(color.hex).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      });
+    }
+  }
+
+  const isLight = color.name === "White" || color.name === "Paper";
+
+  return (
+    <div className={styles.swatch}>
+      <div
+        className={styles.swatchColor}
+        style={{
+          backgroundColor: color.hex,
+          border: color.needsBorder ? "1px solid var(--ifm-color-emphasis-300)" : "none",
+        }}
+      />
+      <div className={styles.swatchMeta}>
+        <strong className={styles.swatchName}>{color.name}</strong>
+        <button
+          className={styles.swatchHex}
+          onClick={handleCopy}
+          title={translate({ id: "brandAssets.colors.copyHex", message: "Copy hex value" })}
+        >
+          {copied
+            ? translate({ id: "brandAssets.colors.copied", message: "Copied!" })
+            : color.hex}
+        </button>
+        <span className={styles.swatchDetail}>RGB {color.rgb}</span>
+        {color.pantone !== "—" && (
+          <span className={styles.swatchDetail}>Pantone {color.pantone}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ColorPalette() {
+  return (
+    <div>
+      <Divider
+        text={translate({ id: "brandAssets.colors.coreTitle", message: "Core Colors" })}
+        id="core-colors"
+      />
+      <div className={styles.coreColorGrid}>
+        {coreColors.map((c) => (
+          <Swatch key={c.name} color={c} />
+        ))}
+      </div>
+
+      <Divider
+        text={translate({ id: "brandAssets.colors.secondaryTitle", message: "Secondary Colors" })}
+        id="secondary-colors"
+      />
+      <div className={styles.secondaryColorGrid}>
+        {secondaryColors.map((c) => (
+          <Swatch key={c.name} color={c} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/BrandAssetsSection/TypographyShowcase.js
+++ b/src/components/BrandAssetsSection/TypographyShowcase.js
@@ -1,0 +1,66 @@
+import React from "react";
+import styles from "./styles.module.css";
+import Divider from "@site/src/components/Layout/Divider";
+import { translate } from "@docusaurus/Translate";
+
+const weights = [
+  { label: "Light", value: 300 },
+  { label: "Regular", value: 400 },
+  { label: "Bold", value: 700 },
+];
+
+export default function TypographyShowcase() {
+  return (
+    <div>
+      <Divider
+        text={translate({ id: "brandAssets.typography.title", message: "Typography" })}
+        id="typography"
+      />
+
+      <div className={styles.specimenBlock}>
+        <div className={styles.specimenLarge}>Aa</div>
+        <div className={styles.specimenAlphabet}>
+          ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789
+        </div>
+      </div>
+
+      <div className={styles.weightGrid}>
+        {weights.map((w) => (
+          <div key={w.label} className={styles.weightCard}>
+            <span className={styles.weightLabel}>{w.label}</span>
+            <span className={styles.weightValue}>{w.value}</span>
+            <p className={styles.weightSample} style={{ fontWeight: w.value }}>
+              {translate({
+                id: "brandAssets.typography.sample",
+                message:
+                  "The quick brown fox jumps over the lazy dog",
+              })}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <p className={styles.typographyNote}>
+        <strong>Chivo</strong>{" "}
+        {translate({
+          id: "brandAssets.typography.credit",
+          message: "by Omnibus-Type —",
+        })}{" "}
+        <a
+          href="https://fonts.google.com/specimen/Chivo"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Fonts
+        </a>
+        <br />
+        <span className={styles.typographyFallback}>
+          {translate({
+            id: "brandAssets.typography.fallback",
+            message: "Fallback: Arial, sans-serif",
+          })}
+        </span>
+      </p>
+    </div>
+  );
+}

--- a/src/components/BrandAssetsSection/UsageGuidelines.js
+++ b/src/components/BrandAssetsSection/UsageGuidelines.js
@@ -1,0 +1,113 @@
+import React from "react";
+import styles from "./styles.module.css";
+import Divider from "@site/src/components/Layout/Divider";
+import { FaCircleCheck, FaCircleXmark } from "react-icons/fa6";
+import { translate } from "@docusaurus/Translate";
+
+const minSizes = [
+  { context: "Web", size: "64 px" },
+  { context: "Tablet", size: "60 px" },
+  { context: "Phone", size: "56 px" },
+  { context: "Print", size: "20 mm" },
+];
+
+const dos = [
+  translate({
+    id: "brandAssets.usage.do1",
+    message: "Use only the specified brand colors",
+  }),
+  translate({
+    id: "brandAssets.usage.do2",
+    message: "Maintain the safe area around the logo",
+  }),
+  translate({
+    id: "brandAssets.usage.do3",
+    message: "The icon can be used as a standalone element",
+  }),
+];
+
+const donts = [
+  translate({
+    id: "brandAssets.usage.dont1",
+    message: "Do not stretch, rotate, or distort the logo",
+  }),
+  translate({
+    id: "brandAssets.usage.dont2",
+    message: "Do not recolor the logo outside brand colors",
+  }),
+  translate({
+    id: "brandAssets.usage.dont3",
+    message: "Do not use the wordmark without the icon",
+  }),
+];
+
+export default function UsageGuidelines() {
+  return (
+    <div>
+      <Divider
+        text={translate({ id: "brandAssets.usage.title", message: "Usage Guidelines" })}
+        id="usage-guidelines"
+      />
+
+      {/* Minimum sizes */}
+      <h3 className={styles.usageHeading}>
+        {translate({ id: "brandAssets.usage.minSizes", message: "Minimum Sizes" })}
+      </h3>
+      <div className={styles.minSizeGrid}>
+        {minSizes.map((item) => (
+          <div key={item.context} className={styles.minSizeCard}>
+            <span className={styles.minSizeContext}>{item.context}</span>
+            <span className={styles.minSizeValue}>{item.size}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Safe area */}
+      <h3 className={styles.usageHeading}>
+        {translate({ id: "brandAssets.usage.safeArea", message: "Safe Area" })}
+      </h3>
+      <p className={styles.usageText}>
+        {translate({
+          id: "brandAssets.usage.safeAreaDesc",
+          message:
+            "Always maintain a clear space around the logo equal to the width of six dots from the starburst icon. This ensures the logo remains legible and visually distinct in all applications.",
+        })}
+      </p>
+
+      {/* Do / Don't */}
+      <h3 className={styles.usageHeading}>
+        {translate({ id: "brandAssets.usage.dosDonts", message: "Do's & Don'ts" })}
+      </h3>
+      <div className={styles.doDontGrid}>
+        <div className={styles.doCard}>
+          {dos.map((text, i) => (
+            <div key={i} className={styles.doDontItem}>
+              <FaCircleCheck className={styles.doIcon} />
+              <span>{text}</span>
+            </div>
+          ))}
+        </div>
+        <div className={styles.dontCard}>
+          {donts.map((text, i) => (
+            <div key={i} className={styles.doDontItem}>
+              <FaCircleXmark className={styles.dontIcon} />
+              <span>{text}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Co-branding */}
+      <h3 className={styles.usageHeading}>
+        {translate({ id: "brandAssets.usage.cobranding", message: "Co-branding" })}
+      </h3>
+      <p className={styles.usageText}>
+        {translate({
+          id: "brandAssets.usage.cobrandingDesc",
+          message:
+            "When the Cardano logo appears alongside a partner logo, the Cardano logo should be displayed at an equal or larger size to maintain brand prominence.",
+        })}
+      </p>
+    </div>
+  );
+}

--- a/src/components/BrandAssetsSection/index.js
+++ b/src/components/BrandAssetsSection/index.js
@@ -1,90 +1,121 @@
 import clsx from "clsx";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import styles from "./styles.module.css";
-import Divider from "@site/src/components/Layout/Divider"; 
-import TitleWithText from "@site/src/components/Layout/TitleWithText"; 
+import Divider from "@site/src/components/Layout/Divider";
+import TitleWithText from "@site/src/components/Layout/TitleWithText";
 import { FaDownload } from "react-icons/fa6";
- 
+import { translate } from "@docusaurus/Translate";
 
-export default function BrandAssetsSection() {
+const logoGroups = [
+  {
+    label: "Cardano Starburst Logo",
+    id: "starburst",
+    variants: [
+      { color: "white", file: "cardano-starburst-white.svg", bg: "dark" },
+      { color: "black", file: "cardano-starburst-black.svg", bg: "paper" },
+      { color: "blue", file: "cardano-starburst-blue.svg", bg: "light" },
+    ],
+  },
+  {
+    label: "Cardano Stacked Logo",
+    id: "stacked",
+    variants: [
+      { color: "white", file: "cardano-stacked-white.svg", bg: "dark" },
+      { color: "black", file: "cardano-stacked-black.svg", bg: "paper" },
+      { color: "blue", file: "cardano-stacked-blue.svg", bg: "light" },
+    ],
+  },
+  {
+    label: "Cardano Horizontal Logo (default)",
+    id: "default",
+    variants: [
+      { color: "white", file: "cardano-horizontal-white.svg", bg: "dark" },
+      { color: "black", file: "cardano-horizontal-black.svg", bg: "paper" },
+      { color: "blue", file: "cardano-horizontal-blue.svg", bg: "light" },
+    ],
+  },
+];
+
+function LogoCard({ variant, groupLabel }) {
+  const src = useBaseUrl(`img/brand-assets/${variant.file}`);
+  const bgClass =
+    variant.bg === "dark"
+      ? styles.cardBgDark
+      : variant.bg === "paper"
+        ? styles.cardBgPaper
+        : styles.cardBgLight;
 
   return (
-    <div>
-        <Divider text="Download" id="download"/>
-        <a href="/downloads/cardano-brand-assets.zip">
-          <FaDownload className={styles.downloadIcon} />
-          <p>Download all Cardano brand assets from this page.</p></a>
-
-        <Divider text="Starburst" id="starburst"/>
-        <div className={styles.logoContainer}>
-          <img
-            src={useBaseUrl("img/brand-assets/cardano-starburst-white.svg")}
-            alt={"Cardano Starburst Logo White"}
-            className={clsx(styles.logo, styles.white)}
-          />
-          <img
-            src={useBaseUrl("img/brand-assets/cardano-starburst-black.svg")}
-            alt={"Cardano Starburst Logo Black"}
-            className={styles.logo}
-          />
-          <img
-            src={useBaseUrl("img/brand-assets/cardano-starburst-blue.svg")}
-            alt={"Cardano Starburst Logo Blue"}
-            className={styles.logo}
-          />
-        </div>
-
-        <Divider text="Stacked" id="stacked"/>
-        <div className={styles.logoContainer}>
-          <img
-            src={useBaseUrl("img/brand-assets/cardano-stacked-white.svg")}
-            alt={"Cardano Starburst Logo White"}
-            className={clsx(styles.logo, styles.white)}
-          />
-          <img
-            src={useBaseUrl("img/brand-assets/cardano-stacked-black.svg")}
-            alt={"Cardano Starburst Logo Black"}
-            className={styles.logo}
-          />
-          <img
-            src={useBaseUrl("img/brand-assets/cardano-stacked-blue.svg")}
-            alt={"Cardano Starburst Logo Blue"}
-            className={styles.logo}
-          />
-        </div>
-
-        <Divider text="Horizontal (default)" id="default"/>
-        <div className={styles.logoContainer}>
-          <img
-            src={useBaseUrl("img/brand-assets/cardano-horizontal-white.svg")}
-            alt={"Cardano Logo White"}
-            className={clsx(styles.logo, styles.white)}
-          />
-          <img
-            src={useBaseUrl("img/brand-assets/cardano-horizontal-black.svg")}
-            alt={"Cardano Logo Black"}
-            className={styles.logo}
-          />
-          <img
-            src={useBaseUrl("img/brand-assets/cardano-horizontal-blue.svg")}
-            alt={"Cardano Logo Blue"}
-            className={styles.logo}
-          />
-        </div>
-      
-        <TitleWithText
-              
-              description={[
-                "Our logo is at the heart of the brand identity. While it is the most recognizable part of the brand \
-                identity it is not the only component. The horizontal logo (shown here) is the primary version and \
-                should be used as the default version.",
-
-                "Please note the [Cardano Foundation Trademark Policy](https://cardanofoundation.org/en/trademark-policy).",
-              ]}
-              titleType="black"
-              headingDot={true}
-            />
+    <div className={styles.logoCard}>
+      <div className={clsx(styles.logoCardPreview, bgClass)}>
+        <img
+          src={src}
+          alt={`${groupLabel} — ${variant.color} version`}
+          className={styles.logoCardImg}
+        />
+      </div>
+      <div className={styles.logoCardFooter}>
+        <span className={styles.logoCardLabel}>{variant.color}</span>
+        <a
+          href={src}
+          download={variant.file}
+          className={styles.logoCardDownload}
+          title={translate({
+            id: "brandAssets.logos.downloadSvg",
+            message: "Download SVG",
+          })}
+        >
+          <FaDownload />
+        </a>
+      </div>
     </div>
   );
-  }
+}
 
+export default function BrandAssetsSection() {
+  return (
+    <div>
+      {logoGroups.map((group) => (
+        <div key={group.id}>
+          <Divider text={group.label} id={group.id} />
+          <div className={styles.logoGrid}>
+            {group.variants.map((v) => (
+              <LogoCard key={v.file} variant={v} groupLabel={group.label} />
+            ))}
+          </div>
+        </div>
+      ))}
+
+      <Divider
+        text={translate({ id: "brandAssets.logos.download", message: "Download" })}
+        id="download"
+      />
+      <a href="/downloads/cardano-brand-assets.zip" className={styles.downloadAll}>
+        <FaDownload className={styles.downloadIcon} />
+        <span>
+          {translate({
+            id: "brandAssets.logos.downloadAll",
+            message: "Download all Cardano brand assets from this page.",
+          })}
+        </span>
+      </a>
+
+      <TitleWithText
+        description={[
+          translate({
+            id: "brandAssets.logos.desc1",
+            message:
+              "Our logo is at the heart of the brand identity. While it is the most recognizable part of the brand identity it is not the only component. The horizontal logo (shown here) is the primary version and should be used as the default version.",
+          }),
+          translate({
+            id: "brandAssets.logos.desc2",
+            message:
+              "Please note the [Cardano Foundation Trademark Policy](https://cardanofoundation.org/en/trademark-policy).",
+          }),
+        ]}
+        titleType="black"
+        headingDot={true}
+      />
+    </div>
+  );
+}

--- a/src/components/BrandAssetsSection/styles.module.css
+++ b/src/components/BrandAssetsSection/styles.module.css
@@ -1,38 +1,348 @@
- 
+/* =============================================
+   Logo Section
+   ============================================= */
+
+.downloadAll {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 1rem;
+}
 
 .downloadIcon {
-  font-size: 3rem;
-  color: var(--ifm-link-color); 
+  font-size: 2rem;
+  color: var(--ifm-link-color);
+  flex-shrink: 0;
 }
 
-.logoContainer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 30px;  
-  justify-content: center; /* Center the logos horizontally */
-  align-items: center; /* Center the logos vertically */
-  margin-top: 30px;
-  margin-bottom: 30px;
+/* 3-column logo card grid */
+.logoGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  margin-top: 24px;
+  margin-bottom: 32px;
 }
 
-.logo {
-  flex: 1 1 auto; /* Flex grow, shrink, and basis */
-  max-width: calc(33.333% - 20px); /* Adjust the percentage based on the number of items per row */
-  margin-bottom: 20px; /* Spacing between rows */
-  
-  padding: 10px; /* Padding around the logos */
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1); /* Adds a subtle shadow around the logos for depth */
-}
-
-.white {
-  background-color: #f0f0f0; /* Background for white logo, adjust color as needed */
-}
-
-/* Responsive Design: Stack images on smaller screens */
-@media (max-width: 576px) {
-  .starburst {
-    max-width: 100%; /* Full width for smaller screens */
+@media (max-width: 768px) {
+  .logoGrid {
+    grid-template-columns: 1fr;
   }
 }
 
- 
+.logoCard {
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.logoCardPreview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px;
+  min-height: 160px;
+}
+
+.cardBgDark {
+  background-color: #1b1b1d;
+}
+
+.cardBgPaper {
+  background-color: #f8f8f5;
+}
+
+.cardBgLight {
+  background-color: #ffffff;
+}
+
+.logoCardImg {
+  max-width: 100%;
+  max-height: 100px;
+  object-fit: contain;
+}
+
+.logoCardFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-background-color);
+}
+
+.logoCardLabel {
+  text-transform: capitalize;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.logoCardDownload {
+  color: var(--ifm-link-color);
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+}
+
+.logoCardDownload:hover {
+  color: var(--ifm-link-hover-color);
+}
+
+/* =============================================
+   Color Palette
+   ============================================= */
+
+.coreColorGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  margin-top: 24px;
+  margin-bottom: 32px;
+}
+
+.secondaryColorGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+  margin-top: 24px;
+  margin-bottom: 32px;
+}
+
+@media (max-width: 768px) {
+  .coreColorGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .secondaryColorGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .coreColorGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.swatch {
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.swatchColor {
+  height: 120px;
+}
+
+.swatchMeta {
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--ifm-background-color);
+}
+
+.swatchName {
+  font-size: 1rem;
+}
+
+.swatchHex {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: monospace;
+  font-size: 0.9rem;
+  color: var(--ifm-link-color);
+  text-align: left;
+  width: fit-content;
+}
+
+.swatchHex:hover {
+  text-decoration: underline;
+}
+
+.swatchDetail {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* =============================================
+   Typography Showcase
+   ============================================= */
+
+.specimenBlock {
+  text-align: center;
+  margin: 32px 0;
+}
+
+.specimenLarge {
+  font-family: Chivo, sans-serif;
+  font-size: 6rem;
+  font-weight: 400;
+  line-height: 1;
+  margin-bottom: 16px;
+}
+
+.specimenAlphabet {
+  font-family: Chivo, sans-serif;
+  font-size: 1.1rem;
+  word-break: break-all;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.weightGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+@media (max-width: 768px) {
+  .weightGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.weightCard {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.weightLabel {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.weightValue {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+  font-family: monospace;
+}
+
+.weightSample {
+  font-family: Chivo, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 8px 0 0;
+}
+
+.typographyNote {
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.typographyFallback {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-500);
+}
+
+/* =============================================
+   Usage Guidelines
+   ============================================= */
+
+.usageHeading {
+  margin-top: 28px;
+  margin-bottom: 12px;
+}
+
+.usageText {
+  max-width: 680px;
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+.minSizeGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+@media (max-width: 768px) {
+  .minSizeGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.minSizeCard {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  text-align: center;
+}
+
+.minSizeContext {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.minSizeValue {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.doDontGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+@media (max-width: 768px) {
+  .doDontGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.doCard {
+  border-radius: 8px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background-color: rgba(59, 121, 130, 0.08);
+  border: 1px solid rgba(59, 121, 130, 0.25);
+}
+
+.dontCard {
+  border-radius: 8px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background-color: rgba(255, 85, 83, 0.06);
+  border: 1px solid rgba(255, 85, 83, 0.25);
+}
+
+.doDontItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  line-height: 1.4;
+}
+
+.doIcon {
+  color: #3b7982;
+  font-size: 1.2rem;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.dontIcon {
+  color: #ff5553;
+  font-size: 1.2rem;
+  flex-shrink: 0;
+  margin-top: 2px;
+}

--- a/src/pages/brand-assets.js
+++ b/src/pages/brand-assets.js
@@ -1,15 +1,27 @@
 import Layout from "@theme/Layout";
 import SiteHero from "@site/src/components/Layout/SiteHero";
 import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
+import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
 import BrandAssetsSection from "../components/BrandAssetsSection";
+import ColorPalette from "../components/BrandAssetsSection/ColorPalette";
+import TypographyShowcase from "../components/BrandAssetsSection/TypographyShowcase";
+import UsageGuidelines from "../components/BrandAssetsSection/UsageGuidelines";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
-import {translate} from '@docusaurus/Translate';
+import Head from "@docusaurus/Head";
+import { translate } from "@docusaurus/Translate";
 
 function HomepageHeader() {
   return (
     <SiteHero
-      title={translate({id: 'brandAssets.hero.title', message: 'Brand Assets'})}
-      description={translate({id: 'brandAssets.hero.description', message: 'Our brand is a reflection of everything that we create. Here are some of the things that make up our brand and how you can use them.'})}
+      title={translate({
+        id: "brandAssets.hero.title",
+        message: "Brand Assets",
+      })}
+      description={translate({
+        id: "brandAssets.hero.description",
+        message:
+          "Our brand is a reflection of everything that we create. Here are some of the things that make up our brand and how you can use them.",
+      })}
       bannerType="braidRedBlue"
     />
   );
@@ -18,15 +30,45 @@ function HomepageHeader() {
 export default function Home() {
   return (
     <Layout
-      title={translate({id: 'brandAssets.layout.title', message: 'Cardano Brand Assets, Logos and Guidelines'})}
-      description={translate({id: 'brandAssets.layout.description', message: 'Our brand is a reflection of everything that we create. Here are some of the things that make up our brand and how you can use them.'})}
+      title={translate({
+        id: "brandAssets.layout.title",
+        message: "Cardano Logo Download — Brand Assets, Colors & Guidelines",
+      })}
+      description={translate({
+        id: "brandAssets.layout.description",
+        message:
+          "Download the official Cardano logo in SVG format. Starburst icon, stacked and horizontal wordmarks in multiple colors, plus brand colors, typography and usage guidelines.",
+      })}
     >
-      <OpenGraphInfo pageName="brand-assets" />
+      <OpenGraphInfo
+        pageName="brand-assets"
+        title="Cardano Logo Download — Brand Assets, Colors & Guidelines"
+        description="Download the official Cardano logo in SVG format. Starburst icon, stacked and horizontal wordmarks in multiple colors, plus brand colors, typography and usage guidelines."
+      />
+      <Head>
+        <meta
+          name="keywords"
+          content="Cardano logo, Cardano logo download, Cardano logo SVG, Cardano starburst, Cardano brand assets, Cardano brand guidelines, Cardano colors, Cardano typography"
+        />
+      </Head>
       <HomepageHeader />
       <main>
         <BoundaryBox>
           <BrandAssetsSection />
         </BoundaryBox>
+        <BackgroundWrapper backgroundType={"solidGrey"}>
+          <BoundaryBox>
+            <ColorPalette />
+          </BoundaryBox>
+        </BackgroundWrapper>
+        <BoundaryBox>
+          <TypographyShowcase />
+        </BoundaryBox>
+        <BackgroundWrapper backgroundType={"solidGrey"}>
+          <BoundaryBox>
+            <UsageGuidelines />
+          </BoundaryBox>
+        </BackgroundWrapper>
       </main>
     </Layout>
   );


### PR DESCRIPTION
- Add ColorPalette component with official Cardano brand colors
- Add TypographyShowcase component with font specimens
- Add UsageGuidelines component with do/don't examples
- Expand brand-assets page layout to include all new sections
- Update styles for responsive grid layout and visual polish