### PR TITLE
feat(glossary): add net change limit term

### DIFF
--- a/glossary/net-change-limit.md
+++ b/glossary/net-change-limit.md
@@ -1,0 +1,15 @@
+---
+title: Net Change Limit
+slug: net-change-limit
+short: A constitutional guardrail that caps the net amount of ada the treasury can pay out over a defined period. DReps agree each limit through an info action.
+category: governance
+level: intermediate
+aliases: ["NCL"]
+link: /governance
+mentalModel: "A spending speed limit for the community treasury. Instead of judging each withdrawal on its own, the community agrees up front how much ada may leave the treasury over a set period, so payouts cannot outpace what the ecosystem can sustain."
+related: [treasury, treasury-withdrawal, treasury-cut, governance-action, info-action, drep, constitution]
+---
+
+The net change limit (NCL) caps how far the Cardano treasury's balance may fall over a defined period of time, in effect bounding the net amount of ada that can leave the treasury. It is not a protocol parameter but a guardrail in the Cardano Constitution (TREASURY-01a), which requires the limit to be agreed by the DReps with a threshold of greater than 50% of the active voting stake.
+
+DReps record that agreement through an [info action](/glossary/info-action), a governance action that captures a community decision without making any direct on-chain change. Each info action sets the limit for one window, and a later info action renews or revises it. Treasury withdrawals cannot be ratified beyond the limit in force, and they must draw on a community-approved ecosystem budget. For a plain-language introduction, see the [net change limit explainer](/news/2025-12-02-what-is-cardano-net-change-limit).

--- a/glossary/treasury-cut.md
+++ b/glossary/treasury-cut.md
@@ -6,7 +6,7 @@ category: consensus
 level: intermediate
 aliases: ["treasuryCut", "Tau", "τ"]
 mentalModel: "A standing tax on block rewards that funds the community piggy bank. A fixed share of every epoch's reward pot is automatically routed to the treasury before delegators see their cut."
-related: [rewards, treasury, monetary-expansion-rate, treasury-withdrawal]
+related: [rewards, treasury, monetary-expansion-rate, treasury-withdrawal, net-change-limit]
 ---
 
 The mainnet value has been `0.20` (20%) since Shelley. Together with the monetary expansion rate, the treasury cut decides the long-run balance between user-facing staking rewards and on-chain treasury accumulation.

--- a/glossary/treasury-withdrawal.md
+++ b/glossary/treasury-withdrawal.md
@@ -6,7 +6,7 @@ category: governance
 aliases: ["Treasury Withdrawal Action"]
 link: /governance
 mentalModel: "The on-chain spend mechanism for the community piggy bank. Anyone can propose taking ada out of the treasury and routing it to a stake address; DReps and the Constitutional Committee vote, and if it passes, the protocol pays out directly with no intermediary holding the money."
-related: [governance-action, treasury, drep, cip-1694, project-catalyst, plomin]
+related: [governance-action, treasury, net-change-limit, drep, cip-1694, project-catalyst, plomin]
 ---
 
 A governance action type that proposes withdrawing ada from the Cardano treasury and paying it out to a specified stake address. Treasury withdrawals require successful DRep and Constitutional Committee votes (the action does not need stake pool ratification).

--- a/glossary/treasury.md
+++ b/glossary/treasury.md
@@ -4,7 +4,7 @@ slug: treasury
 short: An on-chain fund that accumulates a portion of transaction fees and monetary expansion.
 category: governance
 mentalModel: "Like a community piggy bank funded by a slice of every transaction fee and by monetary expansion."
-related: [project-catalyst, governance-action, treasury-cut, treasury-withdrawal, monetary-expansion-rate]
+related: [project-catalyst, governance-action, treasury-cut, treasury-withdrawal, net-change-limit, monetary-expansion-rate]
 ---
 
 An on-chain fund that accumulates a portion of transaction fees and monetary expansion. Used to finance ecosystem development through Project Catalyst and governance actions. See [treasury charts](/insights/supply/summary/#treasury).


### PR DESCRIPTION
- Add glossary/net-change-limit.md defining the Net Change Limit (NCL) as a Cardano Constitution guardrail (TREASURY-01a) that DReps set through an info action
- Cross-link the term from the treasury, treasury-withdrawal, and treasury-cut entries
- Link to the existing net change limit news explainer
- Relates to #606; adds the glossary explanation only, on-page historical tracking stays out of scope here
