### PR TITLE
Fix/governance mobile vlines

### DIFF
--- a/src/data/governanceFAQ.json
+++ b/src/data/governanceFAQ.json
@@ -24,6 +24,16 @@
     "popular": "Yes. You can update or remove your delegation at any time."
   },
   {
+    "question": "Can I delegate my ada to a DRep and a stake pool at the same time?",
+    "answer": [
+      "Yes, and most ada holders do exactly that. DRep delegation and stake pool delegation are two independent actions that delegate two different things from the same ada.",
+      "Stake pool delegation points your stake at a pool operator who produces blocks, and in return you earn a share of block rewards. DRep delegation assigns the voting power of that same stake to someone who votes on governance proposals. Your ada is never locked, spent, or moved in either case. Both are just on-chain signals attached to your stake address.",
+      "Because they run on different rails (block production vs. governance), the two delegations don't compete. You can change either one independently, and you keep earning rewards the whole time."
+    ],
+    "category": "delegation",
+    "popular": "Yes. Stake pool delegation earns rewards, DRep delegation assigns voting power. Same ada, two independent signals."
+  },
+  {
     "question": "What happens if I don't delegate?",
     "answer": [
       "If you don't delegate your voting power, your ada does not count toward any governance vote. Your voice goes unused. Delegating ensures your stake contributes to the decisions that shape Cardano."

--- a/src/pages/governance.module.css
+++ b/src/pages/governance.module.css
@@ -56,9 +56,11 @@
   fill: #0033AD;
 }
 
-.mobileVLine1,
-.mobileVLine2 {
-  display: none;
+@media (min-width: 769px) {
+  .mobileVLine1,
+  .mobileVLine2 {
+    display: none;
+  }
 }
 
 [data-theme='dark'] .connLine {


### PR DESCRIPTION
- Wrap the mobile vertical connectors on /governance in a min-width media query so the CSS to fix minimizer issue                                                                                     
- Add a FAQ entry explaining that DRep delegation and stake pool delegation can run in parallel