### PR TITLE
feat: add GitHub links to ambassador cards

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -3691,6 +3691,9 @@
   "ambassadors.directory.socialAria.youtube": {
     "message": "YouTube channel"
   },
+  "ambassadors.directory.socialAria.github": {
+    "message": "GitHub profile"
+  },
   "ambassadors.stories.divider": {
     "message": "Impact Stories"
   },

--- a/src/components/Ambassadors/AmbassadorCard/index.js
+++ b/src/components/Ambassadors/AmbassadorCard/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import Link from "@docusaurus/Link";
 import { translate } from "@docusaurus/Translate";
 import { BsChatLeftTextFill } from "react-icons/bs";
-import { FaXTwitter, FaLinkedinIn, FaYoutube } from "react-icons/fa6";
+import { FaXTwitter, FaLinkedinIn, FaYoutube, FaGithub } from "react-icons/fa6";
 
 import AmbassadorAvatar, { Flag } from "@site/src/components/Ambassadors/AmbassadorAvatar";
 import { ambassadorContributions, present } from "@site/src/utils/ambassadorLanguages";
@@ -14,6 +14,7 @@ export default function AmbassadorCard({ ambassador, highlighted = false }) {
   const xUrl = present(socials.x) ? socials.x : null;
   const linkedinUrl = present(socials.linkedIn) ? socials.linkedIn : null;
   const youtubeUrl = present(socials.youtube) ? socials.youtube : null;
+  const githubUrl = present(socials.github) ? socials.github : null;
 
   const tagline = present(ambassador.tagline) ? ambassador.tagline : null;
   const areas = ambassadorContributions(ambassador);
@@ -78,6 +79,17 @@ export default function AmbassadorCard({ ambassador, highlighted = false }) {
                 aria-label={translate({ id: "ambassadors.directory.socialAria.youtube", message: "YouTube channel" })}
               >
                 <FaYoutube />
+              </Link>
+            )}
+            {githubUrl && (
+              <Link
+                to={githubUrl}
+                className={styles.socialLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={translate({ id: "ambassadors.directory.socialAria.github", message: "GitHub profile" })}
+              >
+                <FaGithub />
               </Link>
             )}
           </div>

--- a/src/data/ambassadorsData.json
+++ b/src/data/ambassadorsData.json
@@ -93,7 +93,8 @@
     "socials": {
       "x": "https://x.com/wimscardano",
       "linkedIn": "https://www.linkedin.com/in/bernard-sibanda-954563243",
-      "youtube": ""
+      "youtube": "",
+      "github": "https://github.com/besiwims"
     },
     "areasOfContribution": "Education, Software, Meetup"
   },
@@ -149,7 +150,8 @@
     "socials": {
       "x": "https://x.com/danamphred",
       "linkedIn": "https://www.linkedin.com/in/danbaruka/",
-      "youtube": "https://www.youtube.com/@catalystafricatownhall1239"
+      "youtube": "https://www.youtube.com/@catalystafricatownhall1239",
+      "github": "https://github.com/danbaruka"
     },
     "areasOfContribution": "Software, Content, Moderation"
   },
@@ -177,7 +179,8 @@
     "socials": {
       "x": "https://x.com/MedusaAdaWallet",
       "linkedIn": "",
-      "youtube": ""
+      "youtube": "",
+      "github": "https://github.com/Fell-x27"
     },
     "areasOfContribution": "Software, Partnerships, Other"
   },
@@ -569,7 +572,8 @@
     "socials": {
       "x": "https://x.com/bosconfts",
       "linkedIn": "https://www.linkedin.com/in/bosco-ribeiro-4475513a0/",
-      "youtube": "https://www.youtube.com/@BoscoBlockchainPORT/videos"
+      "youtube": "https://www.youtube.com/@BoscoBlockchainPORT/videos",
+      "github": "https://github.com/bosconfts"
     },
     "areasOfContribution": "Content, Business Development"
   },
@@ -597,7 +601,8 @@
     "socials": {
       "x": "https://x.com/oscarw3st",
       "linkedIn": "",
-      "youtube": ""
+      "youtube": "",
+      "github": "https://github.com/OscarW3st"
     },
     "areasOfContribution": "Meetup, Education, Content"
   },
@@ -695,7 +700,8 @@
     "socials": {
       "x": "https://x.com/ATADA_Stakepool",
       "linkedIn": "",
-      "youtube": ""
+      "youtube": "",
+      "github": "https://github.com/gitmachtl"
     },
     "areasOfContribution": "Software"
   },
@@ -891,7 +897,8 @@
     "socials": {
       "x": "https://x.com/rxphair",
       "linkedIn": "",
-      "youtube": ""
+      "youtube": "",
+      "github": "https://github.com/rphair"
     },
     "areasOfContribution": "Software, Meetup, Education"
   },
@@ -1157,7 +1164,8 @@
     "socials": {
       "x": "https://x.com/hinsonsidan",
       "linkedIn": "",
-      "youtube": ""
+      "youtube": "",
+      "github": "https://github.com/HinsonSIDAN"
     },
     "areasOfContribution": "Software, Content, Education"
   },


### PR DESCRIPTION
Add an optional GitHub link to ambassador cards, shown next to the existing social icons (only appears for ambassadors who have a GitHub profile set)

cc @rphair 🫡