### PR TITLE
fix: restore /totals fetch and treasury withdrawal amounts

### DIFF
--- a/src/pages/insights/supply/index.js
+++ b/src/pages/insights/supply/index.js
@@ -12,7 +12,7 @@ import {translate} from '@docusaurus/Translate';
 
 import { makeApiClient } from '@site/src/utils/insights/api';
 import { parseApiError } from '@site/src/utils/insights/errors';
-import { convertLovelacesToAda, toAdaIfMoney, LOVELACE_KEY } from '@site/src/utils/insights/numbers';
+import { convertLovelacesToAda, toAdaIfMoney, LOVELACE_KEY, sumWithdrawalAmounts } from '@site/src/utils/insights/numbers';
 import { MIN_EPOCH, GOVERNANCE_EPOCH_THRESHOLD, getEpochDate } from '@site/src/utils/insights/epochs';
 
 // Layout components 
@@ -216,14 +216,13 @@ function PageContent() {
       let withdrawalsPrev = [];
       
       if (displayedEpoch >= GOVERNANCE_EPOCH_THRESHOLD) {
-        // Fetch governance action based treasury withdrawals for current epoch
-        // Note: For governance epochs, withdrawals are counted in the same epoch they are enacted
+        // For governance epochs, withdrawals are counted in the same epoch they are enacted.
         try {
           const currRes = await api.get(
-            `/proposal_list?proposal_type=eq.TreasuryWithdrawals&enacted_epoch=eq.${displayedEpoch}&enacted_epoch=not.is.null&select=proposal_id,proposal_index,proposal_type,enacted_epoch,meta_json-%3Ebody-%3Etitle,withdrawal-%3Eamount`
+            `/proposal_list?proposal_type=eq.TreasuryWithdrawals&enacted_epoch=eq.${displayedEpoch}&enacted_epoch=not.is.null&select=proposal_id,proposal_index,proposal_type,enacted_epoch,meta_json-%3Ebody-%3Etitle,withdrawal`
           );
           withdrawalsCurr = (currRes.data || []).map(item => ({
-            amount: item.amount != null ? String(item.amount) : '0',
+            amount: String(sumWithdrawalAmounts(item.withdrawal)),
             title: item.title || 'Untitled withdrawal',
             proposal_id: item.proposal_id,
             proposal_index: item.proposal_index

--- a/src/pages/insights/supply/summary.js
+++ b/src/pages/insights/supply/summary.js
@@ -353,24 +353,31 @@ function PageContent() {
       }
       
       // Governance withdrawals (epochs >= 571) - fetch all without epoch filter
-      // Use the same query structure as the working version in index.js, but include title
+      // The `withdrawal` field is an array of {amount, stake_address} objects;
+      // a single proposal can pay out to multiple stake addresses, so we sum them up.
       const withdrawalDetails = [];
       try {
         const withdrawalsRes = await api.get(
-          `/proposal_list?proposal_type=eq.TreasuryWithdrawals&enacted_epoch=not.is.null&select=proposal_id,proposal_index,proposal_type,enacted_epoch,meta_json-%3Ebody-%3Etitle,withdrawal-%3Eamount`
+          `/proposal_list?proposal_type=eq.TreasuryWithdrawals&enacted_epoch=not.is.null&select=proposal_id,proposal_index,proposal_type,enacted_epoch,meta_json-%3Ebody-%3Etitle,withdrawal`
         );
         withdrawalsRes.data.forEach(item => {
           const epoch = item.enacted_epoch;
           if (epoch && epoch >= GOVERNANCE_EPOCH_THRESHOLD) {
+            const totalAmount = Array.isArray(item.withdrawal)
+              ? item.withdrawal.reduce((sum, w) => {
+                  const n = Number(w?.amount);
+                  return sum + (isNaN(n) ? 0 : n);
+                }, 0)
+              : 0;
+
             // Aggregate per epoch (existing behavior)
             if (!allWithdrawals[epoch]) allWithdrawals[epoch] = 0;
-            const amount = item.amount != null ? Number(item.amount) : 0;
-            allWithdrawals[epoch] += isNaN(amount) ? 0 : amount;
+            allWithdrawals[epoch] += totalAmount;
 
             // Store individual withdrawal details (new)
             withdrawalDetails.push({
               epoch: epoch,
-              amount: amount,
+              amount: totalAmount,
               title: item.title || 'Untitled withdrawal',
               proposal_id: item.proposal_id,
               proposal_index: item.proposal_index

--- a/src/pages/insights/supply/summary.js
+++ b/src/pages/insights/supply/summary.js
@@ -11,7 +11,7 @@ import {translate} from '@docusaurus/Translate';
 
 import { makeApiClient } from '@site/src/utils/insights/api';
 import { parseApiError } from '@site/src/utils/insights/errors';
-import { convertLovelacesToAda } from '@site/src/utils/insights/numbers';
+import { convertLovelacesToAda, sumWithdrawalAmounts } from '@site/src/utils/insights/numbers';
 import { MIN_EPOCH, GOVERNANCE_EPOCH_THRESHOLD, getEpochDate } from '@site/src/utils/insights/epochs';
 import './summary.css';
 
@@ -353,8 +353,6 @@ function PageContent() {
       }
       
       // Governance withdrawals (epochs >= 571) - fetch all without epoch filter
-      // The `withdrawal` field is an array of {amount, stake_address} objects;
-      // a single proposal can pay out to multiple stake addresses, so we sum them up.
       const withdrawalDetails = [];
       try {
         const withdrawalsRes = await api.get(
@@ -363,12 +361,7 @@ function PageContent() {
         withdrawalsRes.data.forEach(item => {
           const epoch = item.enacted_epoch;
           if (epoch && epoch >= GOVERNANCE_EPOCH_THRESHOLD) {
-            const totalAmount = Array.isArray(item.withdrawal)
-              ? item.withdrawal.reduce((sum, w) => {
-                  const n = Number(w?.amount);
-                  return sum + (isNaN(n) ? 0 : n);
-                }, 0)
-              : 0;
+            const totalAmount = sumWithdrawalAmounts(item.withdrawal);
 
             // Aggregate per epoch (existing behavior)
             if (!allWithdrawals[epoch]) allWithdrawals[epoch] = 0;

--- a/src/pages/insights/supply/summary.js
+++ b/src/pages/insights/supply/summary.js
@@ -318,7 +318,7 @@ function PageContent() {
       const allTotals = {};
       
       try {
-        const totalsRes = await api.get('/totals?limit=1000&order=epoch_no.asc');
+        const totalsRes = await api.get('/totals?order=epoch_no.asc');
         totalsRes.data.forEach(item => {
           if (item.epoch_no) {
             allTotals[item.epoch_no] = item;

--- a/src/utils/insights/numbers.js
+++ b/src/utils/insights/numbers.js
@@ -11,3 +11,14 @@ export function toAdaIfMoney(key, v) {
   if (!Number.isFinite(n)) return v;
   return LOVELACE_KEY.test(key) ? Math.round(n / 1_000_000) : n;
 }
+
+// Koios returns `withdrawal` on a TreasuryWithdrawals proposal as an array of
+// {amount, stake_address} objects — one entry per recipient. Sum them up to
+// get the total payout in lovelace.
+export function sumWithdrawalAmounts(withdrawal) {
+  if (!Array.isArray(withdrawal)) return 0;
+  return withdrawal.reduce((sum, w) => {
+    const n = Number(w?.amount);
+    return sum + (Number.isNaN(n) ? 0 : n);
+  }, 0);
+}


### PR DESCRIPTION
- Removes unnecessary `limit=1000` query param from /totals fetch (keeps `order=epoch_no.asc`)
- Fixes treasury withdrawal amounts showing as 0 — `withdrawal` is an array of {amount, stake_address}, summed via new `sumWithdrawalAmounts` helper
- Affects both /insights/supply/ and /insights/supply/summary/