### PR TITLE
feat: add glossary entries for key CIP standards and x402

### DIFF
--- a/glossary/cip-19.md
+++ b/glossary/cip-19.md
@@ -1,0 +1,18 @@
+---
+title: CIP-19
+slug: cip-19
+short: "The specification for how a Cardano address is structured in binary: which network it belongs to, the payment credential, and the optional staking credential."
+category: wallets
+aliases: ["Cardano Addresses", "Address format"]
+mentalModel: "The blueprint for what the bytes inside an address actually mean. Bech32 is the readable wrapper you see; CIP-19 is the structure underneath that says which network, who can spend, and which stake key earns the rewards."
+related: [bech32, stake-address, wallet]
+sources:
+  - title: "CIP-19: Cardano Addresses"
+    url: "https://github.com/cardano-foundation/CIPs/tree/master/CIP-0019"
+  - title: "CIP-5: Common Bech32 Prefixes"
+    url: "https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005"
+---
+
+CIP-19 defines the byte-level layout of Cardano addresses: a header that encodes the address type and network (mainnet or testnet), followed by a payment credential (a key hash or script hash that controls spending) and, for most everyday addresses, a staking credential that points to the stake key earning rewards. From this it derives the main address types: base addresses (payment plus staking), enterprise addresses (payment only, no staking), pointer addresses, and reward (stake) addresses.
+
+The human-readable strings people copy and paste, with prefixes like `addr1` and `stake1`, are that binary structure encoded in [Bech32](/glossary/bech32/) following the prefixes set out in CIP-5. So CIP-19 and Bech32 work as a pair: CIP-19 says what the address contains, and Bech32 says how to write it down with built-in error detection.

--- a/glossary/cip-20.md
+++ b/glossary/cip-20.md
@@ -1,0 +1,16 @@
+---
+title: CIP-20
+slug: cip-20
+short: "A standard place to attach a short human-readable message to a transaction, so a memo, note, or comment travels with the payment on-chain."
+category: general
+aliases: ["Transaction message metadata", "674 metadata", "Transaction comment"]
+mentalModel: "The memo field for a Cardano transaction. The ledger ignores it, but wallets, explorers, and exchanges know to look for it, so it is the agreed way to leave a readable note alongside a payment."
+related: [api, cip, native-token]
+sources:
+  - title: "CIP-20: Transaction message/comment metadata"
+    url: "https://github.com/cardano-foundation/CIPs/tree/master/CIP-0020"
+---
+
+CIP-20 reserves the transaction metadata label `674` for a `msg` field: an array of UTF-8 strings, each at most 64 bytes, that together form a human-readable message. Splitting the text into 64-byte chunks works around the protocol's per-string metadata limit, and a reader simply joins the pieces back together. The content is purely informational; the ledger never validates or acts on it.
+
+It is the convention exchanges, donation flows, and dApps use to label what a payment is for, and explorers and wallets display it automatically. Note that label `674` is also where the aggregate transaction-message convention lives, so when you tag a transaction's purpose for analytics you attach a specific application label rather than overloading `674` itself, keeping the readable memo separate from machine-readable attribution.

--- a/glossary/cip-25.md
+++ b/glossary/cip-25.md
@@ -1,0 +1,16 @@
+---
+title: CIP-25
+slug: cip-25
+short: "The convention that tells wallets and marketplaces how to read an NFT's name, image, and attributes from the metadata attached when the token was minted."
+category: tokens
+aliases: ["NFT Metadata Standard", "721 metadata", "Media NFT Metadata Standard"]
+mentalModel: "The agreed JSON shape that turns a raw native token into a recognizable NFT. Without it a token is just a policy id and a name; with it, every wallet and marketplace knows where to find the picture, the title, and the traits."
+related: [nft, native-token, policy-id, cip-68]
+sources:
+  - title: "CIP-25: Media NFT Metadata Standard"
+    url: "https://github.com/cardano-foundation/CIPs/tree/master/CIP-0025"
+---
+
+CIP-25 places a JSON document in the minting transaction's metadata under the label `721`, keyed by the token's policy id and asset name. The document carries a `name`, an `image` (usually an `ipfs://` link), an optional `mediaType`, and any number of custom attributes. Because the data is written at mint time as transaction metadata, it is cheap and simple, and it became the de facto way NFTs are described on Cardano.
+
+The trade-off is that the metadata is effectively frozen: it can only change if the policy stays open and the token is re-minted, which most collections deliberately prevent by time-locking the policy. When a project needs metadata that a smart contract can read on-chain or update over time, [CIP-68](/glossary/cip-68/) is the newer alternative that stores the data in a datum instead of in transaction metadata.

--- a/glossary/cip-30.md
+++ b/glossary/cip-30.md
@@ -1,0 +1,18 @@
+---
+title: CIP-30
+slug: cip-30
+short: "The standard that lets a website talk to a browser-extension wallet, so dApps can request addresses, ask the wallet to sign a transaction, and submit it, all without handling the user's keys."
+category: wallets
+aliases: ["dApp-Wallet Web Bridge", "Wallet Connector", "window.cardano"]
+mentalModel: "The handshake every Cardano dApp uses to reach your wallet. The page asks for permission, the wallet exposes a small set of functions, and from then on the dApp can read your addresses and request signatures, but the private keys never leave the wallet."
+related: [wallet, dapp, cip, cip-8, stake-address]
+sources:
+  - title: "CIP-30: Cardano dApp-Wallet Web Bridge"
+    url: "https://github.com/cardano-foundation/CIPs/tree/master/CIP-0030"
+  - title: "CIP-95: Web-Wallet Bridge, Conway ledger era"
+    url: "https://github.com/cardano-foundation/CIPs/tree/master/CIP-0095"
+---
+
+CIP-30 defines the JavaScript interface a wallet injects into the page as `window.cardano.<walletName>`. After the user approves a connection through `enable()`, the dApp can call a fixed set of methods: read used and unused addresses, fetch the network id, query balances and UTxOs, ask the wallet to sign a transaction (`signTx`) or arbitrary data (`signData`), and submit a finished transaction (`submitTx`). Because the wallet performs every signature internally, the website never sees the seed phrase or private keys.
+
+Almost every "Connect Wallet" button in the Cardano ecosystem speaks CIP-30, which is what lets the same dApp work with Eternl, Lace, VESPR, Typhon and others without custom integrations. CIP-95 extends the same bridge for the Conway era so wallets can also expose governance data and sign DRep registration and votes. When you build a transaction flow, always compare the wallet's reported network id against the network your app expects before signing, so a user on the wrong network gets a clear message instead of a cryptic failure.

--- a/glossary/cip-68.md
+++ b/glossary/cip-68.md
@@ -1,0 +1,17 @@
+---
+title: CIP-68
+slug: cip-68
+short: "A token metadata standard that stores an asset's metadata in an on-chain datum a smart contract can read and update, rather than in the frozen transaction metadata used by CIP-25."
+category: tokens
+level: advanced
+aliases: ["Datum Metadata Standard"]
+mentalModel: "Metadata that lives where contracts can see it. Instead of a label-721 note locked into the mint transaction, the data sits in a datum on a UTxO, so a validator can read it and, if the design allows, change it later."
+related: [datum, native-token, nft, cip-25, reference-input]
+sources:
+  - title: "CIP-68: Datum Metadata Standard"
+    url: "https://github.com/cardano-foundation/CIPs/tree/master/CIP-0068"
+---
+
+CIP-68 splits an asset into a pair that shares one policy id: a reference token (asset-name label `100`) that holds the metadata, and the user-facing token the holder actually owns (`222` for an NFT, `333` for a fungible token, `444` for a rich fungible token). The metadata itself is stored as an inline datum on the UTxO that carries the reference token, so any Plutus script can read it directly on-chain instead of relying on off-chain indexers, which is something [CIP-25](/glossary/cip-25/) metadata cannot offer.
+
+This design makes metadata programmable: because the reference token's datum can be spent and recreated by an authorized transaction, traits can evolve (game items that level up, dynamic art, identity records) while collectors keep holding the same user token. The cost is more moving parts than CIP-25, so simple static collections often still use CIP-25 while projects that need contract-readable or updatable metadata reach for CIP-68.

--- a/glossary/cip-8.md
+++ b/glossary/cip-8.md
@@ -1,0 +1,16 @@
+---
+title: CIP-8
+slug: cip-8
+short: "The standard for signing arbitrary data with a wallet key, used to prove control of an address without sending a transaction or paying a fee."
+category: wallets
+aliases: ["Message Signing", "signData", "COSE signing"]
+mentalModel: "Signing a piece of paper to prove it is yours, instead of moving money to prove you can. The wallet signs a message with the same key that controls an address, and anyone can verify it without anything touching the chain."
+related: [wallet, cip-30, bech32]
+sources:
+  - title: "CIP-8: Message Signing"
+    url: "https://github.com/cardano-foundation/CIPs/tree/master/CIP-0008"
+---
+
+CIP-8 defines how a Cardano key signs an arbitrary payload using the COSE (CBOR Object Signing and Encryption) format, producing a signature plus the public key needed to verify it. Because no transaction is built and nothing is submitted, message signing costs no fee and never appears on-chain; it simply demonstrates that the signer holds the private key behind a given address.
+
+This is the mechanism behind "sign in with Cardano" logins, ownership checks, and gated access: a service hands the wallet a challenge, the wallet signs it, and the service verifies the result against the claimed address. In practice apps reach CIP-8 through the [CIP-30](/glossary/cip-30/) `signData` method, which implements this signing flow inside the dApp-wallet bridge. It is deliberately distinct from signing a transaction, so approving a login can never move your funds.

--- a/glossary/cip-99.md
+++ b/glossary/cip-99.md
@@ -1,0 +1,16 @@
+---
+title: CIP-99
+slug: cip-99
+short: "A standard claim flow that lets newcomers receive ada or tokens at a real-world event by scanning a QR code with their wallet, replacing paper wallets."
+category: wallets
+aliases: ["Proof of Onboarding"]
+mentalModel: "A vending-machine moment for onboarding. Instead of handing someone a printed paper wallet at a booth, you show a QR code; they scan it with a supporting wallet and the assets land in an address they already control."
+related: [wallet, ada, native-token]
+sources:
+  - title: "CIP-99: Proof of Onboarding"
+    url: "https://github.com/cardano-foundation/CIPs/tree/master/CIP-0099"
+---
+
+CIP-99 standardizes how a project distributes ada or native tokens to users at events and campaigns without the friction of paper wallets. It extends the Cardano URI scheme with a `web+cardano://claim/v1` form that carries a faucet URL and a claim code, and it defines the request and response format, including status codes for success, queuing, and errors, that a wallet and the project's server use to complete the transfer. The "proof of onboarding" name comes from the fact that the flow also lets organizers measure how many people actually claimed.
+
+For the recipient the experience is a single scan: a supporting wallet reads the QR code, talks to the faucet, and deposits the assets into an address the user already holds, so there is no seed phrase to transcribe and no separate paper wallet to import later. Wallet support is what makes the standard usable in the field; Eternl and VESPR implemented the claim flow early, and Lace now supports it as well.

--- a/glossary/x402.md
+++ b/glossary/x402.md
@@ -1,0 +1,23 @@
+---
+title: x402
+slug: x402
+short: "An open payment standard that revives the HTTP 402 status code so software, and AI agents in particular, can pay per request in stablecoins without accounts, API keys, or a checkout page."
+category: general
+level: advanced
+aliases: ["HTTP 402", "Payment Required", "x402 protocol"]
+mentalModel: "A toll booth built into the web itself. A client asks for a resource, the server answers '402 Payment Required' with how much and where to pay, the client pays in stablecoins, and the same request goes through, all in a couple of automated round-trips with no human checkout."
+related: [stablecoin, usdm, djed, api, did]
+sources:
+  - title: "x402: Internet-Native Payments Standard"
+    url: "https://www.x402.org/"
+  - title: "What is Coinbase's x402 protocol? (The Block)"
+    url: "https://www.theblock.co/learn/391983/what-is-coinbases-x402-protocol"
+  - title: "x402 on Cardano: Version 2 Standard & Integration (Developers Office Hour)"
+    url: "https://www.youtube.com/watch?v=5yhdNPAn8BA"
+---
+
+HTTP 402 ("Payment Required") has been reserved in the web standards since the 1990s but was never widely used. x402 finally puts it to work: when a client calls a paid endpoint, the server responds with `402` and a description of the payment it expects. The client prebuilds and signs a payment transaction; a server, or an optional facilitator, submits that transaction and, once it has settled on-chain, responds with `200` and the actual content requested. The result is metered, pay-per-call access to APIs and data with no signups, subscriptions, or stored card details. Originally contributed by Coinbase, the protocol moved to neutral stewardship under the Linux Foundation in 2026.
+
+Cardano's eUTxO model fits this flow naturally. The buyer prebuilds and signs a transaction that pays an exact amount, and because any change would invalidate the signature, the server or facilitator can only submit it unchanged; the amount that settles is exactly the amount the buyer signed for. This is a different shape from account-based chains, where an x402 payment is commonly made by granting a contract a spending allowance that application logic then draws against. Both models support x402; the eUTxO version simply carries the exact payment in the signed transaction itself rather than in a separate allowance.
+
+x402 matters most for the emerging agent economy, where autonomous AI agents need to pay for the services they consume on the fly, which is also where stablecoins like [USDM](/glossary/usdm/) and [Djed](/glossary/djed/) fit on Cardano. It is one piece of a wider stack of agentic-commerce standards: AP2 (Agent Payments Protocol) and ACP (Agentic Commerce Protocol) describe how a payment is authorized on the buyer's behalf, MCP (Model Context Protocol) governs how an agent connects to tools and data, and A2A (Agent2Agent) covers how agents talk to one another.


### PR DESCRIPTION
- Add glossary entries for the standards CIP-8, CIP-19, CIP-20, CIP-25, CIP-30, CIP-68, and CIP-99, covering message signing, addresses, transaction messages, NFT and datum metadata, the wallet connector, and event onboarding.
- Add a glossary entry for x402, the HTTP 402 based payment standard for APIs and AI agents, including how it maps onto Cardano's eUTxO model.
- Each entry includes a plain-language definition, a mental model, related terms, and sources.