### PR TITLE
feat: require description frontmatter on news articles and backfill recent 12  

### DIFF
--- a/blog/2026-03-18-media-debate-on-ncl/index.md
+++ b/blog/2026-03-18-media-debate-on-ncl/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-03-18-media-debate-on-ncl
 title: "Cardano Governance - A Debate on NCL & Constitutional Clarity"
+description: "Panel debates Cardano's Net Change Limit and treasury sustainability: constitutional interpretations of fund approval and the Constitutional Committee's role."
 authors: [community]
 tags: [media]
 ---

--- a/blog/2026-03-20-weekly-development-report/index.md
+++ b/blog/2026-03-20-weekly-development-report/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-03-20-weekly-development-report
 title: "Weekly Development Report"
+description: "Cardano Node v10.7 packages ready for the intra-era hard fork to protocol v11. Hydra v1.3.0 ships partial fanout work; team prepares for the Dijkstra era."
 authors: [iog]
 tags: [weekly development report, development]
 ---

--- a/blog/2026-03-25-research-on-validator-incentives/index.md
+++ b/blog/2026-03-25-research-on-validator-incentives/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-03-25-research-on-validator-incentives
 title: "New Research on Validator Incentives and Restaking Security"
+description: "Cardano Foundation, IOG, and Gauntlet study restaking security: how slashing-based validator incentives can cascade across protocols and what to do instead."
 authors: [cf]
 tags: [research]
 ---

--- a/blog/2026-03-27-weekly-development-report/index.md
+++ b/blog/2026-03-27-weekly-development-report/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-03-27-weekly-development-report
 title: "Weekly Development Report"
+description: "Node v10.7.0 ships, Peras adds on-chain certificate tracking, Mithril completes Halo2 SNARK primitives, Aggelos Kiayias named 2026 IACR Fellow."
 authors: [iog]
 tags: [weekly development report, development]
 ---

--- a/blog/2026-03-31-community-digest/index.md
+++ b/blog/2026-03-31-community-digest/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-03-31-community-digest
 title: "Community Digest"
+description: "Midnight mainnet launches ZK apps, FluidTokens runs the first native Bitcoin to Cardano atomic swap, Cardano Node 10.7.0 cuts RAM use from 24 GB to 8 GB."
 authors: [cf]
 tags: [community digest,ambassadors]
 ---

--- a/blog/2026-03-31-critival-integrations/index.md
+++ b/blog/2026-03-31-critival-integrations/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-03-31-critival-integrations
 title: "Critical Integrations Technical Progress update and “Pentad V2”"
+description: "USDCx launch boosts Cardano stablecoin supply 40%. Pyth oracles ready for Q2, Dune and LayerZero integrations in progress, Pentad V2 design begins."
 authors: [intersect]
 tags: [development]
 ---

--- a/blog/2026-04-03-weekly-development-report/index.md
+++ b/blog/2026-04-03-weekly-development-report/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-04-03-weekly-development-report
 title: "Weekly Development Report"
+description: "Lace integrates Midnight mainnet for private assets, Mithril activates SNARK prover on devnet, tx-centrifuge benchmarks land for node v10.6.2."
 authors: [iog]
 tags: [weekly development report, development]
 ---

--- a/blog/2026-04-07-draper-dragen-fund/index.md
+++ b/blog/2026-04-07-draper-dragen-fund/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-04-07-draper-dragen-fund
 title: "Cardano and Draper Dragon Announce Initial Phase of Strategic $80M Ecosystem Fund"
+description: "Cardano Foundation and Draper Dragon launch the $80M Orion Fund for RWA, DeFi, and Bitcoin liquidity, with equity returns flowing to the Cardano treasury."
 authors: [cf]
 tags: [development]
 ---

--- a/blog/2026-04-10-weekly-development-report/index.md
+++ b/blog/2026-04-10-weekly-development-report/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-04-10-weekly-development-report
 title: "Weekly Development Report"
+description: "PlutusCoreBlaster brings Plutus Core into Lean 4. Plutus UPLC optimizations, Mithril SNARK CLI for Cardano blocks, Intersect committee deadline April 17."
 authors: [iog]
 tags: [weekly development report, development]
 ---

--- a/blog/2026-04-13-media-state-of-cardano-defi/index.md
+++ b/blog/2026-04-13-media-state-of-cardano-defi/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-04-13-media-state-of-cardano-defi
 title: "The State of Cardano DeFi"
+description: "Cardano DeFi panel on liquidity depth, stablecoin adoption, and trading UX. Practical paths to better incentive structures and ecosystem coordination."
 authors: [community]
 tags: [media]
 ---

--- a/blog/2026-04-14-community-digest/index.md
+++ b/blog/2026-04-14-community-digest/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-04-14-community-digest
 title: "Community Digest"
+description: "Pragma opens infrastructure project applications, Gerolamo TypeScript node debuts, Cardano hits 120M transactions, Van Rossem hard fork on track for June."
 authors: [cf]
 tags: [community digest,ambassadors]
 ---

--- a/blog/2026-04-17-media-drep-votin-power-concentration/index.md
+++ b/blog/2026-04-17-media-drep-votin-power-concentration/index.md
@@ -1,6 +1,7 @@
 ---
 slug: 2026-04-17-media-drep-votin-power-concentration
 title: "DRep Voting Power Concentration: The Path Forward"
+description: "How wallet design shapes DRep voting power on Cardano. Panel discusses delegation incentives, voter participation, and institutional DReps in governance."
 authors: [community]
 tags: [media]
 ---

--- a/docs/get-involved/create-a-news-article.md
+++ b/docs/get-involved/create-a-news-article.md
@@ -54,6 +54,40 @@ builderfest:
   image_url: ../img/authors/builderfest.png
 ```
 
+## Required Frontmatter
+
+Every news article must declare the following fields at the top of its `index.md`:
+
+| Field | Purpose |
+|---|---|
+| `slug` | The URL path under `/news/`. Must be unique across the site. |
+| `title` | The headline shown on the article page, in listings, and in social cards. |
+| `description` | A 140-160 character meta description used by search engines and social previews (Google snippet, OG card, Twitter card). This is **not** the same as the in-post summary. |
+| `authors` | One or more author handles defined in `/blog/authors.yml`. |
+| `tags` | Topical labels (specific to broad). |
+
+### Writing a good `description`
+
+The `description` answers the question "What is this article about, in one sentence?" A reader scanning Google results decides in under a second whether to click. The description must:
+
+- Stand alone (do not assume the reader has the title in front of them)
+- Stay under ~160 characters or it will be truncated by search engines
+- Avoid duplicating the title verbatim
+- Trigger search intent (use the words people would search for)
+- Be factual; do not embellish
+
+Examples:
+
+| Good | Why |
+|---|---|
+| `description: "Cardano Foundation publishes the December 2025 financial report covering revenue, treasury holdings, grants, and operating costs."` | Tells the reader exactly what the post contains. Includes searchable terms. |
+| `description: "Lace wallet v1.23 ships an updated price feed for Cardano native tokens, alongside Mithril support for node v10.4.1."` | Concrete, names releases, no fluff. |
+
+| Avoid | Why |
+|---|---|
+| `description: "Read more about this exciting news from the Cardano ecosystem!"` | Says nothing. No keywords, no specifics. |
+| `description: "{{title}}"` | Duplicates the title. Search engines penalize this. |
+
 ## Create your first Post
 
 Create a new folder in `/blog` with the name `2024-04-14-hello-world`. Then create an `index.md` in this folder with the following content:
@@ -62,6 +96,7 @@ Create a new folder in `/blog` with the name `2024-04-14-hello-world`. Then crea
 ---
 slug: hello-world
 title: Hello World!
+description: A short greeting and our first post on cardano.org, demonstrating how the news system works for new contributors.
 authors: [builderfest]
 tags: [greetings]
 ---
@@ -79,10 +114,11 @@ As you can see, we have used `builderfest` as the author and the news article us
 
 Copy an image into the 2024-04-14-hello-world folder, then follow the highlighted instructions to add another author and to incorporate the image into the news article: 
 
-```md {4,12} title="blog/2024-04-14-hello-world.md.md"
+```md {4,5,13} title="blog/2024-04-14-hello-world.md.md"
 ---
 slug: hello-world
 title: Hello World!
+description: A short greeting and our first post on cardano.org, demonstrating how the news system works for new contributors.
 authors: [builderfest, taptools]
 tags: [greetings]
 ---
@@ -112,10 +148,11 @@ Cardano.org serves as a hub rather than a primary platform for publishing articl
 
 Additionally, include a `Read more` link directing readers to the full article on its original website. If the article has an image, add the `Read more` link above it:
 
-```md {10} title="blog/2024-04-14-hello-world.md.md"
+```md {11} title="blog/2024-04-14-hello-world.md.md"
 ---
 slug: hello-world
 title: Hello World!
+description: A short greeting and our first post on cardano.org, demonstrating how the news system works for new contributors.
 authors: [builderfest, taptools]
 tags: [greetings]
 ---
@@ -162,6 +199,7 @@ An example entry looks like:
 ---
 slug: 2024-10-25-media-cardano-summit-2024-day1
 title: "Cardano Summit 2024 - Day 1 Highlights"
+description: "Recap of day one at the Cardano Summit 2024 in Dubai: keynotes, panels, the Cardano Market, and community highlights from across the ecosystem."
 authors: [cf]
 tags: [media, summit, events]
 ---


### PR DESCRIPTION
- Add Required Frontmatter section to docs/get-involved/create-a-news-article with field table, good and bad examples, and clarification that description is distinct from the in-post body summary                                                                                            
- Add description to all four frontmatter examples in the doc
- Backfill description on the 12 most recent news posts (Mar 18 to Apr 17 2026), keeping each under 160 characters with concrete keywords for Google snippet and OG/Twitter cards                                                                                                              
- Replaces the previous Docusaurus fallback that used the full post body, which got truncated mid-sentence in search results