### PR TITLE
fix: correct /translations locale mapping and metric display

### DIFF
--- a/scripts/fetch-crowdin-progress.js
+++ b/scripts/fetch-crowdin-progress.js
@@ -13,6 +13,12 @@ const PROJECT_ID = process.env.CROWDIN_PROJECT_ID;
 const TOKEN = process.env.CROWDIN_PERSONAL_TOKEN;
 const OUTPUT = path.join(__dirname, "..", "src", "data", "translation-progress.json");
 
+// Map Crowdin language IDs to the locale codes Docusaurus uses
+// (see docusaurus.config.js i18n.locales). Crowdin reports es-ES, the site uses es.
+const LOCALE_MAP = {
+  "es-ES": "es",
+};
+
 if (!PROJECT_ID || !TOKEN) {
   console.error("Missing CROWDIN_PROJECT_ID or CROWDIN_PERSONAL_TOKEN env vars");
   process.exit(1);
@@ -35,7 +41,7 @@ async function fetchProgress() {
   const languages = json.data.map((entry) => {
     const d = entry.data;
     return {
-      id: d.languageId,
+      id: LOCALE_MAP[d.languageId] || d.languageId,
       name: d.language?.name || d.languageId,
       translationProgress: d.translationProgress,
       approvalProgress: d.approvalProgress,

--- a/src/data/translation-progress.json
+++ b/src/data/translation-progress.json
@@ -1,75 +1,75 @@
 {
-  "lastUpdated": "2026-05-29T07:10:18.515Z",
+  "lastUpdated": "2026-06-03T22:49:54.487Z",
   "languages": [
-    {
-      "id": "de",
-      "name": "German",
-      "translationProgress": 55,
-      "approvalProgress": 0,
-      "words": {
-        "total": 39146,
-        "translated": 21691,
-        "preTranslateAppliedTo": 0,
-        "approved": 13
-      },
-      "phrases": {
-        "total": 3786,
-        "translated": 1920,
-        "preTranslateAppliedTo": 0,
-        "approved": 5
-      }
-    },
-    {
-      "id": "es-ES",
-      "name": "Spanish",
-      "translationProgress": 52,
-      "approvalProgress": 50,
-      "words": {
-        "total": 39146,
-        "translated": 20361,
-        "preTranslateAppliedTo": 0,
-        "approved": 19949
-      },
-      "phrases": {
-        "total": 3786,
-        "translated": 2274,
-        "preTranslateAppliedTo": 0,
-        "approved": 2254
-      }
-    },
     {
       "id": "ja",
       "name": "Japanese",
-      "translationProgress": 48,
-      "approvalProgress": 44,
+      "translationProgress": 90,
+      "approvalProgress": 89,
       "words": {
-        "total": 39146,
-        "translated": 19016,
-        "preTranslateAppliedTo": 0,
+        "total": 19573,
+        "translated": 17662,
+        "preTranslateAppliedTo": 66,
         "approved": 17596
       },
       "phrases": {
-        "total": 3786,
-        "translated": 1851,
-        "preTranslateAppliedTo": 0,
+        "total": 1893,
+        "translated": 1644,
+        "preTranslateAppliedTo": 28,
         "approved": 1616
+      }
+    },
+    {
+      "id": "es",
+      "name": "Spanish",
+      "translationProgress": 65,
+      "approvalProgress": 39,
+      "words": {
+        "total": 19573,
+        "translated": 12737,
+        "preTranslateAppliedTo": 5058,
+        "approved": 7677
+      },
+      "phrases": {
+        "total": 1893,
+        "translated": 1354,
+        "preTranslateAppliedTo": 411,
+        "approved": 941
+      }
+    },
+    {
+      "id": "de",
+      "name": "German",
+      "translationProgress": 60,
+      "approvalProgress": 0,
+      "words": {
+        "total": 19573,
+        "translated": 11746,
+        "preTranslateAppliedTo": 660,
+        "approved": 13
+      },
+      "phrases": {
+        "total": 1893,
+        "translated": 1162,
+        "preTranslateAppliedTo": 173,
+        "approved": 5
       }
     },
     {
       "id": "vi",
       "name": "Vietnamese",
-      "translationProgress": 14,
+      "translationProgress": 28,
       "approvalProgress": 0,
       "words": {
-        "total": 39146,
-        "translated": 5544,
-        "preTranslateAppliedTo": 0,
+        "total": 19573,
+        "translated": 5576,
+        "preTranslateAppliedTo": 5438,
         "approved": 0
       },
       "phrases": {
-        "total": 3786,
-        "translated": 779,
-        "preTranslateAppliedTo": 0,
+        "total": 1893,
+        "translated": 781,
+        "preTranslateAppliedTo": 716,
         "approved": 0
       }
     }

--- a/src/pages/translations.js
+++ b/src/pages/translations.js
@@ -36,6 +36,7 @@ function ProgressBar({ percentage }) {
 }
 
 function LocaleCard({ language }) {
+  const fmt = (n) => new Intl.NumberFormat('en-US').format(n);
   return (
     <div style={{
       border: '1px solid #ddd',
@@ -44,20 +45,18 @@ function LocaleCard({ language }) {
       marginBottom: '20px',
       backgroundColor: 'var(--ifm-card-background-color)',
     }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
-        <h3 style={{ margin: 0 }}>{language.name} ({language.id})</h3>
-        <span style={{ fontSize: '14px', color: '#666' }}>
-          {language.phrases.translated} / {language.phrases.total} phrases
-        </span>
-      </div>
+      <h3 style={{ marginTop: 0, marginBottom: '12px' }}>{language.name} ({language.id})</h3>
 
       <ProgressBar percentage={language.translationProgress} />
 
-      {language.approvalProgress > 0 && (
-        <div style={{ marginTop: '8px', fontSize: '13px', color: '#666' }}>
-          {language.approvalProgress}% approved
-        </div>
-      )}
+      <div style={{ marginTop: '8px', fontSize: '13px', color: '#666' }}>
+        {fmt(language.words.translated)} / {fmt(language.words.total)} words
+        {' · '}
+        {fmt(language.phrases.translated)} / {fmt(language.phrases.total)} phrases
+        {language.approvalProgress > 0 && (
+          <>{' · '}{language.approvalProgress}% approved</>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Map Crowdin's es-ES language id to es so the Spanish card matches the site locale (docusaurus.config.js, i18n/es/)
- Show both word and phrase counts under each language bar. The bar stays word-based (Crowdin translationProgress), resolving the previously contradictory phrase-only label
- Regenerate translation-progress.json with fresh Crowdin data: totals dropped from 3786 to 1893 phrases after removing a duplicate `staging` source branch in Crowdin that was doubling the denominator and capping every language near 50%