### PR TITLE
fix: strip mega-only props before forwarding to original DropdownNavbarItem

### DIFF
--- a/src/theme/NavbarItem/DropdownNavbarItem/index.js
+++ b/src/theme/NavbarItem/DropdownNavbarItem/index.js
@@ -22,9 +22,11 @@ export default function DropdownNavbarItem({mobile = false, ...props}) {
     props.customProps &&
     Array.isArray(props.customProps.columns);
 
-  // On mobile or when not marked as mega, fall back to the original behavior
+  // On mobile or when not marked as mega, fall back to the original behavior.
+  // Strip mega-specific props so they don't leak onto DOM elements.
   if (!mega || isMobile) {
-    return <OriginalDropdownNavbarItem mobile={mobile} {...props} />;
+    const {customProps, mega: _mega, ...passthroughProps} = props;
+    return <OriginalDropdownNavbarItem mobile={mobile} {...passthroughProps} />;
   }
 
   const columns = props.customProps.columns;


### PR DESCRIPTION
- Filters `customProps` and `mega` out of props before passing them to `OriginalDropdownNavbarItem`
- Fixes React DOM warning: `React does not recognize the customProps prop on a DOM element`
- Affects all non-mega dropdowns and mobile navbar