### PR TITLE
Rebuild /hardforks timeline as custom component

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "process": "^0.11.10",
     "raw-loader": "^4.0.2",
     "react": "^18.3.1",
-    "react-chrono": "^2.6.1",
     "react-collapsible": "^2.10.0",
     "react-dom": "^18.3.1",
     "react-icons": "^5.0.1",

--- a/src/components/HardForkTimeline/index.js
+++ b/src/components/HardForkTimeline/index.js
@@ -1,0 +1,151 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import clsx from "clsx";
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+import styles from "./styles.module.css";
+
+const useIsomorphicLayoutEffect = ExecutionEnvironment.canUseDOM
+  ? React.useLayoutEffect
+  : useEffect;
+
+export default function HardForkTimeline({ items }) {
+  const rowRefs = useRef([]);
+  const timelineRef = useRef(null);
+  const [eraSegments, setEraSegments] = useState([]);
+
+  const eraGroups = useMemo(() => {
+    const groups = [];
+    items.forEach((item, idx) => {
+      const last = groups[groups.length - 1];
+      if (!last || last.era !== item.era) {
+        groups.push({ era: item.era, start: idx, end: idx });
+      } else {
+        last.end = idx;
+      }
+    });
+    return groups;
+  }, [items]);
+
+  useIsomorphicLayoutEffect(() => {
+    function measure() {
+      const container = timelineRef.current;
+      if (!container) return;
+      const containerTop = container.getBoundingClientRect().top;
+      const DOT_MARGIN = 14;
+
+      const dotCenters = rowRefs.current.map((row) => {
+        if (!row) return null;
+        const dot = row.querySelector(`.${styles.dot}`);
+        if (!dot) return null;
+        const r = dot.getBoundingClientRect();
+        return r.top + r.height / 2 - containerTop;
+      });
+
+      const lastDot = dotCenters[dotCenters.length - 1];
+      if (lastDot != null) {
+        container.style.setProperty("--hf-line-end", `${lastDot}px`);
+      }
+
+      // Each era's region runs from the dot of its starting HF (g.end, oldest in the
+      // group) UP TO the dot of the next-newer era's starting HF. We render the era
+      // label in EVERY gap between consecutive dots inside that region, so it stays
+      // obvious which era the timeline is in after each hard fork.
+      const next = eraGroups.flatMap((g, gIdx) => {
+        const bottomDot = dotCenters[g.end];
+        if (bottomDot == null) return [];
+        const prevGroup = eraGroups[gIdx - 1];
+        const topBoundary = prevGroup ? dotCenters[prevGroup.end] : 0;
+        if (topBoundary == null) return [];
+
+        const insideDots = [];
+        for (let i = g.start; i <= g.end; i++) {
+          if (dotCenters[i] != null) insideDots.push(dotCenters[i]);
+        }
+        insideDots.sort((a, b) => a - b);
+
+        const gaps = [];
+        if (insideDots.length === 0) {
+          gaps.push([topBoundary + DOT_MARGIN, bottomDot - DOT_MARGIN]);
+        } else {
+          gaps.push([topBoundary + DOT_MARGIN, insideDots[0] - DOT_MARGIN]);
+          for (let i = 0; i < insideDots.length - 1; i++) {
+            gaps.push([insideDots[i] + DOT_MARGIN, insideDots[i + 1] - DOT_MARGIN]);
+          }
+        }
+
+        return gaps
+          .filter(([a, b]) => b - a > 20)
+          .map(([top, bottom]) => ({ era: g.era, top, height: bottom - top }));
+      });
+      setEraSegments(next);
+    }
+    measure();
+    const observer = new ResizeObserver(measure);
+    if (timelineRef.current) observer.observe(timelineRef.current);
+    window.addEventListener("resize", measure);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [eraGroups]);
+
+  return (
+    <ol className={styles.timeline} ref={timelineRef}>
+      {eraSegments.map((seg) => (
+        <span
+          key={`era-${seg.era}-${seg.top}`}
+          className={styles.eraStripe}
+          style={{ top: `${seg.top}px`, height: `${seg.height}px` }}
+          aria-hidden="true"
+        >
+          <span className={styles.eraLabel}>{seg.era.replace(/\s+Era$/i, "")}</span>
+        </span>
+      ))}
+      {items.map((item, index) => {
+        const side = index % 2 === 0 ? "right" : "left";
+        return (
+          <li
+            key={`${item.date}-${item.name}`}
+            ref={(el) => (rowRefs.current[index] = el)}
+            className={clsx(styles.row, styles[side], item.active && styles.activeRow)}
+          >
+            <div className={styles.axis} aria-hidden="true">
+              <span className={clsx(styles.dot, item.active && styles.dotActive)} />
+              <span className={styles.connector} />
+            </div>
+            <article className={clsx(styles.card, item.active && styles.cardActive)}>
+              <header className={styles.cardHeader}>
+                <div className={styles.cardHeaderText}>
+                  <span className={styles.date}>{item.date}</span>
+                  <h3 className={styles.name}>{item.name}</h3>
+                </div>
+                {item.epoch && (
+                  <span className={styles.epochPill}>
+                    <span className={styles.epochLabel}>{item.epochLabel}</span>
+                    <span className={styles.epochValue}>{item.epoch}</span>
+                  </span>
+                )}
+              </header>
+              {item.description && (
+                <p className={styles.description}>{item.description}</p>
+              )}
+              {item.meta?.length > 0 && (
+                <>
+                  <hr className={styles.divider} />
+                  <dl className={styles.meta}>
+                    {item.meta.map(({ label, value }) => (
+                      <div className={styles.metaRow} key={label}>
+                        <dt className={styles.metaLabel}>{label}</dt>
+                        <dd className={styles.metaValue}>{value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </>
+              )}
+              <span className={styles.srEra}>{item.era}</span>
+            </article>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/components/HardForkTimeline/styles.module.css
+++ b/src/components/HardForkTimeline/styles.module.css
@@ -1,0 +1,363 @@
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  position: relative;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  height: var(--hf-line-end, 100%);
+  left: 50%;
+  width: 2px;
+  background-color: var(--ifm-color-primary);
+  transform: translateX(-50%);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr 60px 1fr;
+  align-items: center;
+  position: relative;
+}
+
+.axis {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  z-index: 3;
+}
+
+.connector {
+  position: absolute;
+  top: 50%;
+  height: 2px;
+  width: 24px;
+  background-color: var(--ifm-color-primary);
+  transform: translateY(-50%);
+}
+
+.row.right .connector {
+  left: 50%;
+}
+
+.row.left .connector {
+  right: 50%;
+}
+
+.dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 4px #ffffff;
+  position: relative;
+  z-index: 1;
+}
+
+.dotActive {
+  width: 16px;
+  height: 16px;
+  box-shadow: 0 0 0 4px #ffffff, 0 0 0 6px var(--ifm-color-primary);
+}
+
+.row.left .card {
+  grid-column: 1;
+  grid-row: 1;
+  justify-self: end;
+}
+
+.row.right .card {
+  grid-column: 3;
+  grid-row: 1;
+  justify-self: start;
+}
+
+.eraStripe {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.eraLabel {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  background-color: #ffffff;
+  padding: 0.9rem 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ifm-color-primary);
+  border-radius: 4px;
+}
+
+.srEra {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.card {
+  max-width: 420px;
+  width: 100%;
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgba(0, 51, 173, 0.08);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: relative;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  background-color: #ffffff;
+  transform: translateY(-50%) rotate(45deg);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.row.right .card::before {
+  left: -8px;
+  border-left: 1px solid #e2e8f0;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.row.left .card::before {
+  right: -8px;
+  border-top: 1px solid #e2e8f0;
+  border-right: 1px solid #e2e8f0;
+}
+
+.cardActive::before {
+  border-color: var(--ifm-color-primary);
+}
+
+.cardActive {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 8px 24px rgba(0, 51, 173, 0.16);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.cardHeaderText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.epochPill {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  flex-shrink: 0;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background-color: rgba(0, 51, 173, 0.08);
+  color: var(--ifm-color-primary);
+  font-size: 0.8rem;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.epochLabel {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.7rem;
+}
+
+.epochValue {
+  font-weight: 700;
+}
+
+[data-theme="dark"] .epochPill {
+  background-color: rgba(102, 132, 206, 0.18);
+}
+
+.date {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+}
+
+.name {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0;
+  color: #1a1a1a;
+}
+
+.description {
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: #475569;
+  margin: 0;
+}
+
+.divider {
+  border: 0;
+  border-top: 1px solid #e2e8f0;
+  margin: 0.25rem 0;
+}
+
+.meta {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.metaLabel {
+  margin: 0;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.metaLabel::after {
+  content: ":";
+}
+
+.metaValue {
+  margin: 0;
+  color: #475569;
+  word-break: break-all;
+}
+
+[data-theme="dark"] .card {
+  background-color: var(--ifm-background-surface-color);
+  border-color: var(--ifm-color-emphasis-300);
+}
+
+[data-theme="dark"] .cardActive {
+  border-color: var(--ifm-color-primary);
+}
+
+[data-theme="dark"] .name {
+  color: var(--ifm-font-color-base);
+}
+
+[data-theme="dark"] .description,
+[data-theme="dark"] .metaValue {
+  color: var(--ifm-color-emphasis-700);
+}
+
+[data-theme="dark"] .metaLabel {
+  color: var(--ifm-font-color-base);
+}
+
+[data-theme="dark"] .divider {
+  border-top-color: var(--ifm-color-emphasis-300);
+}
+
+[data-theme="dark"] .dot,
+[data-theme="dark"] .dotActive {
+  box-shadow: 0 0 0 4px var(--ifm-background-color);
+}
+
+[data-theme="dark"] .dotActive {
+  box-shadow: 0 0 0 4px var(--ifm-background-color), 0 0 0 6px var(--ifm-color-primary);
+}
+
+[data-theme="dark"] .eraLabel {
+  background-color: var(--ifm-background-color);
+}
+
+@media (max-width: 768px) {
+  .timeline {
+    gap: 1.5rem;
+  }
+
+  .timeline::before {
+    left: 16px;
+  }
+
+  .row,
+  .row.left,
+  .row.right {
+    grid-template-columns: 32px 1fr;
+    align-items: center;
+  }
+
+  .axis {
+    grid-column: 1;
+    width: 32px;
+  }
+
+  .row.left .card,
+  .row.right .card,
+  .card {
+    grid-column: 2;
+    justify-self: stretch;
+    max-width: none;
+  }
+
+  .row.left .connector,
+  .row.right .connector {
+    left: 50%;
+    right: auto;
+    width: 16px;
+  }
+
+  .row.left .card::before,
+  .row.right .card::before {
+    left: -7px;
+    right: auto;
+  }
+
+  .row.left .card::after,
+  .row.right .card::after {
+    left: -5px;
+    right: auto;
+  }
+
+  .eraStripe {
+    left: 16px;
+  }
+
+  .eraLabel {
+    padding: 0.6rem 0.2rem;
+    font-size: 0.7rem;
+  }
+}

--- a/src/pages/hardforks.js
+++ b/src/pages/hardforks.js
@@ -1,7 +1,5 @@
 import React from "react";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
-import Link from "@docusaurus/Link";
 import SiteHero from "@site/src/components/Layout/SiteHero";
 import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
 import Divider from "@site/src/components/Layout/Divider";
@@ -9,133 +7,210 @@ import TitleWithText from "@site/src/components/Layout/TitleWithText";
 import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
-import { Chrono } from "react-chrono";
-import BrowserOnly from '@docusaurus/BrowserOnly';
-import { translate } from '@docusaurus/Translate';
-import styles from "./hardforks.module.css";
+import HardForkTimeline from "@site/src/components/HardForkTimeline";
+import { translate } from "@docusaurus/Translate";
 
-// Hard Fork List
+const labelEpoch = () =>
+  translate({ id: "hardforks.timeline.label.epoch", message: "Epoch" });
+const labelProtocolVersion = () =>
+  translate({ id: "hardforks.timeline.label.protocolVersion", message: "Protocol Version" });
+const labelTransactionId = () =>
+  translate({ id: "hardforks.timeline.label.transactionId", message: "Transaction ID" });
+const labelTransactionIds = () =>
+  translate({ id: "hardforks.timeline.label.transactionIds", message: "Transaction IDs" });
+
 function getTimelineItems() {
   return [
     {
-      title: "Byron Era",
-      cardTitle: "September 29, 2017",
-      cardSubtitle: "Name: Byron",
-      cardDetailedText: [
-        translate({ id: 'hardforks.timeline.byron.description', message: 'The launch of the Cardano mainnet and introduction of the ada cryptocurrency.' }),
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " 0",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 1.0",
-        translate({ id: 'hardforks.timeline.label.transactionId', message: 'Transaction ID' }) + ": N/A (Genesis block)",
+      era: "Conway Era",
+      date: "June, 2026 (tentative)",
+      name: "van Rossem",
+      description: translate({
+        id: "hardforks.timeline.vanrossem.description",
+        message:
+          "Inter-era upgrade delivering cleaner ledger rules, VRF key uniqueness, Plutus smart contract performance improvements and new cryptographic built-ins",
+      }),
+      epochLabel: labelEpoch(),
+      epoch: "tbd",
+      meta: [
+        { label: labelProtocolVersion(), value: "11.0" },
+        { label: labelTransactionIds(), value: "tbd" },
       ],
     },
     {
-      title: "Shelley Era",
-      cardTitle: "July 29, 2020",
-      cardSubtitle: "Name: Shelley",
-      cardDetailedText: [
-        translate({ id: 'hardforks.timeline.shelley.description', message: 'Introduced staking and decentralization features, transitioning from a federated to a decentralized system.' }),
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " 208",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 2.0",
-        translate({ id: 'hardforks.timeline.label.transactionId', message: 'Transaction ID' }) + ": N/A (Transitioned through several updates)",
+      era: "Conway Era",
+      date: "January 29, 2025",
+      name: "Plomin",
+      description: translate({
+        id: "hardforks.timeline.plomin.description",
+        message:
+          "Introducing the second batch of decentralized governance features of CIP-1694. Enabling the full set of governance actions and the DRep role.",
+      }),
+      epochLabel: labelEpoch(),
+      epoch: "537",
+      meta: [
+        { label: labelProtocolVersion(), value: "10.0" },
+        {
+          label: labelTransactionIds(),
+          value: "0b19476e40bbbb5e1e8ce153523762e2b6859e7ecacbaf06eaa0ee6a447e79b9",
+        },
+      ],
+      active: true,
+    },
+    {
+      era: "Conway Era",
+      date: "September 1, 2024",
+      name: "Chang",
+      description: translate({
+        id: "hardforks.timeline.chang1.description",
+        message:
+          "Introducing the first batch of decentralized governance features of CIP-1694. Enabling only parameter changes and hard fork initiations.",
+      }),
+      epochLabel: labelEpoch(),
+      epoch: "507",
+      meta: [
+        { label: labelProtocolVersion(), value: "9.0" },
+        {
+          label: labelTransactionIds(),
+          value:
+            "9ba6a580bceb8f94e65a683e8291c89382835f46e3cf928eb521f5581ade4820, 4e377ceb5c5721257a3d7960f3053468bbea45ed8ac22cd559c69e757da5e0ae",
+        },
       ],
     },
     {
-      title: "Allegra Era",
-      cardTitle: "December 16, 2020",
-      cardSubtitle: "Name: Allegra",
-      cardDetailedText: [
-        translate({ id: 'hardforks.timeline.allegra.description', message: 'Added token locking capabilities, which was a prerequisite for the smart contract functionality.' }),
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " 236",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 3.0",
-        translate({ id: 'hardforks.timeline.label.transactionId', message: 'Transaction ID' }) + ": 1fbd16c1d1b1933f2f97a313db8c749bdcf65a39d996515b0f5e5535baad68e8",
+      era: "Babbage Era",
+      date: "February 14, 2023",
+      name: "Valentine",
+      description: translate({
+        id: "hardforks.timeline.valentine.description",
+        message:
+          "Introduced further improvements to Plutus smart contract functionality and overall network performance.",
+      }),
+      epochLabel: labelEpoch(),
+      epoch: "394",
+      meta: [
+        { label: labelProtocolVersion(), value: "8.0" },
+        {
+          label: labelTransactionIds(),
+          value:
+            "a83f479c5635e1e563a19f6e72a1be59fb082bbf31de90cc176850ee799b08ac, 62c3c13187423c47f629e6187f36fbd61a9ba1d05d101588340cfbfdf47b22d2",
+        },
       ],
     },
     {
-      title: "Mary Era",
-      cardTitle: "March 1, 2021",
-      cardSubtitle: "Name: Mary",
-      cardDetailedText: [
-        translate({ id: 'hardforks.timeline.mary.description', message: 'Brought native token functionality to Cardano, allowing users to create and transact with custom tokens.' }),
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " 251",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 4.0",
-        translate({ id: 'hardforks.timeline.label.transactionId', message: 'Transaction ID' }) + ": b7f5658a5aabced7f8599cf7bf7cb9d6f730b865a5a0430f2dc7488caf25752e",
+      era: "Babbage Era",
+      date: "September 22, 2022",
+      name: "Vasil",
+      description: translate({
+        id: "hardforks.timeline.vasil.description",
+        message:
+          "Improved the scalability and performance of the network, named after Vasil Dabov, a Cardano community member.",
+      }),
+      epochLabel: labelEpoch(),
+      epoch: "365",
+      meta: [
+        { label: labelProtocolVersion(), value: "7.0" },
+        {
+          label: labelTransactionIds(),
+          value:
+            "3abda97c78c71e8a21473529aca94d78d364dfa1a866ef8245885e18085b4e4c, 8230f33cd7ad3f8601e94ea2b18abdc591187e190ea8ebecc25e20fc66200f13",
+        },
       ],
     },
     {
-      title: "Alonzo Era",
-      cardTitle: "September 12, 2021",
-      cardSubtitle: "Name: Alonzo",
-      cardDetailedText: [
-        translate({ id: 'hardforks.timeline.alonzo.description', message: 'Introduced smart contract capabilities using Plutus, enabling the deployment of decentralized applications (dApps).' }),
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " 290",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 5.0",
-        translate({ id: 'hardforks.timeline.label.transactionId', message: 'Transaction ID' }) + ": N/A (Specific transaction ID not provided)",
+      era: "Alonzo Era",
+      date: "October 22, 2021",
+      name: "(Lobster)",
+      epochLabel: labelEpoch(),
+      epoch: "298",
+      meta: [
+        { label: labelProtocolVersion(), value: "6.0" },
+        { label: labelTransactionId(), value: "N/A (Specific transaction ID not provided)" },
       ],
     },
     {
-      title: "Alonzo Era",
-      cardTitle: "October 22, 2021",
-      cardSubtitle: "Name: (Lobster)", //TODO: confirm name
-      cardDetailedText: [
-        // "-", // FIXME: what changed?
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " 298",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 6.0",
-        translate({ id: 'hardforks.timeline.label.transactionId', message: 'Transaction ID' }) + ": N/A (Specific transaction ID not provided)",
+      era: "Alonzo Era",
+      date: "September 12, 2021",
+      name: "Alonzo",
+      description: translate({
+        id: "hardforks.timeline.alonzo.description",
+        message:
+          "Introduced smart contract capabilities using Plutus, enabling the deployment of decentralized applications (dApps).",
+      }),
+      epochLabel: labelEpoch(),
+      epoch: "290",
+      meta: [
+        { label: labelProtocolVersion(), value: "5.0" },
+        { label: labelTransactionId(), value: "N/A (Specific transaction ID not provided)" },
       ],
     },
     {
-      title: "Babbage Era",
-      cardTitle: "September 22, 2022",
-      cardSubtitle: "Name: Vasil",
-      cardDetailedText: [
-        translate({ id: 'hardforks.timeline.vasil.description', message: 'Improved the scalability and performance of the network, named after Vasil Dabov, a Cardano community member.' }),
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " 365",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 7.0",
-        translate({ id: 'hardforks.timeline.label.transactionIds', message: 'Transaction IDs' }) + ": 3abda97c78c71e8a21473529aca94d78d364dfa1a866ef8245885e18085b4e4c, 8230f33cd7ad3f8601e94ea2b18abdc591187e190ea8ebecc25e20fc66200f13",
+      era: "Mary Era",
+      date: "March 1, 2021",
+      name: "Mary",
+      description: translate({
+        id: "hardforks.timeline.mary.description",
+        message:
+          "Brought native token functionality to Cardano, allowing users to create and transact with custom tokens.",
+      }),
+      epochLabel: labelEpoch(),
+      epoch: "251",
+      meta: [
+        { label: labelProtocolVersion(), value: "4.0" },
+        {
+          label: labelTransactionId(),
+          value: "b7f5658a5aabced7f8599cf7bf7cb9d6f730b865a5a0430f2dc7488caf25752e",
+        },
       ],
     },
     {
-      title: "Babbage Era",
-      cardTitle: "February 14, 2023",
-      cardSubtitle: "Name: Valentine",
-      cardDetailedText: [
-        translate({ id: 'hardforks.timeline.valentine.description', message: 'Introduced further improvements to Plutus smart contract functionality and overall network performance.' }),
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " 394",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 8.0",
-        translate({ id: 'hardforks.timeline.label.transactionIds', message: 'Transaction IDs' }) + ": a83f479c5635e1e563a19f6e72a1be59fb082bbf31de90cc176850ee799b08ac, 62c3c13187423c47f629e6187f36fbd61a9ba1d05d101588340cfbfdf47b22d2",
+      era: "Allegra Era",
+      date: "December 16, 2020",
+      name: "Allegra",
+      description: translate({
+        id: "hardforks.timeline.allegra.description",
+        message:
+          "Added token locking capabilities, which was a prerequisite for the smart contract functionality.",
+      }),
+      epochLabel: labelEpoch(),
+      epoch: "236",
+      meta: [
+        { label: labelProtocolVersion(), value: "3.0" },
+        {
+          label: labelTransactionId(),
+          value: "1fbd16c1d1b1933f2f97a313db8c749bdcf65a39d996515b0f5e5535baad68e8",
+        },
       ],
     },
     {
-      title: "Conway Era",
-      cardTitle: "September 1, 2024",
-      cardSubtitle: "Name: Chang 1",
-      cardDetailedText: [
-        translate({ id: 'hardforks.timeline.chang1.description', message: 'Introducing the first batch of decentralized governance features of CIP-1694. Enabling only parameter changes and hard fork initiations.' }),
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " 507",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 9.0",
-        translate({ id: 'hardforks.timeline.label.transactionIds', message: 'Transaction IDs' }) + ": 9ba6a580bceb8f94e65a683e8291c89382835f46e3cf928eb521f5581ade4820, 4e377ceb5c5721257a3d7960f3053468bbea45ed8ac22cd559c69e757da5e0ae",
+      era: "Shelley Era",
+      date: "July 29, 2020",
+      name: "Shelley",
+      description: translate({
+        id: "hardforks.timeline.shelley.description",
+        message:
+          "Introduced staking and decentralization features, transitioning from a federated to a decentralized system.",
+      }),
+      epochLabel: labelEpoch(),
+      epoch: "208",
+      meta: [
+        { label: labelProtocolVersion(), value: "2.0" },
+        { label: labelTransactionId(), value: "N/A (Transitioned through several updates)" },
       ],
     },
     {
-      title: "Conway Era",
-      cardTitle: "January 29, 2025",
-      cardSubtitle: "Name: Plomin",
-      cardDetailedText: [
-        translate({ id: 'hardforks.timeline.plomin.description', message: 'Introducing the second batch of decentralized governance features of CIP-1694. Enabling the full set of governance actions and the DRep role.' }),
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " 537",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 10.0",
-        translate({ id: 'hardforks.timeline.label.transactionIds', message: 'Transaction IDs' }) + ": 0b19476e40bbbb5e1e8ce153523762e2b6859e7ecacbaf06eae0ee6a447e79b9",
-      ],
-    },
-    {
-      title: "Conway Era",
-      cardTitle: "June, 2026 (tentative)",
-      cardSubtitle: "Name: van Rossem",
-      cardDetailedText: [
-        translate({ id: 'hardforks.timeline.vanrossem.description', message: 'Inter-era upgrade delivering cleaner ledger rules, VRF key uniqueness, Plutus smart contract performance improvements and new cryptographic built-ins' }),
-        translate({ id: 'hardforks.timeline.label.epoch', message: 'Epoch' }) + " tbd",
-        translate({ id: 'hardforks.timeline.label.protocolVersion', message: 'Protocol Version' }) + ": 11.0",
-        translate({ id: 'hardforks.timeline.label.transactionIds', message: 'Transaction IDs' }) + ": tbd",
+      era: "Byron Era",
+      date: "September 29, 2017",
+      name: "Byron",
+      description: translate({
+        id: "hardforks.timeline.byron.description",
+        message: "The launch of the Cardano mainnet and introduction of the ada cryptocurrency.",
+      }),
+      epochLabel: labelEpoch(),
+      epoch: "0",
+      meta: [
+        { label: labelProtocolVersion(), value: "1.0" },
+        { label: labelTransactionId(), value: "N/A (Genesis block)" },
       ],
     },
   ];
@@ -144,8 +219,11 @@ function getTimelineItems() {
 function HomepageHeader() {
   return (
     <SiteHero
-      title={translate({ id: 'hardforks.hero.title', message: 'Hard forks' })}
-      description={translate({ id: 'hardforks.hero.description', message: 'What hard forks were implemented, and what functionalities did they introduce?' })}
+      title={translate({ id: "hardforks.hero.title", message: "Hard forks" })}
+      description={translate({
+        id: "hardforks.hero.description",
+        message: "What hard forks were implemented, and what functionalities did they introduce?",
+      })}
       bannerType="starburst"
     />
   );
@@ -154,51 +232,51 @@ function HomepageHeader() {
 export default function Home() {
   return (
     <Layout
-      title={translate({ id: 'hardforks.layout.title', message: 'Cardano Hard Forks, Network Upgrade History' })}
-      description={translate({ id: 'hardforks.layout.description', message: 'A complete timeline of Cardano hard forks from Byron to Chang. Explore each network upgrade, what changed, and how the protocol has evolved.' })}
+      title={translate({
+        id: "hardforks.layout.title",
+        message: "Cardano Hard Forks, Network Upgrade History",
+      })}
+      description={translate({
+        id: "hardforks.layout.description",
+        message:
+          "A complete timeline of Cardano hard forks from Byron to Chang. Explore each network upgrade, what changed, and how the protocol has evolved.",
+      })}
     >
       <OpenGraphInfo pageName="hard-forks" />
       <HomepageHeader />
       <BackgroundWrapper backgroundType={"zoom"}>
         <BoundaryBox>
           <TitleWithText
-            title={translate({ id: 'hardforks.content.title', message: 'Cardano Hard Forks' })}
-            description={translate({ id: 'hardforks.content.description', message: 'Hard forks in Cardano do not signify division and differences within the ecosystem. On the contrary, they define a specific and collectively agreed-upon exact time (slot) when all nodes switch from the current era to a new one, applying new functions, validation rules, or parameter values. All stake pool operators need to install the upgrade, and they also have a say and must agree to it. A Cardano hard fork is, therefore, not a separation but a precise collective evolution.' })}
+            title={translate({ id: "hardforks.content.title", message: "Cardano Hard Forks" })}
+            description={translate({
+              id: "hardforks.content.description",
+              message:
+                "Hard forks in Cardano do not signify division and differences within the ecosystem. On the contrary, they define a specific and collectively agreed-upon exact time (slot) when all nodes switch from the current era to a new one, applying new functions, validation rules, or parameter values. All stake pool operators need to install the upgrade, and they also have a say and must agree to it. A Cardano hard fork is, therefore, not a separation but a precise collective evolution.",
+            })}
             headingDot={true}
           />
-          <Divider text={translate({ id: 'hardforks.divider.timeline', message: 'Timeline' })} id="timeline" />
-
-          <BrowserOnly fallback={<div>{translate({ id: 'hardforks.loading', message: 'Loading...' })}</div>}>
-            {() => (
-              <div className={styles.timelineWrapper}>
-                <Chrono
-                  items={getTimelineItems().slice().reverse()}
-                  mode="VERTICAL_ALTERNATING"
-                  cardHeight={280}
-                  activeItemIndex={1}
-                  useReadMore={false}
-                  disableToolbar={true}
-                  disableClickOnCircle={true}
-                  disableTimelinePoint={false}
-                  theme={{
-                    primary: "#093DB0",
-                    secondary: "#007FFF",
-                    cardBgColor: "white",
-                    titleColor: "#093DB0",
-                    titleColorActive: "#FF7676",
-                  }}
-                />
-              </div>
-            )}
-          </BrowserOnly>
+          <Divider
+            text={translate({ id: "hardforks.divider.timeline", message: "Timeline" })}
+            id="timeline"
+          />
+          <HardForkTimeline items={getTimelineItems()} />
         </BoundaryBox>
       </BackgroundWrapper>
 
       <BackgroundWrapper backgroundType={"solidGrey"}>
         <BoundaryBox>
-          <Divider text={translate({ id: 'hardforks.divider.transactionIds', message: 'hard fork transaction ids' })} />
+          <Divider
+            text={translate({
+              id: "hardforks.divider.transactionIds",
+              message: "hard fork transaction ids",
+            })}
+          />
           <TitleWithText
-            description={translate({ id: 'hardforks.transactionIds.description', message: 'Note that some hard forks, particularly Byron and Shelley, transitioned through a series of updates and may not have a single specific transaction id associated with them. For the others, the provided transaction ids correspond to significant parameter updates leading to the hard forks.' })}
+            description={translate({
+              id: "hardforks.transactionIds.description",
+              message:
+                "Note that some hard forks, particularly Byron and Shelley, transitioned through a series of updates and may not have a single specific transaction id associated with them. For the others, the provided transaction ids correspond to significant parameter updates leading to the hard forks.",
+            })}
           />
           <SpacerBox size="medium" />
         </BoundaryBox>

--- a/src/pages/hardforks.js
+++ b/src/pages/hardforks.js
@@ -176,7 +176,6 @@ export default function Home() {
                 activeItemIndex={9}
                 disableToolbar={true}
                 disableClickOnCircle={true}
-                disableInteraction={true}
                 disableTimelinePoint={false}
                 theme={{
                   primary: "#093DB0",

--- a/src/pages/hardforks.js
+++ b/src/pages/hardforks.js
@@ -12,6 +12,7 @@ import SpacerBox from "@site/src/components/Layout/SpacerBox";
 import { Chrono } from "react-chrono";
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import { translate } from '@docusaurus/Translate';
+import styles from "./hardforks.module.css";
 
 // Hard Fork List
 function getTimelineItems() {
@@ -169,22 +170,25 @@ export default function Home() {
 
           <BrowserOnly fallback={<div>{translate({ id: 'hardforks.loading', message: 'Loading...' })}</div>}>
             {() => (
-              <Chrono
-                items={getTimelineItems()}
-                mode="VERTICAL_ALTERNATING"
-                cardHeight={280}
-                activeItemIndex={9}
-                disableToolbar={true}
-                disableClickOnCircle={true}
-                disableTimelinePoint={false}
-                theme={{
-                  primary: "#093DB0",
-                  secondary: "#007FFF",
-                  cardBgColor: "white",
-                  titleColor: "#093DB0",
-                  titleColorActive: "#FF7676",
-                }}
-              />
+              <div className={styles.timelineWrapper}>
+                <Chrono
+                  items={getTimelineItems().slice().reverse()}
+                  mode="VERTICAL_ALTERNATING"
+                  cardHeight={280}
+                  activeItemIndex={1}
+                  useReadMore={false}
+                  disableToolbar={true}
+                  disableClickOnCircle={true}
+                  disableTimelinePoint={false}
+                  theme={{
+                    primary: "#093DB0",
+                    secondary: "#007FFF",
+                    cardBgColor: "white",
+                    titleColor: "#093DB0",
+                    titleColorActive: "#FF7676",
+                  }}
+                />
+              </div>
             )}
           </BrowserOnly>
         </BoundaryBox>

--- a/src/pages/hardforks.module.css
+++ b/src/pages/hardforks.module.css
@@ -1,0 +1,3 @@
+.timelineWrapper :global([class*="TimelineContentDetailsWrapper"])::after {
+  display: none;
+}

--- a/src/pages/hardforks.module.css
+++ b/src/pages/hardforks.module.css
@@ -1,3 +1,0 @@
-.timelineWrapper :global([class*="TimelineContentDetailsWrapper"])::after {
-  display: none;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2186,7 +2186,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
   integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
 
-"@emotion/is-prop-valid@1.4.0", "@emotion/is-prop-valid@^1.3.0":
+"@emotion/is-prop-valid@^1.3.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz#e9ad47adff0b5c94c72db3669ce46de33edf28c0"
   integrity sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==
@@ -2240,7 +2240,7 @@
     "@emotion/use-insertion-effect-with-fallbacks" "^1.2.0"
     "@emotion/utils" "^1.4.2"
 
-"@emotion/unitless@0.10.0", "@emotion/unitless@^0.10.0":
+"@emotion/unitless@^0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
   integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
@@ -3994,11 +3994,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/stylis@4.2.7":
-  version "4.2.7"
-  resolved "https://registry.yarnpkg.com/@types/stylis/-/stylis-4.2.7.tgz#1813190525da9d2a2b6976583bdd4af5301d9fd4"
-  integrity sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==
-
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
@@ -5058,11 +5053,6 @@ camelcase@^7.0.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-7.0.1.tgz#f02e50af9fd7782bc8b88a3558c32fd3a388f048"
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
 
-camelize@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
-  integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
-
 caniuse-api@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
@@ -5216,11 +5206,6 @@ classcat@^5.0.3, classcat@^5.0.4:
   resolved "https://registry.yarnpkg.com/classcat/-/classcat-5.0.5.tgz#8c209f359a93ac302404a10161b501eba9c09c77"
   integrity sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==
 
-classnames@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
-  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
-
 clean-css@^5.2.2, clean-css@^5.3.3, clean-css@~5.3.2:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.3.tgz#b330653cd3bd6b75009cc25c714cae7b93351ccd"
@@ -5326,7 +5311,7 @@ commander@^10.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
-commander@^2.20.0, commander@^2.20.3:
+commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -5576,11 +5561,6 @@ css-blank-pseudo@^7.0.1:
   dependencies:
     postcss-selector-parser "^7.0.0"
 
-css-color-keywords@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
-  integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
-
 css-declaration-sorter@^7.2.0:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz#acd204976d7ca5240b5579bfe6e73d4d088fd568"
@@ -5648,15 +5628,6 @@ css-select@^5.1.0:
     domutils "^3.0.1"
     nth-check "^2.0.1"
 
-css-to-react-native@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
-  integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
-  dependencies:
-    camelize "^1.0.0"
-    css-color-keywords "^1.0.0"
-    postcss-value-parser "^4.0.2"
-
 css-tree@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
@@ -5687,11 +5658,6 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
-
-cssfilter@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
-  integrity sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==
 
 cssnano-preset-advanced@^6.1.2:
   version "6.1.2"
@@ -5762,7 +5728,7 @@ csso@^5.0.5:
   dependencies:
     css-tree "~2.2.0"
 
-csstype@3.2.3, csstype@^3.0.2, csstype@^3.2.2:
+csstype@^3.0.2, csstype@^3.2.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
@@ -5860,11 +5826,6 @@ data-view-byte-offset@^1.0.1:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
-
-dayjs@^1.11.13:
-  version "1.11.20"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.20.tgz#88d919fd639dc991415da5f4cb6f1b6650811938"
-  integrity sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==
 
 debounce@^1.2.1:
   version "1.2.1"
@@ -6930,11 +6891,6 @@ flatted@^3.2.9:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
-
-focus-visible@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.1.tgz#38615e8be4d4df7819a0d9d92cdee4fda183ac96"
-  integrity sha512-8Bx950VD1bWTQJEH/AM6SpEk+SU55aVnp4Ujhuuxy3eMEBCRwBnTBnVXr9YAPvZL3/CNjCa8u4IWfNmEO53whA==
 
 follow-redirects@^1.0.0, follow-redirects@^1.15.6:
   version "1.15.11"
@@ -9324,7 +9280,7 @@ nanoassert@^2.0.0:
   resolved "https://registry.yarnpkg.com/nanoassert/-/nanoassert-2.0.0.tgz#a05f86de6c7a51618038a620f88878ed1e490c09"
   integrity sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==
 
-nanoid@^3.1.31, nanoid@^3.3.11, nanoid@^3.3.7:
+nanoid@^3.1.31, nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
@@ -10393,7 +10349,7 @@ postcss-unique-selectors@^6.0.4:
   dependencies:
     postcss-selector-parser "^6.0.16"
 
-postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
+postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
@@ -10402,15 +10358,6 @@ postcss-zindex@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/postcss-zindex/-/postcss-zindex-6.0.2.tgz#e498304b83a8b165755f53db40e2ea65a99b56e1"
   integrity sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==
-
-postcss@8.4.49:
-  version "8.4.49"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.49.tgz#4ea479048ab059ab3ae61d082190fabfd994fe19"
-  integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
-  dependencies:
-    nanoid "^3.3.7"
-    picocolors "^1.1.1"
-    source-map-js "^1.2.1"
 
 postcss@^8.4.21, postcss@^8.4.24, postcss@^8.4.33, postcss@^8.5.4:
   version "8.5.8"
@@ -10643,18 +10590,6 @@ rc@1.2.8, rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-chrono@^2.6.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/react-chrono/-/react-chrono-2.9.1.tgz#a2bb87c93ae6095b6a48742b67869a9ac6f8b84e"
-  integrity sha512-/Qq6O7MQ3MYpq0A6IRAKS3mpx4y5B5Jl5os67Q/nt7iuvEnLJ08Yl6/7vlorH1NC2MiLzykOLO3vPnRAChb+HA==
-  dependencies:
-    classnames "^2.5.1"
-    dayjs "^1.11.13"
-    focus-visible "^5.2.1"
-    styled-components "^6.1.18"
-    use-debounce "^10.0.4"
-    xss "^1.0.15"
 
 react-collapsible@^2.10.0:
   version "2.10.0"
@@ -11429,7 +11364,7 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-shallowequal@1.1.0, shallowequal@^1.1.0:
+shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
@@ -11909,21 +11844,6 @@ style-to-object@1.0.14:
   dependencies:
     inline-style-parser "0.2.7"
 
-styled-components@^6.1.18:
-  version "6.3.12"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.3.12.tgz#263a1c52bd1c5d1cdd2667e9605e5ffa8df592d0"
-  integrity sha512-hFR6xsVkVYbsdcUlzPYFvFfoc6o2KlV0VvgRIQwSYMtdThM7SCxnjX9efh/cWce2kTq16I/Kl3xM98xiLptsXA==
-  dependencies:
-    "@emotion/is-prop-valid" "1.4.0"
-    "@emotion/unitless" "0.10.0"
-    "@types/stylis" "4.2.7"
-    css-to-react-native "3.2.0"
-    csstype "3.2.3"
-    postcss "8.4.49"
-    shallowequal "1.1.0"
-    stylis "4.3.6"
-    tslib "2.8.1"
-
 stylehacks@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-6.1.1.tgz#543f91c10d17d00a440430362d419f79c25545a6"
@@ -11936,11 +11856,6 @@ stylis@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
   integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
-
-stylis@4.3.6:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.6.tgz#7c7b97191cb4f195f03ecab7d52f7902ed378320"
-  integrity sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==
 
 supports-color@^7.1.0:
   version "7.2.0"
@@ -12153,15 +12068,15 @@ tslib@2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
-tslib@2.8.1, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.0, tslib@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
 tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.0, tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsyringe@^4.10.0:
   version "4.10.0"
@@ -12454,11 +12369,6 @@ url-loader@^4.1.1:
     loader-utils "^2.0.0"
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
-
-use-debounce@^10.0.4:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-10.1.1.tgz#b08b596b60a55fd4c18b44b37fdc02f058baf30a"
-  integrity sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==
 
 use-sync-external-store@^1.2.2:
   version "1.6.0"
@@ -12883,14 +12793,6 @@ xml-js@^1.6.11:
   integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
   dependencies:
     sax "^1.2.4"
-
-xss@^1.0.15:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.15.tgz#96a0e13886f0661063028b410ed1b18670f4e59a"
-  integrity sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==
-  dependencies:
-    commander "^2.20.3"
-    cssfilter "0.0.10"
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
- Replace `react-chrono` with a custom `HardForkTimeline` component; a recent library version regressed
- Reverse the timeline to newest-first, with Plomin marked as the active hard fork
- Show epoch as a tag pill in the top-right of each card
- Render the era name as vertical text on the line, positioned in the actual era period (between the HF that starts the era  and the HF that starts the next era)