### PR TITLE
Feat/stablecoins followup

### DIFF
--- a/src/components/Stablecoins/useStablecoinLiveData.js
+++ b/src/components/Stablecoins/useStablecoinLiveData.js
@@ -109,13 +109,17 @@ export default function useStablecoinLiveData() {
 
     async function loadFee() {
       try {
-        // Match the methodology used on /insights/transactions#avg-fee:
-        // weighted average over recent epochs, fees / tx_count. This reflects
-        // what users actually pay on-chain, not the protocol-min fee floor.
+        // Weighted average over the last 10 epochs (~50 days), fees / tx_count.
+        // Reflects current network conditions, smoothed across multiple epochs.
+        // Koios `/epoch_info` returns every epoch since launch, so we sort
+        // descending by epoch_no and keep the most recent slice.
         const epochsRes = await withSingleRetry(() => koios.get("/epoch_info"));
         if (cancelled) return;
 
-        const rows = Array.isArray(epochsRes?.data) ? epochsRes.data : [];
+        const rows = (Array.isArray(epochsRes?.data) ? epochsRes.data : [])
+          .slice()
+          .sort((a, b) => Number(b.epoch_no) - Number(a.epoch_no))
+          .slice(0, 10);
         let totalFees = 0;
         let totalTx = 0;
         for (const row of rows) {

--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -1601,22 +1601,6 @@ export const Showcases = [
     x: "AscentRivals",
   },
   {
-    title: "USDM Stablecoin",
-    description:
-      "Fully backed USD stablecoin on Cardano with off-chain reserves and monthly attestations. Designed for payments, treasury, and DeFi applications.",
-    tagline: "Fully backed USD stablecoin on Cardano",
-    icon: "/img/app-icons/usdm.jpeg",
-    statsLabel: "$usdm",
-    statsNote: "mint/burn only",
-    website: "https://moneta.global/",
-    source: null,
-    category: "other",
-    properties: [],
-    maintainerPick: false,
-    beginnerFriendly: false,
-    x: "USDMOfficial",
-  },
-  {
     title: "Asteria",
     description:
       "Fully on-chain strategy game built for developers. Pilot a spaceship across a 2D grid where every entity is a Cardano eUTXO and Plutus contract.",

--- a/src/pages/apps/index.js
+++ b/src/pages/apps/index.js
@@ -453,6 +453,13 @@ function GuidedPathsBanner() {
       }),
     },
     {
+      to: "/stablecoins",
+      label: translate({
+        id: "apps.guidedPaths.stablecoins",
+        message: "Use stablecoins",
+      }),
+    },
+    {
       to: "/governance#paths",
       label: translate({
         id: "apps.guidedPaths.governance",

--- a/src/pages/stablecoins.js
+++ b/src/pages/stablecoins.js
@@ -1,7 +1,7 @@
 import React from "react";
 import clsx from "clsx";
 import Layout from "@theme/Layout";
-import { translate } from "@docusaurus/Translate";
+import Translate, { translate } from "@docusaurus/Translate";
 
 import SiteHero from "@site/src/components/Layout/SiteHero";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
@@ -291,6 +291,36 @@ export default function Stablecoins() {
             </div>
           </BoundaryBox>
         </BackgroundWrapper>
+
+        <BoundaryBox>
+          <div className={pageStyles.dataAttribution}>
+            <p>
+              <Translate
+                id="stablecoins.attribution.market"
+                values={{
+                  coingecko: (
+                    <a
+                      href="https://www.coingecko.com"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      CoinGecko
+                    </a>
+                  ),
+                }}
+              >
+                {"Market data powered by {coingecko}."}
+              </Translate>
+            </p>
+            <p className={pageStyles.dataAttributionFresh}>
+              {translate({
+                id: "stablecoins.attribution.freshness",
+                message:
+                  "Values update automatically and may lag exchange tickers by a few minutes.",
+              })}
+            </p>
+          </div>
+        </BoundaryBox>
       </main>
     </Layout>
   );

--- a/src/pages/stablecoins.js
+++ b/src/pages/stablecoins.js
@@ -119,7 +119,7 @@ export default function Stablecoins() {
                   {translate({
                     id: "stablecoins.bridges.intro",
                     message:
-                      "The future is interoperable, and so are stablecoins. From PayPal to Moneta, several services allow you to access Cardano's advantages.",
+                      "The future is interoperable, and so are stablecoins. From PayPal to MakerDAO, several bridges allow you to access Cardano's advantages.",
                   })}
                 </p>
               </div>

--- a/src/pages/stablecoins.module.css
+++ b/src/pages/stablecoins.module.css
@@ -160,3 +160,29 @@
 .whyCardano {
   padding: 1rem 0px;
 }
+
+.dataAttribution {
+  margin: 3rem auto 1.5rem auto;
+  text-align: center;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.dataAttribution a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--ifm-color-emphasis-400);
+  text-underline-offset: 2px;
+}
+
+.dataAttribution a:hover {
+  color: var(--ifm-color-emphasis-800);
+  text-decoration-color: currentColor;
+}
+
+.dataAttributionFresh {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-500);
+}


### PR DESCRIPTION
- Limit the "Average Fee" stat to the last 10 epochs (~50 days) instead of aggregating every epoch since mainnet launch 
   "recent epochs"                                                                                           
- Add CoinGecko attribution at the bottom of /stablecoins as long as we are using the free tier
- Drop the standalone USDM entry from /apps now that /stablecoins is the canonical home for stablecoin info
- Add a "Use stablecoins" to  "Guided Paths" 
