### PR TITLE
feat: preload Chivo fonts and fix insights canonical typo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -102,6 +102,52 @@ const config = {
         media: '(prefers-color-scheme: dark)',
       },
     },
+    // Preload the two Chivo variable fonts so the browser fetches them in
+    // parallel with the HTML/CSS instead of waiting for the CSS to declare
+    // them. Paths point to /fonts/* which are served from static/ unhashed,
+    // matching the @font-face URLs declared inline below.
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preload',
+        as: 'font',
+        type: 'font/ttf',
+        href: '/fonts/Chivo-VariableFont_wght.ttf',
+        crossorigin: 'anonymous',
+      },
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preload',
+        as: 'font',
+        type: 'font/ttf',
+        href: '/fonts/Chivo-Italic-VariableFont_wght.ttf',
+        crossorigin: 'anonymous',
+      },
+    },
+    // Inline @font-face so the URLs stay as /fonts/* (webpack does not see
+    // them) and the preload above hits the same cache entry.
+    {
+      tagName: 'style',
+      attributes: {},
+      innerHTML: `
+        @font-face {
+          font-family: 'Chivo';
+          font-style: normal;
+          font-weight: 100 900;
+          font-display: swap;
+          src: url('/fonts/Chivo-VariableFont_wght.ttf') format('truetype-variations');
+        }
+        @font-face {
+          font-family: 'Chivo';
+          font-style: italic;
+          font-weight: 100 900;
+          font-display: swap;
+          src: url('/fonts/Chivo-Italic-VariableFont_wght.ttf') format('truetype-variations');
+        }
+      `,
+    },
   ],
 
   presets: [

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -129,24 +129,9 @@ div[id^="mautic-form-container-"] .mauticform_wrapper {
   padding-bottom: 15px;
 }
 
-/* Chivo Variable Font */
-@font-face {
-  font-family: 'Chivo';
-  font-style: normal;
-  font-weight: 100 900;
-  /* This range covers Thin to Black weights */
-  font-display: swap;
-  src: url('/fonts/Chivo-VariableFont_wght.ttf') format('truetype-variations');
-}
-
-@font-face {
-  font-family: 'Chivo';
-  font-style: italic;
-  font-weight: 100 900;
-  /* This range covers Thin to Black weights */
-  font-display: swap;
-  src: url('/fonts/Chivo-Italic-VariableFont_wght.ttf') format('truetype-variations');
-}
+/* Chivo Variable Font @font-face declarations live inline in docusaurus.config.js
+   headTags so the URLs stay stable (no webpack hash) and can be matched by the
+   <link rel="preload"> entries in the document head. */
 
 /* Cardano Brand */
 body {

--- a/src/pages/insights/supply/index.js
+++ b/src/pages/insights/supply/index.js
@@ -412,7 +412,7 @@ function PageContent() {
   const pageTitle = `Cardano ada Supply Distribution – Epoch ${displayedEpoch} (${epochDate})`;
   const pageDescription = `Explore the Cardano ADA supply distribution for epoch ${displayedEpoch}. Understand how ADA is allocated across circulating supply, reserves, staking rewards, and the treasury. `
   const pageKeywords = `Cardano, ADA, supply distribution, staking rewards, Cardano treasury, Ouroboros protocol, Cardano blockchain, ADA rewards, Cardano supply insights`
-  const canonicalUrl = `https://www.cardano.org.com/insights/supply${displayedEpoch ? `?epoch=${displayedEpoch}` : ''}`;
+  const canonicalUrl = `https://cardano.org/insights/supply/${displayedEpoch ? `?epoch=${displayedEpoch}` : ''}`;
 
   const navStickyClass = 'epochNavSticky'; // CSS is in custom.css
 


### PR DESCRIPTION
- Add <link rel="preload"> for both Chivo TTFs in headTags so the browser fetches them in parallel with HTML/CSS instead of waiting for the stylesheet
- Move @font-face declarations from src/css/custom.css to inline <style> in headTags so the URLs stay as /fonts/* and match the preload (otherwise webpack hashes them and the preload misses)
- Fix typo in insights/supply canonical URL