### PR TITLE
fix: map Crowdin locale codes to Docusaurus short codes in navbar

### DIFF
--- a/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
+++ b/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
@@ -10,6 +10,10 @@ import progressData from '@site/src/data/translation-progress.json';
 const translationStats = {en: 100};
 progressData.languages.forEach((lang) => {
   translationStats[lang.id] = lang.translationProgress;
+  const shortCode = lang.id.split('-')[0];
+  if (shortCode !== lang.id) {
+    translationStats[shortCode] = lang.translationProgress;
+  }
 });
 
 // Progress bar component


### PR DESCRIPTION
- Crowdin uses `es-ES` as language ID, but Docusaurus uses `es` as locale code
- The navbar translation progress lookup failed for Spanish (showed 0% instead of 31%)
- Now also maps the short code (`es-ES` → `es`) so the lookup succeeds
- No impact on languages already using short codes (ja, de, vi)