### PR TITLE
add latest Roundtable Talks to News

### DIFF
--- a/blog/2025-07-21-media-followup-to-nested-transactions/index.md
+++ b/blog/2025-07-21-media-followup-to-nested-transactions/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2025-07-21-media-followup-to-nested-transactions
+title: "Roundtable Talk: A Followup to Nested Transactions"
+authors: [community]
+tags: [media]
+---
+
+A Roundtable Talk, features a deep-dive discussion on the evolution and implementation of Nested Transactions within the Cardano ledger. Participants discussed the technical readiness of the protocol, the potential for Babel fees, and the introduction of new programmability layers. The conversation also addressed risks regarding system complexity and censorship resistance, emphasizing the role of community consensus in navigating alternative paths for Cardano’s future governance and technical direction.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=p8uJ_4ydoBU)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/p8uJ_4ydoBU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2025-09-01-media-developers-tooling-on-cardano/index.md
+++ b/blog/2025-09-01-media-developers-tooling-on-cardano/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2025-09-01-media-developers-tooling-on-cardano
+title: "Roundtable Talk: Developers Tooling on Cardano"
+authors: [community]
+tags: [media]
+---
+
+A Roundtable Talk, features a discussion from the Cardano Berlin Hackathon on the evolution of developer tooling. Participants discussed the shift from early limitations to modern solutions like Aiken and open-source SDKs. The conversation also covered the role of the Plutus Pioneer Program and the importance of developer onboarding in securing Cardano’s long-term accessibility and global adoption.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=6KQMjFw3eeA)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/6KQMjFw3eeA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2025-09-20-media-cardano-culture/index.md
+++ b/blog/2025-09-20-media-cardano-culture/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2025-09-20-media-cardano-culture
+title: "Roundtable Talk: Cardano Culture"
+authors: [community]
+tags: [media]
+---
+
+A Roundtable Talk, features a discussion from Rare Evo Las Vegas on the values and spirit of Cardano Culture. Participants discussed the evolution of community voices, the impact of grassroots funding, and the importance of IRL presence. The conversation also addressed intentional culture shaping and inclusivity to ensure a resilient and welcoming environment for the global ecosystem.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=xImZSlcCvBc)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/xImZSlcCvBc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2025-09-22-media-community-expertise-in-action/index.md
+++ b/blog/2025-09-22-media-community-expertise-in-action/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2025-09-22-media-community-expertise-in-action
+title: "Roundtable Talk: Community Expertise in Action"
+authors: [community]
+tags: [media]
+---
+
+A Roundtable Talk, features a discussion on the Fund 14 Representative Pilot and the evolution of Project Catalyst. Participants discussed shifting from popularity-based voting toward systematic, expertise-driven decision-making. The conversation also compared evaluation frameworks to help DReps prioritize quality and fairness, ensuring a more informed and transparent governance process for Fund 15 and beyond.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=_gIxu8e-nHg)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/_gIxu8e-nHg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2025-10-02-media-community-expertise-in-action-2/index.md
+++ b/blog/2025-10-02-media-community-expertise-in-action-2/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2025-10-02-media-community-expertise-in-action-2
+title: "Roundtable Talk: Community Expertise in Action - part 2"
+authors: [community]
+tags: [media]
+---
+
+A Roundtable Talk, features a discussion for the Eastern Hemisphere on the Fund 14 Representative Pilot. Participants focused on shifting from popularity-based voting toward systematic, expertise-driven evaluations. The session explored how structured frameworks can guide DReps to improve the quality and fairness of future governance decisions.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=7hRP-OiUQEQ)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/7hRP-OiUQEQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2025-12-16-media-Pathways-to-longterm-treasury-sustainability/index.md
+++ b/blog/2025-12-16-media-Pathways-to-longterm-treasury-sustainability/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2025-12-16-media-Pathways-to-longterm-treasury-sustainability
+title: "Cross Ecosystem Roundtable Talk (Cardano-Polkadot): Pathways to Long-Term Treasury Sustainability"
+authors: [community]
+tags: [media]
+---
+
+A Roundtable Talk, features the first Cross Ecosystem discussion between the Cardano and Polkadot Foundations on decentralized treasury sustainability. Participants discussed shared Web3 challenges and compared various approaches to long-term funding. The conversation highlighted the importance of economic stability and sustainable management strategies to support decentralized network growth across ecosystems.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=YuvoTakrrRE)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/YuvoTakrrRE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2026-01-28-media-your-art-your-rules/index.md
+++ b/blog/2026-01-28-media-your-art-your-rules/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2026-01-28-media-your-art-your-rules
+title: "Cardano Roundtable Talk - Your Art, Your Rules"
+authors: [community]
+tags: [media]
+---
+
+A Roundtable Talk, features a discussion from the NuLuna event in Barcelona on ownership and career paths for creators on Cardano. Participants explored how artists and musicians leverage Web3 for direct community coordination and sustainable business models. The conversation also addressed industry myths and practical strategies for building creative careers within the blockchain ecosystem.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=BQI_JeBQn28)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/BQI_JeBQn28" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits/index.md
+++ b/blog/2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits
+title: "SPO Table Talk: Understanding GA – Updates to Plutus execution limits"
+authors: [community]
+tags: [media]
+---
+
+A Roundtable Talk, features a discussion on increasing Plutus memory units to enhance throughput and developer flexibility. Participants addressed node performance, constitutional guardrails, and the vital role of SPO participation under CIP-1694. The session aimed to provide SPOs with the technical clarity needed for informed voting on protocol scaling.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=FUyxLuCMbBI)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/FUyxLuCMbBI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2026-02-26-media-gap-in-supply-chain-management/index.md
+++ b/blog/2026-02-26-media-gap-in-supply-chain-management/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2026-02-26-media-gap-in-supply-chain-management
+title: "Understanding the Adoption Gap in Supply Chain Management"
+authors: [community]
+tags: [media]
+---
+
+A Roundtable Talk, features a discussion on supply chain resilience and the gap between blockchain’s promise and enterprise adoption. Participants explored how regulations like Digital Product Passports drive traceability needs while unpacking the barriers to large-scale implementation. The session focused on the practical shifts required to move blockchain from pilot projects to widespread utility.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=YplAZcEnr94)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/YplAZcEnr94" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2026-03-18-media-debate-on-ncl/index.md
+++ b/blog/2026-03-18-media-debate-on-ncl/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2026-03-18-media-debate-on-ncl
+title: "Cardano Governance - A Debate on NCL & Constitutional Clarity"
+authors: [community]
+tags: [media]
+---
+
+This session explores the Net Change Limit (NCL) and its role in Cardano’s treasury sustainability. Participants discussed constitutional interpretations regarding fund approval and the role of the Constitutional Committee, focusing on clarifying governance rules to ensure responsible spending and transparency within the ecosystem.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=NgBxeOmdBlw)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/NgBxeOmdBlw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2026-04-13-media-state-of-cardano-defi/index.md
+++ b/blog/2026-04-13-media-state-of-cardano-defi/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2026-04-13-media-state-of-cardano-defi
+title: "The State of Cardano DeFi"
+authors: [community]
+tags: [media]
+---
+
+This session addresses Cardano’s DeFi growth, focusing on liquidity depth, stablecoin adoption, and user experience. Participants discussed trading efficiency and explored practical solutions like improved incentive structures and ecosystem coordination to unlock the next phase of DeFi.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=sgrZFbUbGfg)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/sgrZFbUbGfg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/blog/2026-04-17-media-drep-votin-power-concentration/index.md
+++ b/blog/2026-04-17-media-drep-votin-power-concentration/index.md
@@ -1,0 +1,14 @@
+---
+slug: 2026-04-17-media-drep-votin-power-concentration
+title: "DRep Voting Power Concentration: The Path Forward"
+authors: [community]
+tags: [media]
+---
+
+This session explores how wallet design influences delegation and voting power concentration in Cardano. Participants discussed DRep accountability, voter participation, and the role of institutional DReps, focusing on identifying healthy dynamics for a balanced and decentralized governance ecosystem.
+
+<div style={{ textAlign: 'right' }}>
+[**Watch now**](https://www.youtube.com/watch?v=0gwdMmCUAeA)
+</div>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/0gwdMmCUAeA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>


### PR DESCRIPTION
**Pull Request Title:** Add Roundtable Talks and media coverage to News section

---

**Description:**
Added 12 new media entries to the `blog/` directory, featuring the "Roundtable Talk" series. 

**Headlines:**
* **DRep Voting Power Concentration: The Path Forward** (April 17, 2026)
* **The State of Cardano DeFi** (April 13, 2026)
* **A Debate on NCL & Constitutional Clarity** (March 18, 2026)
* **Understanding the Adoption Gap in Supply Chain Management** (Feb 26, 2026)
* **SPO Table Talk: Updates to Plutus Execution Limits** (Feb 03, 2026)
* **Your Art, Your Rules: Creators on Cardano** (Jan 28, 2026)
* **Cardano-Polkadot: Pathways to Treasury Sustainability** (Dec 16, 2025)
* **Community Expertise in Action (Parts 1 & 2)** (Sept/Oct 2025)
* **Cardano Culture** (Sept 20, 2025)
* **Developers Tooling on Cardano** (Sept 01, 2025)
* **Followup to Nested Transactions** (July 21, 2025)

---

**Testing:**
* **Embed Verification:** Confirmed that all YouTube `<iframe>` embeds render correctly and maintain aspect ratio in the local build.
* **Link Validation:** Verified that all "Watch now" links point to the correct time-stamped videos on YouTube.
* **Route Check:** Successfully verified that all 12 new slugs are accessible and front-matter is correctly formatted.

