### PR TITLE
feat: add ODATANO to apps with description and icon

### DIFF
--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -282,7 +282,7 @@ export const Showcases = [
   {
     title: "CExplorer",
     description:
-        "Independent Cardano explorer with all-in-one dashboards covering blocks, transactions, stake pools, governance, and asset statistics.",
+      "Independent Cardano explorer with all-in-one dashboards covering blocks, transactions, stake pools, governance, and asset statistics.",
     tagline: "Independent Cardano explorer with dashboards",
     icon: "/img/app-icons/cexplorer.png",
     website: "https://cexplorer.io/",
@@ -1080,7 +1080,7 @@ export const Showcases = [
   {
     title: "Medusa Wallet",
     description:
-        "A lightweight Cardano wallet focused on privacy and user protection, enabling easy and secure access to funds even in untrusted or compromised environments. ",
+      "A lightweight Cardano wallet focused on privacy and user protection, enabling easy and secure access to funds even in untrusted or compromised environments. ",
     tagline: "Privacy-focused lightweight Cardano wallet",
     icon: "/img/app-icons/medusa.jpg",
     website: "https://adawallet.io",
@@ -1095,7 +1095,7 @@ export const Showcases = [
       features: ["staking"],
       type: "light",
     },
-   },
+  },
   {
     title: "Dano Finance",
     description:
@@ -1194,7 +1194,7 @@ export const Showcases = [
     beginnerFriendly: false,
     x: "BeginWallet",
   },
-    {
+  {
     title: "Stuff.io",
     description:
       "Digital-ownership platform on Cardano letting consumers own, share, gift, or resell their movies, music, ebooks, audiobooks, and podcasts as NFTs.",
@@ -1911,6 +1911,19 @@ export const Showcases = [
     maintainerPick: false,
     beginnerFriendly: false,
     x: "hizz_io",
+  },
+  {
+    title: "ODATANO",
+    description:
+      "Connects enterprise systems to Cardano through a SAP CAP-based OData V4 API for on-chain data access, transaction building, and submission.",
+    tagline: "Enterprise OData V4 bridge for Cardano",
+    icon: "/img/app-icons/odatano.svg",
+    website: "https://odatano.dev",
+    source: "https://github.com/ODATANO",
+    category: "other",
+    properties: ["opensource"],
+    maintainerPick: false,
+    beginnerFriendly: false,
   },
 ];
 

--- a/static/img/app-icons/odatano.svg
+++ b/static/img/app-icons/odatano.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <!-- Icon: Bold O with diagonal split and data stream -->
+  <g transform="translate(100, 100)">
+    <!-- O shape - left half (dark) -->
+    <path d="M-3,-56 C-32,-53 -56,-32 -56,0 C-56,32 -32,56 0,56 L-3,56 L-3,-56 Z M-3,-32 L-3,32 C-17,29 -32,17 -32,0 C-32,-17 -17,-29 -3,-32 Z" fill="#001B5E"/>
+    
+    <!-- O shape - right half (lighter blue) -->
+    <path d="M3,-56 C32,-53 56,-32 56,0 C56,32 32,56 0,56 L3,56 L3,-56 Z M3,-32 L3,32 C17,29 32,17 32,0 C32,-17 17,-29 3,-32 Z" fill="#0C5ECF"/>
+    
+    <!-- Data stream dots in the gap -->
+    <circle cx="0" cy="-28" r="3.2" fill="#3B8EF0" opacity="0.9"/>
+    <circle cx="0" cy="-12" r="2.4" fill="#3B8EF0" opacity="0.7"/>
+    <circle cx="0" cy="4" r="2.4" fill="#3B8EF0" opacity="0.5"/>
+    <circle cx="0" cy="20" r="3.2" fill="#3B8EF0" opacity="0.7"/>
+    <circle cx="0" cy="34" r="2.4" fill="#3B8EF0" opacity="0.4"/>
+  </g>
+</svg>


### PR DESCRIPTION
Hi everyone. 

After my talk on Friday during the Developer Hour, Darlisa asked me to add ODATANO here as well. Strictly speaking, it probably wouldn't quite fit in this section, as there isn't an "app" you can try out straight away. 

I've added it under `category: "other"` because none of the primary categories (`dex`, `wallet`, `analytics`, `ecosystem`, …) really fit, but happy to move it if you have a better suggestion.

A couple of other things worth flagging so you can decide how to handle them:

- **Mainnet eligibility.** The submission guide asks for apps that are live on Cardano mainnet and have a stable mainnet-only domain. ODATANO supports `NETWORK=mainnet` and `odatano.dev` is the project homepage, but as a library/plugin, there's no hosted mainnet URL a visitor can click through to yet.
- **Icon only, no screenshot.** Went without a `preview` since ~80% of existing entries do the same. Happy to add maybe a screenshot of one of the example Applications if you'd like one for the listing.
- **Also listed in developer-portal.** ODATANO is already in the Builder Tools list on `developers.cardano.org` which is arguably the more natural home. Totally fine with me if you'd rather keep it there only.

For the GitHub Link, I used the ODATANO GitHub Org with all the available Example App Implementations (TRACE, QUANTIX, x402, etc.).

I think this might fit better here, but I can, of course, still change it.

Let me know what you'd like to adjust.

## Checklist

- [X] I have read the [Contributing Guidelines](https://github.com/cardano-foundation/cardano-org/blob/staging/CONTRIBUTING.md).
- [X] I have read the [App Requirements](https://github.com/cardano-foundation/cardano-org/blob/staging/docs/get-involved/add-app.md) and understand that entries failing the [curation policy](https://github.com/cardano-foundation/cardano-org/blob/staging/docs/get-involved/apps-curation-policy.md) may be removed during quarterly review.
- [ ] I have added my image to `src/data/app-screenshots/`
- [X] (Optional) I have added my icon/logo to `static/img/app-icons/`
- [X] I have run `yarn build` after adding my changes **without getting any errors**.
- [X] I have not committed any changes to `yarn.lock`.
- [X] I have left `maintainerPick: false` on my entry. `maintainerPick` is set by page maintainers through the [Maintainer picks](https://github.com/cardano-foundation/cardano-org/blob/staging/docs/get-involved/maintainer-picks.md) process, not by submitters.
- [X] I have left `beginnerFriendly: false` unless the app is verifiably newcomer-friendly (clear onboarding, low jargon, working defaults).
- [ ] My screenshot follows the [screenshot guidelines](https://github.com/cardano-foundation/cardano-org/blob/staging/docs/get-involved/add-app.md#step-by-step-process): around 1280×720 (16:9) JPEG, under 500 KB, light theme, app UI not a marketing page. The build's screenshot size check will reject anything over 500 KB.
- [X] My `title` is ≤ 25 characters (ideally 15-20). The build's schema validator rejects anything longer. Drop a redundant `Cardano` prefix where the bare project name still reads cleanly.
- [X] My `tagline` is ≤ 60 characters and describes what the app **is**, not what it promises (e.g. "Multi-pool DEX with deepest liquidity", not "Best DEX on Cardano!"). The build's schema validator rejects anything longer.
- [X] My `description` is between **120 and 180 characters** (1-2 sentences). The build's schema validator rejects anything outside this range. Long descriptions get truncated in search results and social-share previews; very short ones repeat the tagline.
- [X] (Optional) If I added an `x` field, it is just the handle — no `@`, no URL — and matches X's own handle rules (1-15 characters, letters/digits/underscores).




