### PR TITLE
feat: self-healing hreflang sitemap with lastmod and noise filters 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,8 +13,7 @@ import 'dotenv/config';
 // GitHub Settings to setup repository and branch customFields
 const vars = require('./variables')
 
-const fs = require('node:fs');
-const path = require('node:path');
+const { createSitemapItemsHook } = require('./scripts/sitemap-hreflang');
 
 // enable or disable the announcement header bar (see 'announcementBar' section below)
 const isAnnouncementActive = false;
@@ -134,158 +133,9 @@ const config = {
           changefreq: 'weekly',
           priority: 0.5,
           ignorePatterns: ['**/tags/**', '**/news/tags/**', '**/news/page/**'],
-          /**
-           * Self-healing hreflang annotations.
-           *
-           * For every URL in the sitemap, we add `<xhtml:link rel="alternate" hreflang="...">`
-           * entries pointing to the equivalent page in each locale that actually has the
-           * translated content. We also drop URLs from per-locale sitemaps when the locale
-           * has no translation for that page, so we never declare a German URL as an
-           * alternate for an English-only article.
-           *
-           * Three content classes:
-           *
-           *   1. React pages (src/pages/*)         -> always available in every locale,
-           *                                          translations come from i18n JSON
-           *                                          catalogs (docusaurus-theme-classic,
-           *                                          per-page Translate calls)
-           *
-           *   2. Docs (docs/*.md)                  -> per-locale source file at
-           *                                          i18n/<locale>/docusaurus-plugin-content-docs/current/<path>.md
-           *
-           *   3. Blog / news (blog/*.md)           -> per-locale source file at
-           *                                          i18n/<locale>/docusaurus-plugin-content-blog/<slug>.md
-           *                                          (also matches <slug>/index.md for
-           *                                          posts laid out as a directory)
-           *
-           * The news index `/news/` is treated as a React-style page since it is just a
-           * paginated list whose UI is fully translated.
-           *
-           * To extend: if you add a new content plugin (e.g. a second blog at /events),
-           * add a clause in `getTranslationSourcePath` that maps its URL prefix to the
-           * expected `i18n/<locale>/docusaurus-plugin-<id>/...` path.
-           */
-          createSitemapItems: async (params) => {
-            const { defaultCreateSitemapItems, siteConfig } = params;
-            const items = await defaultCreateSitemapItems(params);
-            const { locales, defaultLocale } = siteConfig.i18n;
-            const siteUrl = siteConfig.url.replace(/\/$/, '');
-            const projectRoot = __dirname;
-
-            // Strip the locale prefix from a pathname to get the locale-neutral path.
-            // Example: "/de/governance/" -> "/governance/"
-            const stripLocale = (pathname) => {
-              for (const l of locales) {
-                if (l !== defaultLocale && pathname.startsWith(`/${l}/`)) {
-                  return pathname.slice(l.length + 1);
-                }
-              }
-              return pathname;
-            };
-
-            // Detect which locale a given URL belongs to (by prefix). Default locale has
-            // no prefix, so anything that doesn't start with a non-default locale is EN.
-            const detectLocale = (pathname) => {
-              for (const l of locales) {
-                if (l !== defaultLocale && pathname.startsWith(`/${l}/`)) return l;
-              }
-              return defaultLocale;
-            };
-
-            // Build the canonical URL for a given locale + neutral pathname.
-            const localeUrl = (locale, neutralPathname) =>
-              locale === defaultLocale
-                ? `${siteUrl}${neutralPathname}`
-                : `${siteUrl}/${locale}${neutralPathname}`;
-
-            // Map a locale-neutral pathname to the on-disk path of its translation
-            // source for `locale`. Returns null for React pages (always translated via
-            // i18n catalogs) and for paths we don't recognize as markdown content.
-            const getTranslationSourcePath = (neutralPathname, locale) => {
-              const trimmed = neutralPathname.replace(/\/$/, '');
-
-              // Blog / news posts: /news/<slug>/  (but not /news/ itself)
-              const newsMatch = trimmed.match(/^\/news\/(.+)$/);
-              if (newsMatch) {
-                const slug = newsMatch[1];
-                const baseDir = path.join(
-                  projectRoot,
-                  'i18n',
-                  locale,
-                  'docusaurus-plugin-content-blog',
-                );
-                return [
-                  path.join(baseDir, `${slug}.md`),
-                  path.join(baseDir, `${slug}.mdx`),
-                  path.join(baseDir, slug, 'index.md'),
-                  path.join(baseDir, slug, 'index.mdx'),
-                ];
-              }
-
-              // Docs: /docs/<path>
-              const docsMatch = trimmed.match(/^\/docs\/(.+)$/);
-              if (docsMatch) {
-                const docPath = docsMatch[1];
-                const baseDir = path.join(
-                  projectRoot,
-                  'i18n',
-                  locale,
-                  'docusaurus-plugin-content-docs',
-                  'current',
-                );
-                return [
-                  path.join(baseDir, `${docPath}.md`),
-                  path.join(baseDir, `${docPath}.mdx`),
-                  path.join(baseDir, docPath, 'index.md'),
-                  path.join(baseDir, docPath, 'index.mdx'),
-                ];
-              }
-
-              // React page or unknown -> treat as always-translated.
-              return null;
-            };
-
-            // Decide whether a given locale has a usable translation for the page.
-            // - Default locale: always true (it is the source).
-            // - React page (no source path candidates): true.
-            // - Markdown page: true iff at least one candidate file exists on disk.
-            const hasTranslation = (neutralPathname, locale) => {
-              if (locale === defaultLocale) return true;
-              const candidates = getTranslationSourcePath(neutralPathname, locale);
-              if (!candidates) return true;
-              return candidates.some((p) => fs.existsSync(p));
-            };
-
-            const result = [];
-            for (const item of items) {
-              const { pathname } = new URL(item.url);
-              const currentLocale = detectLocale(pathname);
-              const neutralPathname = stripLocale(pathname);
-
-              // Drop URLs from non-default locale sitemaps when no translation exists.
-              if (!hasTranslation(neutralPathname, currentLocale)) {
-                continue;
-              }
-
-              // Build hreflang links only for locales that have the translation.
-              const translatedLocales = locales.filter((l) =>
-                hasTranslation(neutralPathname, l),
-              );
-              const links = translatedLocales.map((l) => ({
-                lang: l,
-                url: localeUrl(l, neutralPathname),
-              }));
-              // Always anchor x-default to the default locale (only if it exists,
-              // which it does for any URL we keep here).
-              links.push({
-                lang: 'x-default',
-                url: localeUrl(defaultLocale, neutralPathname),
-              });
-
-              result.push({ ...item, links });
-            }
-            return result;
-          },
+          // Hook implementation lives in scripts/sitemap-hreflang.js so it can be
+          // unit-tested without spinning up a Docusaurus build. See the JSDoc there.
+          createSitemapItems: createSitemapItemsHook({ projectRoot: __dirname }),
         },
       }),
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,6 +13,9 @@ import 'dotenv/config';
 // GitHub Settings to setup repository and branch customFields
 const vars = require('./variables')
 
+const fs = require('node:fs');
+const path = require('node:path');
+
 // enable or disable the announcement header bar (see 'announcementBar' section below)
 const isAnnouncementActive = false;
 
@@ -125,6 +128,164 @@ const config = {
           // don't be evil
           trackingID: 'G-LGRGXBVYMC',
           anonymizeIP: true,
+        },
+        sitemap: {
+          lastmod: 'date',
+          changefreq: 'weekly',
+          priority: 0.5,
+          ignorePatterns: ['**/tags/**', '**/news/tags/**', '**/news/page/**'],
+          /**
+           * Self-healing hreflang annotations.
+           *
+           * For every URL in the sitemap, we add `<xhtml:link rel="alternate" hreflang="...">`
+           * entries pointing to the equivalent page in each locale that actually has the
+           * translated content. We also drop URLs from per-locale sitemaps when the locale
+           * has no translation for that page, so we never declare a German URL as an
+           * alternate for an English-only article.
+           *
+           * Three content classes:
+           *
+           *   1. React pages (src/pages/*)         -> always available in every locale,
+           *                                          translations come from i18n JSON
+           *                                          catalogs (docusaurus-theme-classic,
+           *                                          per-page Translate calls)
+           *
+           *   2. Docs (docs/*.md)                  -> per-locale source file at
+           *                                          i18n/<locale>/docusaurus-plugin-content-docs/current/<path>.md
+           *
+           *   3. Blog / news (blog/*.md)           -> per-locale source file at
+           *                                          i18n/<locale>/docusaurus-plugin-content-blog/<slug>.md
+           *                                          (also matches <slug>/index.md for
+           *                                          posts laid out as a directory)
+           *
+           * The news index `/news/` is treated as a React-style page since it is just a
+           * paginated list whose UI is fully translated.
+           *
+           * To extend: if you add a new content plugin (e.g. a second blog at /events),
+           * add a clause in `getTranslationSourcePath` that maps its URL prefix to the
+           * expected `i18n/<locale>/docusaurus-plugin-<id>/...` path.
+           */
+          createSitemapItems: async (params) => {
+            const { defaultCreateSitemapItems, siteConfig } = params;
+            const items = await defaultCreateSitemapItems(params);
+            const { locales, defaultLocale } = siteConfig.i18n;
+            const siteUrl = siteConfig.url.replace(/\/$/, '');
+            const projectRoot = __dirname;
+
+            // Strip the locale prefix from a pathname to get the locale-neutral path.
+            // Example: "/de/governance/" -> "/governance/"
+            const stripLocale = (pathname) => {
+              for (const l of locales) {
+                if (l !== defaultLocale && pathname.startsWith(`/${l}/`)) {
+                  return pathname.slice(l.length + 1);
+                }
+              }
+              return pathname;
+            };
+
+            // Detect which locale a given URL belongs to (by prefix). Default locale has
+            // no prefix, so anything that doesn't start with a non-default locale is EN.
+            const detectLocale = (pathname) => {
+              for (const l of locales) {
+                if (l !== defaultLocale && pathname.startsWith(`/${l}/`)) return l;
+              }
+              return defaultLocale;
+            };
+
+            // Build the canonical URL for a given locale + neutral pathname.
+            const localeUrl = (locale, neutralPathname) =>
+              locale === defaultLocale
+                ? `${siteUrl}${neutralPathname}`
+                : `${siteUrl}/${locale}${neutralPathname}`;
+
+            // Map a locale-neutral pathname to the on-disk path of its translation
+            // source for `locale`. Returns null for React pages (always translated via
+            // i18n catalogs) and for paths we don't recognize as markdown content.
+            const getTranslationSourcePath = (neutralPathname, locale) => {
+              const trimmed = neutralPathname.replace(/\/$/, '');
+
+              // Blog / news posts: /news/<slug>/  (but not /news/ itself)
+              const newsMatch = trimmed.match(/^\/news\/(.+)$/);
+              if (newsMatch) {
+                const slug = newsMatch[1];
+                const baseDir = path.join(
+                  projectRoot,
+                  'i18n',
+                  locale,
+                  'docusaurus-plugin-content-blog',
+                );
+                return [
+                  path.join(baseDir, `${slug}.md`),
+                  path.join(baseDir, `${slug}.mdx`),
+                  path.join(baseDir, slug, 'index.md'),
+                  path.join(baseDir, slug, 'index.mdx'),
+                ];
+              }
+
+              // Docs: /docs/<path>
+              const docsMatch = trimmed.match(/^\/docs\/(.+)$/);
+              if (docsMatch) {
+                const docPath = docsMatch[1];
+                const baseDir = path.join(
+                  projectRoot,
+                  'i18n',
+                  locale,
+                  'docusaurus-plugin-content-docs',
+                  'current',
+                );
+                return [
+                  path.join(baseDir, `${docPath}.md`),
+                  path.join(baseDir, `${docPath}.mdx`),
+                  path.join(baseDir, docPath, 'index.md'),
+                  path.join(baseDir, docPath, 'index.mdx'),
+                ];
+              }
+
+              // React page or unknown -> treat as always-translated.
+              return null;
+            };
+
+            // Decide whether a given locale has a usable translation for the page.
+            // - Default locale: always true (it is the source).
+            // - React page (no source path candidates): true.
+            // - Markdown page: true iff at least one candidate file exists on disk.
+            const hasTranslation = (neutralPathname, locale) => {
+              if (locale === defaultLocale) return true;
+              const candidates = getTranslationSourcePath(neutralPathname, locale);
+              if (!candidates) return true;
+              return candidates.some((p) => fs.existsSync(p));
+            };
+
+            const result = [];
+            for (const item of items) {
+              const { pathname } = new URL(item.url);
+              const currentLocale = detectLocale(pathname);
+              const neutralPathname = stripLocale(pathname);
+
+              // Drop URLs from non-default locale sitemaps when no translation exists.
+              if (!hasTranslation(neutralPathname, currentLocale)) {
+                continue;
+              }
+
+              // Build hreflang links only for locales that have the translation.
+              const translatedLocales = locales.filter((l) =>
+                hasTranslation(neutralPathname, l),
+              );
+              const links = translatedLocales.map((l) => ({
+                lang: l,
+                url: localeUrl(l, neutralPathname),
+              }));
+              // Always anchor x-default to the default locale (only if it exists,
+              // which it does for any URL we keep here).
+              links.push({
+                lang: 'x-default',
+                url: localeUrl(defaultLocale, neutralPathname),
+              });
+
+              result.push({ ...item, links });
+            }
+            return result;
+          },
         },
       }),
     ],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "crowdin:upload": "crowdin upload sources",
     "crowdin:upload-all": "crowdin upload sources && crowdin upload translations",
     "crowdin:download": "crowdin download",
-    "crowdin:progress": "node scripts/fetch-crowdin-progress.js"
+    "crowdin:progress": "node scripts/fetch-crowdin-progress.js",
+    "test:sitemap": "node scripts/test-sitemap-hreflang.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",

--- a/scripts/sitemap-hreflang.js
+++ b/scripts/sitemap-hreflang.js
@@ -1,0 +1,154 @@
+/**
+ * Self-healing hreflang annotations for the Docusaurus sitemap plugin.
+ *
+ * "Self-healing" means: instead of statically declaring all locales as
+ * hreflang alternates for every page (which lies to Google about untranslated
+ * pages), we check the filesystem at build time. A locale only becomes a
+ * hreflang alternate for a page when an actual translation file exists under
+ * `i18n/<locale>/...`. Drop a translation in, the alternate appears on the
+ * next build; remove it, the alternate disappears. No config maintenance.
+ *
+ * For every URL in the sitemap, we add `<xhtml:link rel="alternate" hreflang="...">`
+ * entries pointing to the equivalent page in each locale that actually has the
+ * translated content. We also drop URLs from per-locale sitemaps when the locale
+ * has no translation for that page, so we never declare a German URL as an
+ * alternate for an English-only article.
+ *
+ * Three content classes:
+ *
+ *   1. React pages (src/pages/*)         -> always available in every locale,
+ *                                          translations come from i18n JSON
+ *                                          catalogs (docusaurus-theme-classic,
+ *                                          per-page Translate calls)
+ *
+ *   2. Docs (docs/*.md)                  -> per-locale source file at
+ *                                          i18n/<locale>/docusaurus-plugin-content-docs/current/<path>.md
+ *
+ *   3. Blog / news (blog/*.md)           -> per-locale source file at
+ *                                          i18n/<locale>/docusaurus-plugin-content-blog/<slug>.md
+ *                                          (also matches <slug>/index.md for
+ *                                          posts laid out as a directory)
+ *
+ * The news index `/news/` is treated as a React-style page since it is just a
+ * paginated list whose UI is fully translated.
+ *
+ * To extend: if you add a new content plugin (e.g. a second blog at /events),
+ * add a clause in `getTranslationSourcePath` that maps its URL prefix to the
+ * expected `i18n/<locale>/docusaurus-plugin-<id>/...` path.
+ *
+ * The helpers are exported separately so they can be unit-tested without
+ * spinning up a full Docusaurus build (see scripts/test-sitemap-hreflang.js).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * @param {{ locales: string[], defaultLocale: string, siteUrl: string, projectRoot: string }} cfg
+ */
+function buildHelpers({ locales, defaultLocale, siteUrl, projectRoot }) {
+  const normalizedSiteUrl = siteUrl.replace(/\/$/, '');
+
+  // "/de/governance/" -> "/governance/", "/governance/" -> "/governance/"
+  const stripLocale = (pathname) => {
+    for (const l of locales) {
+      if (l !== defaultLocale && pathname.startsWith(`/${l}/`)) {
+        return pathname.slice(l.length + 1);
+      }
+    }
+    return pathname;
+  };
+
+  // "/de/governance/" -> "de", "/governance/" -> defaultLocale
+  const detectLocale = (pathname) => {
+    for (const l of locales) {
+      if (l !== defaultLocale && pathname.startsWith(`/${l}/`)) return l;
+    }
+    return defaultLocale;
+  };
+
+  const localeUrl = (locale, neutralPathname) =>
+    locale === defaultLocale
+      ? `${normalizedSiteUrl}${neutralPathname}`
+      : `${normalizedSiteUrl}/${locale}${neutralPathname}`;
+
+  // Returns an array of candidate file paths for the translation, or null when
+  // the URL is a React page (no source file to check; assumed always-translated).
+  const getTranslationSourcePath = (neutralPathname, locale) => {
+    const trimmed = neutralPathname.replace(/\/$/, '');
+
+    const newsMatch = trimmed.match(/^\/news\/(.+)$/);
+    if (newsMatch) {
+      const slug = newsMatch[1];
+      const baseDir = path.join(projectRoot, 'i18n', locale, 'docusaurus-plugin-content-blog');
+      return [
+        path.join(baseDir, `${slug}.md`),
+        path.join(baseDir, `${slug}.mdx`),
+        path.join(baseDir, slug, 'index.md'),
+        path.join(baseDir, slug, 'index.mdx'),
+      ];
+    }
+
+    const docsMatch = trimmed.match(/^\/docs\/(.+)$/);
+    if (docsMatch) {
+      const docPath = docsMatch[1];
+      const baseDir = path.join(projectRoot, 'i18n', locale, 'docusaurus-plugin-content-docs', 'current');
+      return [
+        path.join(baseDir, `${docPath}.md`),
+        path.join(baseDir, `${docPath}.mdx`),
+        path.join(baseDir, docPath, 'index.md'),
+        path.join(baseDir, docPath, 'index.mdx'),
+      ];
+    }
+
+    return null;
+  };
+
+  const hasTranslation = (neutralPathname, locale) => {
+    if (locale === defaultLocale) return true;
+    const candidates = getTranslationSourcePath(neutralPathname, locale);
+    if (!candidates) return true;
+    return candidates.some((p) => fs.existsSync(p));
+  };
+
+  return { stripLocale, detectLocale, localeUrl, getTranslationSourcePath, hasTranslation };
+}
+
+/**
+ * Factory for the Docusaurus `sitemap.createSitemapItems` callback. The
+ * Docusaurus runtime supplies `siteConfig` at call time, so we only need to
+ * close over the project root here.
+ *
+ * @param {{ projectRoot: string }} cfg
+ */
+function createSitemapItemsHook({ projectRoot }) {
+  return async (params) => {
+    const { defaultCreateSitemapItems, siteConfig } = params;
+    const items = await defaultCreateSitemapItems(params);
+    const { locales, defaultLocale } = siteConfig.i18n;
+    const { stripLocale, detectLocale, localeUrl, hasTranslation } = buildHelpers({
+      locales,
+      defaultLocale,
+      siteUrl: siteConfig.url,
+      projectRoot,
+    });
+
+    const result = [];
+    for (const item of items) {
+      const { pathname } = new URL(item.url);
+      const currentLocale = detectLocale(pathname);
+      const neutralPathname = stripLocale(pathname);
+
+      if (!hasTranslation(neutralPathname, currentLocale)) continue;
+
+      const translatedLocales = locales.filter((l) => hasTranslation(neutralPathname, l));
+      const links = translatedLocales.map((l) => ({ lang: l, url: localeUrl(l, neutralPathname) }));
+      links.push({ lang: 'x-default', url: localeUrl(defaultLocale, neutralPathname) });
+
+      result.push({ ...item, links });
+    }
+    return result;
+  };
+}
+
+module.exports = { buildHelpers, createSitemapItemsHook };

--- a/scripts/test-sitemap-hreflang.js
+++ b/scripts/test-sitemap-hreflang.js
@@ -1,0 +1,362 @@
+/**
+ * Tests for scripts/sitemap-hreflang.js, the self-healing hreflang
+ * implementation used by the Docusaurus sitemap plugin.
+ *
+ * Background: what "self-healing hreflang" means
+ * -----------------------------------------------
+ * Google's hreflang spec says: when you tell a search engine that
+ * `https://cardano.org/de/governance/` is the German alternate of
+ * `https://cardano.org/governance/`, you are promising the German URL
+ * actually serves German content. If both URLs serve identical English
+ * markup (because no translation exists yet), Google sees duplicate
+ * content under different URLs and either ignores the hreflang signals,
+ * deduplicates the URLs, or shows the wrong one in the wrong locale.
+ *
+ * Most i18n hreflang setups in the wild are statically configured: every
+ * page declares all locales as alternates, regardless of whether a
+ * translation exists. That is fine on day one when nothing is translated
+ * (Google ignores the bogus alternates) and fine on day N when everything
+ * is translated, but in the middle (where this site lives) it is wrong.
+ *
+ * Our hook, in scripts/sitemap-hreflang.js, instead checks the
+ * filesystem for each URL: does an actual translation file exist under
+ * `i18n/<locale>/...`? Only those locales become hreflang alternates,
+ * and untranslated pages are dropped from the per-locale sitemaps
+ * altogether. The result is a sitemap that always reflects reality.
+ *
+ * It is "self-healing" in the sense that no config change is needed when
+ * translation status changes: drop a translated `i18n/de/.../foo.md`
+ * into the repo, and on the next build the German hreflang alternate
+ * appears automatically (and the German sitemap starts including it).
+ * Remove the file, and the alternate disappears. The hreflang annotation
+ * tracks the source tree without manual list maintenance.
+ *
+ * Run from the project root:
+ *   yarn test:sitemap            (runs unit + file-system sections)
+ *   node scripts/test-sitemap-hreflang.js
+ *
+ * The "Build-Output Tests" section is opt-in: it only runs when a recent
+ * temp-dir build is found on disk, so the tests still complete in well
+ * under a second in CI without a full 5-minute build.
+ *
+ * Three sections:
+ *   1. UNIT          pure URL helpers, no IO
+ *   2. FILE-SYSTEM   assertions against the real i18n/ directory
+ *   3. BUILD-OUTPUT  snapshot-style checks against the latest build/sitemap.xml
+ *
+ * To add new content types or locales: extend the helpers in
+ * scripts/sitemap-hreflang.js and add coverage here.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { buildHelpers } = require('./sitemap-hreflang');
+
+const projectRoot = path.resolve(__dirname, '..');
+const siteUrl = 'https://cardano.org';
+const locales = ['en', 'ja', 'de', 'es', 'vi'];
+const defaultLocale = 'en';
+
+const { stripLocale, detectLocale, localeUrl, getTranslationSourcePath, hasTranslation } =
+  buildHelpers({ locales, defaultLocale, siteUrl, projectRoot });
+
+// ---- Test runner ----
+
+let passed = 0, failed = 0;
+const fails = [];
+const expect = (name, actual, expected) => {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) passed++;
+  else { failed++; fails.push({ name, expected, actual }); }
+};
+const section = (title) => console.log(`\n=== ${title} ===`);
+
+// ============================================================
+// 1. UNIT TESTS: pure URL helpers, no IO
+// ============================================================
+
+section('detectLocale');
+expect('default at root', detectLocale('/'), 'en');
+expect('default static page', detectLocale('/governance/'), 'en');
+expect('default news post', detectLocale('/news/2021-foo/'), 'en');
+expect('default news index', detectLocale('/news/'), 'en');
+expect('default deep doc', detectLocale('/docs/get-involved/style-guide/'), 'en');
+expect('de root', detectLocale('/de/'), 'de');
+expect('de static', detectLocale('/de/governance/'), 'de');
+expect('ja static', detectLocale('/ja/apps/'), 'ja');
+expect('es deep', detectLocale('/es/docs/use-cases/payments/'), 'es');
+expect('vi news', detectLocale('/vi/news/'), 'vi');
+expect('not fooled by locale string in path segment', detectLocale('/news/de-something-de-something/'), 'en');
+expect('not fooled by trailing locale-like slug', detectLocale('/news/de/'), 'en');
+
+section('stripLocale');
+expect('default unchanged at root', stripLocale('/'), '/');
+expect('default unchanged static', stripLocale('/governance/'), '/governance/');
+expect('de stripped', stripLocale('/de/governance/'), '/governance/');
+expect('vi nested stripped', stripLocale('/vi/docs/get-involved/create-a-page/'), '/docs/get-involved/create-a-page/');
+expect('en news unchanged', stripLocale('/news/2021-07-26-july-developer-portal/'), '/news/2021-07-26-july-developer-portal/');
+expect('ja news stripped', stripLocale('/ja/news/foo-bar/'), '/news/foo-bar/');
+expect('not fooled by mid-path locale', stripLocale('/governance/de-stuff/'), '/governance/de-stuff/');
+expect('only strips first segment', stripLocale('/de/de-section/'), '/de-section/');
+
+section('localeUrl');
+expect('en root', localeUrl('en', '/'), 'https://cardano.org/');
+expect('en static', localeUrl('en', '/governance/'), 'https://cardano.org/governance/');
+expect('de static', localeUrl('de', '/governance/'), 'https://cardano.org/de/governance/');
+expect('ja deep doc', localeUrl('ja', '/docs/use-cases/payments/'), 'https://cardano.org/ja/docs/use-cases/payments/');
+expect('es news index', localeUrl('es', '/news/'), 'https://cardano.org/es/news/');
+
+section('getTranslationSourcePath: structure');
+expect('react page returns null (root)', getTranslationSourcePath('/', 'de'), null);
+expect('react page returns null (static)', getTranslationSourcePath('/governance/', 'de'), null);
+expect('news index returns null', getTranslationSourcePath('/news/', 'de'), null);
+expect('docs index returns null', getTranslationSourcePath('/docs/', 'de'), null);
+expect('news post: 4 candidates', getTranslationSourcePath('/news/foo-bar/', 'de').length, 4);
+expect('docs page: 4 candidates', getTranslationSourcePath('/docs/communities/', 'de').length, 4);
+expect('nested docs: 4 candidates', getTranslationSourcePath('/docs/use-cases/payments/', 'ja').length, 4);
+expect('multi-segment news slug', getTranslationSourcePath('/news/2026/special-edition/', 'de').length, 4);
+
+section('getTranslationSourcePath: actual paths');
+expect(
+  'news .md candidate',
+  getTranslationSourcePath('/news/abc/', 'de')[0],
+  path.join(projectRoot, 'i18n/de/docusaurus-plugin-content-blog/abc.md'),
+);
+expect(
+  'news .mdx candidate',
+  getTranslationSourcePath('/news/abc/', 'de')[1],
+  path.join(projectRoot, 'i18n/de/docusaurus-plugin-content-blog/abc.mdx'),
+);
+expect(
+  'news index.md candidate',
+  getTranslationSourcePath('/news/abc/', 'de')[2],
+  path.join(projectRoot, 'i18n/de/docusaurus-plugin-content-blog/abc/index.md'),
+);
+expect(
+  'docs .md candidate',
+  getTranslationSourcePath('/docs/x/', 'ja')[0],
+  path.join(projectRoot, 'i18n/ja/docusaurus-plugin-content-docs/current/x.md'),
+);
+
+// ============================================================
+// 2. FILE-SYSTEM TESTS: assert against real i18n/ state
+// ============================================================
+
+section('hasTranslation: defaults & React pages');
+expect('default locale always true (root)', hasTranslation('/', 'en'), true);
+expect('default locale always true (any)', hasTranslation('/anything/whatever/', 'en'), true);
+expect('react page in de', hasTranslation('/governance/', 'de'), true);
+expect('react page in vi (homepage)', hasTranslation('/', 'vi'), true);
+expect('news index in all locales', hasTranslation('/news/', 'de'), true);
+expect('news index in ja', hasTranslation('/news/', 'ja'), true);
+expect('docs index in es', hasTranslation('/docs/', 'es'), true);
+
+section('hasTranslation: docs known-translated to all 4 non-default');
+const known_translated_docs = [
+  '/docs/communities/',
+  '/docs/use-cases/',
+  '/docs/use-cases/payments/',
+  '/docs/use-cases/agriculture/',
+  '/docs/use-cases/data-storage/',
+  '/docs/use-cases/defi/',
+  '/docs/use-cases/digital-identity/',
+  '/docs/use-cases/education/',
+  '/docs/use-cases/finance-kyc/',
+  '/docs/use-cases/government/',
+  '/docs/use-cases/healthcare/',
+  '/docs/use-cases/logistics/',
+  '/docs/use-cases/music-ip/',
+  '/docs/use-cases/retail/',
+  '/docs/use-cases/social-programs/',
+  '/docs/use-cases/tokenized-assets/',
+  '/docs/use-cases/voting-systems/',
+];
+for (const url of known_translated_docs) {
+  for (const loc of ['de', 'ja', 'es', 'vi']) {
+    expect(`${url} translated in ${loc}`, hasTranslation(url, loc), true);
+  }
+}
+
+section('hasTranslation: docs known-untranslated');
+const known_untranslated_docs = [
+  '/docs/glossary/',
+  '/docs/get-involved/',
+  '/docs/get-involved/style-guide/',
+  '/docs/get-involved/add-app/',
+  '/docs/get-involved/components/divider/',
+  '/docs/get-involved/create-a-page/',
+];
+for (const url of known_untranslated_docs) {
+  for (const loc of ['de', 'ja', 'es', 'vi']) {
+    expect(`${url} NOT translated in ${loc}`, hasTranslation(url, loc), false);
+  }
+}
+
+section('hasTranslation: news posts (none translated, all locales should be false)');
+const sample_news = [
+  '/news/2021-07-26-july-developer-portal/',
+  '/news/2026-04-07-cardano-ecosystem-introduces-rwa-fund/',
+  '/news/2025-03-28-weekly-development-report/',
+];
+for (const url of sample_news) {
+  for (const loc of ['de', 'ja', 'es', 'vi']) {
+    expect(`${url} NOT translated in ${loc}`, hasTranslation(url, loc), false);
+  }
+  expect(`${url} translated in en (default)`, hasTranslation(url, 'en'), true);
+}
+
+// ============================================================
+// 3. BUILD-OUTPUT TESTS: verify the actual generated sitemap (opt-in)
+// ============================================================
+
+const findLatestBuildDir = () => {
+  const tmpRoot = require('os').tmpdir();
+  let parents = [tmpRoot];
+  // macOS uses /var/folders/... per-user temp dirs that aren't tmpRoot here.
+  // Walk one level if tmpRoot doesn't directly contain tmp.* dirs.
+  try {
+    const direct = fs.readdirSync(tmpRoot).filter(n => n.startsWith('tmp.'));
+    if (direct.length === 0) parents = [tmpRoot];
+  } catch {}
+  const candidates = [];
+  for (const parent of parents) {
+    try {
+      for (const entry of fs.readdirSync(parent)) {
+        if (!entry.startsWith('tmp.')) continue;
+        const p = path.join(parent, entry);
+        const sitemapPath = path.join(p, 'build/sitemap.xml');
+        try {
+          if (fs.statSync(sitemapPath).isFile()) candidates.push({ p, mtime: fs.statSync(sitemapPath).mtimeMs });
+        } catch {}
+      }
+    } catch {}
+  }
+  candidates.sort((a, b) => b.mtime - a.mtime);
+  return candidates[0]?.p ?? null;
+};
+
+const buildDir = findLatestBuildDir();
+section(`Build-Output (using ${buildDir || '<no temp build found, skipping>'})`);
+
+if (!buildDir) {
+  console.log('  Build-Output Tests skipped. Run "yarn build" in a temp dir to enable.');
+} else {
+  const parseSitemap = (file) => {
+    const xml = fs.readFileSync(file, 'utf8');
+    const urls = [];
+    const urlBlocks = xml.match(/<url>[\s\S]*?<\/url>/g) || [];
+    for (const block of urlBlocks) {
+      const loc = (block.match(/<loc>([^<]+)<\/loc>/) || [])[1];
+      const lastmod = (block.match(/<lastmod>([^<]+)<\/lastmod>/) || [])[1];
+      const links = [...block.matchAll(/hreflang="([^"]+)"\s+href="([^"]+)"/g)].map(m => ({ lang: m[1], url: m[2] }));
+      urls.push({ loc, lastmod, links });
+    }
+    return urls;
+  };
+
+  const sitemaps = Object.fromEntries(
+    locales.map(l => [
+      l,
+      parseSitemap(path.join(buildDir, l === defaultLocale ? 'build/sitemap.xml' : `build/${l}/sitemap.xml`)),
+    ]),
+  );
+
+  expect('en sitemap has > 400 urls', sitemaps.en.length > 400, true);
+  expect(
+    'per-locale sitemaps roughly equal',
+    [sitemaps.de, sitemaps.ja, sitemaps.es, sitemaps.vi].every(s => s.length === sitemaps.de.length),
+    true,
+  );
+  expect('per-locale sitemap is a subset of EN by count', sitemaps.de.length < sitemaps.en.length, true);
+
+  const enWithLastmod = sitemaps.en.filter(u => u.lastmod).length;
+  expect('most EN urls have lastmod', enWithLastmod / sitemaps.en.length > 0.9, true);
+  expect(
+    'EN lastmod values are YYYY-MM-DD',
+    sitemaps.en.filter(u => u.lastmod).every(u => /^\d{4}-\d{2}-\d{2}$/.test(u.lastmod)),
+    true,
+  );
+
+  const newsPosts = sitemaps.en.filter(u => /\/news\/[^/]+\/$/.test(new URL(u.loc).pathname) && !u.loc.endsWith('/news/'));
+  expect('EN has many news posts', newsPosts.length > 100, true);
+  expect(
+    'all EN news posts have only [en, x-default]',
+    newsPosts.every(u => {
+      const langs = u.links.map(l => l.lang).sort();
+      return JSON.stringify(langs) === JSON.stringify(['en', 'x-default']);
+    }),
+    true,
+  );
+
+  for (const loc of ['de', 'ja', 'es', 'vi']) {
+    const newsInLoc = sitemaps[loc].filter(
+      u => /\/news\/[^/]+\/$/.test(new URL(u.loc).pathname) && !u.loc.endsWith('/news/'),
+    );
+    expect(`${loc} sitemap has 0 news posts`, newsInLoc.length, 0);
+  }
+
+  for (const loc of locales) {
+    const newsIndex = sitemaps[loc].find(u => u.loc.endsWith('/news/'));
+    expect(`${loc} sitemap contains /news/ index`, !!newsIndex, true);
+    if (newsIndex) {
+      const langs = newsIndex.links.map(l => l.lang).sort();
+      expect(`${loc} /news/ index has all 5 + x-default hreflang`, langs, ['de', 'en', 'es', 'ja', 'vi', 'x-default']);
+    }
+  }
+
+  for (const loc of locales) {
+    const govPath = loc === defaultLocale ? '/governance/' : `/${loc}/governance/`;
+    const gov = sitemaps[loc].find(u => new URL(u.loc).pathname === govPath);
+    expect(`${loc} sitemap contains governance with full hreflang`, gov ? gov.links.length : 0, 6);
+  }
+
+  for (const loc of locales) {
+    const commPath = loc === defaultLocale ? '/docs/communities/' : `/${loc}/docs/communities/`;
+    const comm = sitemaps[loc].find(u => new URL(u.loc).pathname === commPath);
+    expect(`${loc} sitemap contains /docs/communities/`, !!comm, true);
+  }
+
+  expect('EN has /docs/glossary/', !!sitemaps.en.find(u => new URL(u.loc).pathname === '/docs/glossary/'), true);
+  for (const loc of ['de', 'ja', 'es', 'vi']) {
+    const gloss = sitemaps[loc].find(u => new URL(u.loc).pathname === `/${loc}/docs/glossary/`);
+    expect(`${loc} sitemap does NOT contain glossary`, !!gloss, false);
+  }
+
+  for (const loc of locales) {
+    const wrongXDefault = sitemaps[loc].find(u => {
+      const xd = u.links.find(l => l.lang === 'x-default');
+      return xd && (xd.url.includes('/de/') || xd.url.includes('/ja/') || xd.url.includes('/es/') || xd.url.includes('/vi/'));
+    });
+    expect(`${loc} x-default never points to non-default locale`, !!wrongXDefault, false);
+  }
+
+  for (const loc of locales) {
+    const broken = sitemaps[loc].filter(u => {
+      const self = u.links.find(l => l.lang === loc);
+      return self && self.url !== u.loc;
+    });
+    expect(`${loc} self-hreflang matches its loc`, broken.length, 0);
+  }
+
+  for (const loc of locales) {
+    const noisy = sitemaps[loc].filter(u => /\/tags\/|\/news\/page\/|\/news\/tags\//.test(u.loc));
+    expect(`${loc} sitemap has no tag/page noise`, noisy.length, 0);
+  }
+}
+
+// ============================================================
+// Summary
+// ============================================================
+
+console.log(`\n${'='.repeat(60)}`);
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  console.log('\nFailures:');
+  for (const f of fails) {
+    console.log(`  - ${f.name}`);
+    console.log(`      expected ${JSON.stringify(f.expected)}`);
+    console.log(`      got      ${JSON.stringify(f.actual)}`);
+  }
+}
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
- Configure the Docusaurus sitemap plugin with `lastmod: 'date'`, explicit `changefreq`/`priority`, and `ignorePatterns` that drop `/tags/**`, `/news/page/**` and `/news/tags/**` from the sitemaps                                                                        
 - Add a custom `createSitemapItems` hook that declares `<xhtml:link rel="alternate" hreflang="...">` only for locales that actually have a translation file under `i18n/<locale>/...`; pages without a translation are dropped from per-locale sitemaps                          
 - Self-healing means: drop a `i18n/de/.../foo.md` into the repo and the German hreflang alternate appears on the next build; remove it and the alternate disappears. No config maintenance as translation coverage changes                                                   
 - News posts currently have no translations, so they appear only in the EN sitemap with `hreflang="en"` + `x-default` and will light up automatically as Crowdin produces translations                                                                                         
 - Extract the hook to `scripts/sitemap-hreflang.js` so the logic can be unit-tested without running a 5-minute Docusaurus build
 - Add `scripts/test-sitemap-hreflang.js` with a three-section suite (URL helpers, filesystem lookups, snapshot checks against the generated sitemap XML) runnable via `yarn test:sitemap`