### PR TITLE
chore: enforce lint in CI and resolve all React Hooks warnings

### DIFF
--- a/.github/workflows/yarn-build.yml
+++ b/.github/workflows/yarn-build.yml
@@ -18,4 +18,5 @@ jobs:
           cache: yarn
       - run: corepack enable
       - run: yarn install --frozen-lockfile
+      - run: yarn lint
       - run: yarn build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,10 @@ export default [
   react.configs.flat['jsx-runtime'],
   jsxA11y.flatConfigs.recommended,
 
+  // Pin the React version globally so the recommended config above does not
+  // emit a "React version not specified" meta-warning.
+  { settings: { react: { version: '18.3' } } },
+
   {
     files: ['src/**/*.{js,jsx}', 'scripts/**/*.js', 'docusaurus.config.js'],
     languageOptions: {

--- a/src/components/Ambassadors/AmbassadorsHero/index.js
+++ b/src/components/Ambassadors/AmbassadorsHero/index.js
@@ -62,6 +62,8 @@ export default function AmbassadorsHero() {
   const [lineHidden, setLineHidden] = useState(false);
 
   useEffect(() => {
+    // Shuffle on the client only; shuffling during render would desync SSR markup.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setItems(shuffled(FEATURED_POOL));
   }, []);
 

--- a/src/components/AppFilterPanel/index.js
+++ b/src/components/AppFilterPanel/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState, useEffect } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useHistory, useLocation } from "@docusaurus/router";
 import { translate } from "@docusaurus/Translate";
 import clsx from "clsx";
@@ -22,11 +22,12 @@ export default function AppFilterPanel() {
   const location = useLocation();
   const history = useHistory();
   const [open, setOpen] = useState(false);
-  const [selectedTags, setSelectedTags] = useState([]);
-
-  useEffect(() => {
-    setSelectedTags(readSearchTags(location.search));
-  }, [location.search]);
+  // Tags are derived from the URL, the single source of truth, not mirrored
+  // into local state.
+  const selectedTags = useMemo(
+    () => readSearchTags(location.search),
+    [location.search]
+  );
 
   const activeCategory = useMemo(
     () => selectedTags.find((t) => CategoryList.includes(t)) || null,

--- a/src/components/AppList/index.js
+++ b/src/components/AppList/index.js
@@ -81,7 +81,6 @@ export default function AppList({ categories = [], beginnerFriendly = false, slu
         .map((slug) => {
           const found = Showcases.find((app) => app.slug === slug);
           if (!found && process.env.NODE_ENV !== 'production') {
-            // eslint-disable-next-line no-console
             console.warn(`[AppList] Unknown slug "${slug}" — no matching app in Showcases.`);
           }
           return found;

--- a/src/components/CompaniesShowcase/index.js
+++ b/src/components/CompaniesShowcase/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useLocation, useHistory } from "@docusaurus/router";
 import { useBaseUrlUtils } from "@docusaurus/useBaseUrl";
 import ThemedImage from "@theme/ThemedImage";
@@ -92,9 +92,10 @@ export default function CompaniesShowcase() {
   const params = new URLSearchParams(location.search);
   const activeTab = params.get("tab");
 
-  const activeCompany = activeTab
-    ? companies.find((c) => getCompanyId(c) === activeTab)
-    : null;
+  const activeCompany = useMemo(
+    () => (activeTab ? companies.find((c) => getCompanyId(c) === activeTab) : null),
+    [activeTab]
+  );
 
   useEffect(() => {
     if (activeCompany && spotlightRef.current) {
@@ -103,7 +104,7 @@ export default function CompaniesShowcase() {
         block: "start",
       });
     }
-  }, [activeTab]);
+  }, [activeCompany]);
 
   function handleSelect(company) {
     const id = getCompanyId(company);

--- a/src/components/DRepDelegate/index.js
+++ b/src/components/DRepDelegate/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import { translate } from "@docusaurus/Translate";
@@ -439,8 +439,9 @@ function SpecialOption({ label, help, onSelect, target, disabled }) {
 export default function DRepDelegate() {
   const { siteConfig: { customFields } } = useDocusaurusContext();
   const API_URL = customFields.CARDANO_ORG_API_URL;
-  const apiRef = useRef(null);
-  if (!apiRef.current && API_URL) apiRef.current = makeApiClient(API_URL);
+  // Create the API client once. A lazy useState initializer keeps it stable
+  // across renders without reading a ref during render.
+  const [apiClient] = useState(() => (API_URL ? makeApiClient(API_URL) : null));
 
   const [pool, setPool] = useState([]);
   const [displayed, setDisplayed] = useState([]);
@@ -453,13 +454,15 @@ export default function DRepDelegate() {
 
   useEffect(() => {
     if (!API_URL) return;
-    const api = apiRef.current;
+    const api = apiClient;
     if (!api) return;
 
     let cancelled = false;
 
     const cached = readPoolCache();
     if (cached) {
+      // Hydrate from the client-only localStorage cache on mount.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPool(cached);
       setDisplayed(fisherYates(cached).slice(0, DISPLAY_COUNT));
       setLoading(false);
@@ -536,7 +539,7 @@ export default function DRepDelegate() {
 
     fetchDReps();
     return () => { cancelled = true; };
-  }, [API_URL]);
+  }, [API_URL, apiClient]);
 
   const reshuffle = useCallback(() => {
     setDisplayed(fisherYates(pool).slice(0, DISPLAY_COUNT));
@@ -555,9 +558,11 @@ export default function DRepDelegate() {
 
   useEffect(() => {
     if (!wallet) return;
-    const api = apiRef.current;
+    const api = apiClient;
     if (!api) return;
     let cancelled = false;
+    // Reset delegation state when the connected wallet changes, before refetch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDelegation(undefined);
     setStakeRegistered(undefined);
     (async () => {
@@ -585,7 +590,7 @@ export default function DRepDelegate() {
       }
     })();
     return () => { cancelled = true; };
-  }, [wallet, pool, tx.status]);
+  }, [wallet, pool, tx.status, apiClient]);
 
   const handleSelect = useCallback(async (target, displayName) => {
     if (!wallet || wrongNetwork || txBusy) return;

--- a/src/components/DelegationFlow/index.js
+++ b/src/components/DelegationFlow/index.js
@@ -286,6 +286,8 @@ export default function DelegationFlow({ storageKey = DEFAULT_STORAGE_KEY }) {
     if (typeof window === "undefined") return;
     try {
       const saved = localStorage.getItem(storageKey);
+      // Restore the saved step from client-only localStorage on mount.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       if (saved) setCurrentStep(parseInt(saved, 10) || 1);
     } catch (e) {}
   }, [storageKey]);

--- a/src/components/GlossaryTerm/index.js
+++ b/src/components/GlossaryTerm/index.js
@@ -221,7 +221,8 @@ export default function GlossaryTerm({ term }) {
   // plugin failed to register (e.g. build error in loadContent); we still want
   // the page to render rather than crash the whole route.
   const glossaryData = usePluginData('glossary-routes') || {};
-  const terms = glossaryData.terms || [];
+  // Memoize so the fallback [] keeps a stable reference across renders.
+  const terms = useMemo(() => glossaryData.terms || [], [glossaryData.terms]);
   const categoryDef = CATEGORIES[term.category];
 
   const { siteConfig } = useDocusaurusContext();

--- a/src/components/GovernanceCharts/index.js
+++ b/src/components/GovernanceCharts/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import { ReactFlowProvider } from "@xyflow/react";
 import GovernanceGraphs from "@site/src/components/GovernanceGraphs";
 import {translate} from '@docusaurus/Translate';
@@ -123,10 +123,24 @@ export default function GovernanceCharts({
     initialCategory || (initialChartId ? initialChartId.split(':')[0] : null)
   );
   const [activeGraphIndex, setActiveGraphIndex] = useState(null);
-  const [graphsData, setGraphsData] = useState({});
-  const [allGraphs, setAllGraphs] = useState([]);
+  // Charts are derived once from the static CATEGORY_DATA, not stored in state.
+  const graphsData = useMemo(() => {
+    const organizedData = {};
+    Object.entries(CATEGORY_DATA).forEach(([category, data]) => {
+      organizedData[category] = data.map((chart) => ({
+        id: `${category}:${chart.title}`,
+        title: chart.title,
+        description: chart.description,
+        parameterDetails: chart.parameterDetails,
+        graphData: chart.graphData,
+        category,
+        parameters: extractParameters(chart.parameterDetails),
+      }));
+    });
+    return organizedData;
+  }, []);
+  const allGraphs = useMemo(() => Object.values(graphsData).flat(), [graphsData]);
   const [searchTerm, setSearchTerm] = useState("");
-  const [searchResults, setSearchResults] = useState([]);
   const [parametersDropdownOpen, setParametersDropdownOpen] = useState(false);
   const [selectedParameters, setSelectedParameters] = useState(initialParameters);
   // remember last selection
@@ -155,6 +169,8 @@ export default function GovernanceCharts({
     // only if URL has realy changed
     if (urlSignature !== lastUrlSigRef.current) {
       if (initialCategory !== activeCategory) {
+        // Sync internal selection to external URL changes (back/forward).
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setActiveCategory(initialCategory || null);
         setActiveGraphIndex(null);
         setActiveChartId(null);
@@ -174,34 +190,9 @@ export default function GovernanceCharts({
   }, [urlSignature, initialCategory, initialParameters]);
 
 
-  // Initialize charts data
   useEffect(() => {
-    const organizedData = {};
-    let allGraphsList = [];
-
-    Object.entries(CATEGORY_DATA).forEach(([category, data]) => {
-      const categoryGraphs = data.map((chart) => {
-        const parameters = extractParameters(chart.parameterDetails);
-        const chartId = `${category}:${chart.title}`;
-        return {
-          id: chartId,
-          title: chart.title,
-          description: chart.description,
-          parameterDetails: chart.parameterDetails,
-          graphData: chart.graphData,
-          category: category,
-          parameters: parameters,
-        };
-      });
-      organizedData[category] = categoryGraphs;
-      allGraphsList = [...allGraphsList, ...categoryGraphs];
-    });
-
-    setGraphsData(organizedData);
-    setAllGraphs(allGraphsList);
-  }, []);
-
-  useEffect(() => {
+    // Reset the selected graph whenever the active category changes.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveGraphIndex(null);
   }, [activeCategory]);
 
@@ -213,15 +204,14 @@ export default function GovernanceCharts({
   }, []);
 
   // Filter charts based on search term and parameters
-  useEffect(() => {
-    let results = [];
+  const searchResults = useMemo(() => {
+    if (!searchTerm && selectedParameters.length === 0) return [];
 
-    if (searchTerm || selectedParameters.length > 0) {
-      const graphsToFilter = activeCategory
-        ? graphsData[activeCategory] || []
-        : allGraphs;
+    const graphsToFilter = activeCategory
+      ? graphsData[activeCategory] || []
+      : allGraphs;
 
-      results = graphsToFilter.filter((graph) => {
+    return graphsToFilter.filter((graph) => {
         const textMatch =
           !searchTerm ||
           graph.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -241,9 +231,6 @@ export default function GovernanceCharts({
 
         return textMatch && paramMatch;
       });
-    }
-
-    setSearchResults(results);
   }, [searchTerm, selectedParameters, allGraphs, activeCategory, graphsData]);
 
   // Close dropdown when clicking outside

--- a/src/components/GovernanceGraphs/index.js
+++ b/src/components/GovernanceGraphs/index.js
@@ -271,7 +271,7 @@ export default function FlowChart({
           });
       }, 500);
     },
-    [reactFlowInstance, title, isDarkMode]
+    [reactFlowInstance, title, isDarkMode, downloading]
   );
 
   // Initialize the ReactFlow instance

--- a/src/components/GovernancePathsSection/index.js
+++ b/src/components/GovernancePathsSection/index.js
@@ -75,6 +75,8 @@ export default function GovernancePathsSection() {
     const hash = window.location.hash.replace(/^#/, "").toLowerCase();
     const idx = HASH_TO_INDEX[hash];
     if (idx == null) return;
+    // Select the section addressed by the URL hash on mount (client-only).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelectedIndex(idx);
     wrapperRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, []);

--- a/src/components/GovernancePulse/index.js
+++ b/src/components/GovernancePulse/index.js
@@ -12,22 +12,21 @@ function useCountUp(target, duration = ANIMATION_DURATION) {
   const frameRef = useRef(null);
 
   useEffect(() => {
-    if (target == null || target === 0) {
-      setValue(target ?? 0);
-      return;
-    }
-
+    // Animate towards the resolved target. Driving the first setValue from the
+    // rAF callback (instead of a synchronous early-return setState) keeps the
+    // zero/null case visually identical while avoiding a cascading render.
+    const end = target ?? 0;
     const start = performance.now();
     const animate = (now) => {
       const elapsed = now - start;
       const progress = Math.min(elapsed / duration, 1);
       // easeOutCubic
       const eased = 1 - Math.pow(1 - progress, 3);
-      setValue(eased * target);
+      setValue(eased * end);
       if (progress < 1) {
         frameRef.current = requestAnimationFrame(animate);
       } else {
-        setValue(target);
+        setValue(end);
       }
     };
     frameRef.current = requestAnimationFrame(animate);
@@ -59,16 +58,13 @@ function formatAdaValue(value) {
 export default function GovernancePulse() {
   const { siteConfig: { customFields } } = useDocusaurusContext();
   const API_URL = customFields.CARDANO_ORG_API_URL;
-  const apiRef = useRef(null);
-  if (!apiRef.current && API_URL) apiRef.current = makeApiClient(API_URL);
 
   const [data, setData] = useState(null);
   const [error, setError] = useState(false);
 
   useEffect(() => {
     if (!API_URL) return;
-    const api = apiRef.current;
-    if (!api) return;
+    const api = makeApiClient(API_URL);
 
     async function fetchData() {
       try {

--- a/src/components/Layout/InsightsEpochNav/index.js
+++ b/src/components/Layout/InsightsEpochNav/index.js
@@ -32,7 +32,11 @@ export default function InsightsEpochNav({
   const [input, setInput] = useState(String(displayedEpoch));
   const inputRef = useRef(null);
 
-  useEffect(() => { setInput(String(displayedEpoch)); }, [displayedEpoch]);
+  useEffect(() => {
+    // Keep the editable input in sync when the displayed epoch prop changes.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setInput(String(displayedEpoch));
+  }, [displayedEpoch]);
 
   useEffect(() => {
     if (isJumpMode && inputRef.current) setTimeout(() => inputRef.current?.focus(), 50);

--- a/src/components/Layout/StepCard/index.js
+++ b/src/components/Layout/StepCard/index.js
@@ -54,11 +54,13 @@ export default function StepCard({ steps = [], initialStep = 1, onStepChange, wa
         console.error('Failed to save step to localStorage', e);
       }
     }
-  }, [currentStep]);
+  }, [currentStep, storageKey]);
 
   // Auto-check the checkbox when wallet is connected on step 4
   React.useEffect(() => {
     if (currentStep === 4 && walletConnected) {
+      // Auto-check once the wallet connects on step 4.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setChecked(true);
     }
   }, [currentStep, walletConnected]);

--- a/src/components/Layout/WelcomeHero/index.js
+++ b/src/components/Layout/WelcomeHero/index.js
@@ -25,6 +25,8 @@ function WelcomeHero({ title, description }) {
     const gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
 
     if (isOldDevice || !gl) {
+      // Disable WebGL after client-only capability detection.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setWebglSupported(false);
       return;
     }

--- a/src/components/Stablecoins/useStablecoinLiveData.js
+++ b/src/components/Stablecoins/useStablecoinLiveData.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { makeApiClient } from "@site/src/utils/insights/api";
 import {
@@ -41,10 +41,10 @@ export default function useStablecoinLiveData() {
   const koiosUrl = customFields.CARDANO_ORG_API_URL;
   const cgUrl = customFields.CARDANO_ORG_CG_API_URL;
 
-  const koiosRef = useRef(null);
-  const cgRef = useRef(null);
-  if (!koiosRef.current && koiosUrl) koiosRef.current = makeApiClient(koiosUrl);
-  if (!cgRef.current && cgUrl) cgRef.current = makeApiClient(cgUrl);
+  // Create the API clients once via lazy initializers instead of writing refs
+  // during render.
+  const [koios] = useState(() => (koiosUrl ? makeApiClient(koiosUrl) : null));
+  const [cg] = useState(() => (cgUrl ? makeApiClient(cgUrl) : null));
 
   const [pricesById, setPricesById] = useState(null);
   const [pricesStatus, setPricesStatus] = useState("loading");
@@ -53,12 +53,12 @@ export default function useStablecoinLiveData() {
 
   useEffect(() => {
     if (!koiosUrl || !cgUrl) {
+      // Missing API config: flag both as errored. One-shot, not a render loop.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPricesStatus("error");
       setFeeStatus("error");
       return undefined;
     }
-    const koios = koiosRef.current;
-    const cg = cgRef.current;
     if (!koios || !cg) {
       setPricesStatus("error");
       setFeeStatus("error");
@@ -101,7 +101,6 @@ export default function useStablecoinLiveData() {
         setPricesStatus("ready");
       } catch (err) {
         if (cancelled) return;
-        // eslint-disable-next-line no-console
         console.error("useStablecoinLiveData: prices fetch failed", err);
         setPricesStatus("error");
       }
@@ -139,7 +138,6 @@ export default function useStablecoinLiveData() {
         }
       } catch (err) {
         if (cancelled) return;
-        // eslint-disable-next-line no-console
         console.error("useStablecoinLiveData: fee fetch failed", err);
         setFeeStatus("error");
       }
@@ -150,7 +148,7 @@ export default function useStablecoinLiveData() {
     return () => {
       cancelled = true;
     };
-  }, [koiosUrl, cgUrl]);
+  }, [koiosUrl, cgUrl, koios, cg]);
 
   return { pricesById, pricesStatus, avgFeeAda, feeStatus };
 }
@@ -189,7 +187,6 @@ async function fetchKoiosMarketCaps(koios, currentPrices) {
     );
     rows = Array.isArray(res?.data) ? res.data : [];
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error("useStablecoinLiveData: Koios asset_info failed", err);
     return {};
   }

--- a/src/components/TermExplainer/index.js
+++ b/src/components/TermExplainer/index.js
@@ -12,6 +12,8 @@ export default function TermExplainer({ category }) {
     if (category && termsData.categories[category]) {
       const categoryTerms = termsData.categories[category];
       const randomTerms = categoryTerms.sort(() => 0.5 - Math.random()).slice(0, 2);
+      // Pick random terms on the client only to avoid an SSR hydration mismatch.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setTerms(randomTerms);
     }
   }, [category]);

--- a/src/components/showcase/ShowcaseFilterToggle/index.js
+++ b/src/components/showcase/ShowcaseFilterToggle/index.js
@@ -26,6 +26,8 @@ export default function ShowcaseFilterToggle() {
   const [operator, setOperator] = useState(false);
 
   useEffect(() => {
+    // Sync the toggle from the URL; it is also user-togglable, so it stays state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setOperator(readOperator(location.search) === "OR");
   }, [location]);
 
@@ -56,7 +58,6 @@ export default function ShowcaseFilterToggle() {
         }}
         checked={!operator}
       />
-      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label htmlFor={id} className={clsx(styles.checkboxLabel, "shadow--md")}>
         <span className={styles.checkboxLabelOr}>OR</span>
         <span className={styles.checkboxLabelAnd}>AND</span>

--- a/src/components/showcase/ShowcaseLatestToggle/index.js
+++ b/src/components/showcase/ShowcaseLatestToggle/index.js
@@ -26,6 +26,8 @@ export default function ShowcaseLatestToggle() {
   const [operator, setOperator] = useState(false);
 
   useEffect(() => {
+    // Sync the toggle from the URL; it is also user-togglable, so it stays state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setOperator(readLatestOperator(location.search) === "LAST");
   }, [location]);
 
@@ -56,7 +58,6 @@ export default function ShowcaseLatestToggle() {
         }}
         checked={!operator}
       />
-      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label htmlFor={id} className={clsx(styles.checkboxLabel, "shadow--md")}>
         <span className={styles.checkboxLabelOr}>LAST</span>
         <span className={styles.checkboxLabelALL}>ALL</span>

--- a/src/components/showcase/ShowcaseTooltip/index.js
+++ b/src/components/showcase/ShowcaseTooltip/index.js
@@ -48,6 +48,8 @@
    const timeout = useRef(null);
    const tooltipId = `${id}_tooltip`;
  
+   // Resolve the portal container from the DOM (client-only).
+   /* eslint-disable react-hooks/set-state-in-effect */
    useEffect(() => {
      if (anchorEl) {
        if (typeof anchorEl === 'string') {
@@ -59,6 +61,7 @@
        setContainer(document.body);
      }
    }, [container, anchorEl]);
+   /* eslint-enable react-hooks/set-state-in-effect */
  
    useEffect(() => {
      const showEvents = ['mouseenter', 'focus'];

--- a/src/pages/apps/index.js
+++ b/src/pages/apps/index.js
@@ -227,6 +227,8 @@ function useFilteredProjects() {
   const [sortOption, setSortOption] = useState(DEFAULT_SORT);
 
   useEffect(() => {
+    // Sync filters from the URL; all of these are also user-controlled.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelectedTags(readSearchTags(location.search));
     setOperator(readOperator(location.search));
     setLatest(readLatestOperator(location.search));
@@ -278,6 +280,8 @@ function SearchBar() {
 
   useEffect(() => {
     const newValue = readSearchName(location.search) || "";
+    // Sync the search box from the URL; it is also user-editable.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setValue(newValue);
     if (
       location.state?.isSearch &&
@@ -288,14 +292,15 @@ function SearchBar() {
     }
   }, [location]);
 
-  const debouncedHistoryPush = useCallback(
-    _debounce((newSearchString) => {
-      history.push({
-        ...location,
-        search: newSearchString,
-        state: { isSearch: true },
-      });
-    }, 300),
+  const debouncedHistoryPush = useMemo(
+    () =>
+      _debounce((newSearchString) => {
+        history.push({
+          ...location,
+          search: newSearchString,
+          state: { isSearch: true },
+        });
+      }, 300),
     [history, location]
   );
 

--- a/src/pages/constitution.js
+++ b/src/pages/constitution.js
@@ -55,6 +55,8 @@ const ConstitutionList = () => {
 
   useEffect(() => {
     if (!API_URL || !API_KEY) {
+      // Surface the missing-config error; this branch runs once, not in a loop.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setError('API URL or API Key is missing!');
       return;
     }

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -130,7 +130,7 @@ export default function Home() {
           <select
             className={clsx("selectField", "selectFieldArrow")}
             onChange={handleTopicChange}
-            value={selectedTopic}
+            value={selectedTopic ?? ""}
           >
             <option value="">{translate({id: 'contact.select.placeholder', message: 'not yet decided (please select)'})}</option>
             <option value="iog">

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -104,6 +104,8 @@ export default function Home() {
     const queryParams = new URLSearchParams(location.search);
     const type = queryParams.get("topic");
     if (type) {
+      // Preselect the topic from the URL query; it is also user-selectable.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedTopic(type);
     }
   }, [location]); // Dependency array, re-run effect if location changes

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -127,6 +127,7 @@ export default function Home() {
   const [pastPage, setPastPage] = useState(1);
 
   const { upcomingEvents, pastEvents } = useMemo(() => {
+    const todayUTC = new Date(todayTimestamp);
     const sortedEvents = [...events].sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
 
     const upcoming = sortedEvents.filter((event) => new Date(event.startDate) >= todayUTC);
@@ -146,6 +147,8 @@ export default function Home() {
   useEffect(() => {
     if (upcomingTotalPages === 0) {
       if (upcomingPage !== 1) {
+        // Clamp pagination when the upcoming list shrinks to empty.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setUpcomingPage(1);
       }
       return;
@@ -159,6 +162,8 @@ export default function Home() {
   useEffect(() => {
     if (pastTotalPages === 0) {
       if (pastPage !== 1) {
+        // Clamp pagination when the past list shrinks to empty.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setPastPage(1);
       }
       return;

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -150,6 +150,8 @@ function GlossarySearch({
   }, [normalizedQuery, terms]);
 
   useEffect(() => {
+    // Reset the highlighted result when the query changes.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setHighlight(0);
   }, [normalizedQuery]);
 
@@ -440,7 +442,8 @@ export default function GlossaryIndex() {
   // Null-safe in case the plugin failed to register; the page still renders an
   // empty index instead of crashing.
   const glossaryData = usePluginData('glossary-routes') || {};
-  const terms = glossaryData.terms || [];
+  // Memoize so the fallback [] keeps a stable reference across renders.
+  const terms = useMemo(() => glossaryData.terms || [], [glossaryData.terms]);
   const history = useHistory();
   const location = useLocation();
   const { siteConfig } = useDocusaurusContext();
@@ -456,6 +459,8 @@ export default function GlossaryIndex() {
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
+    // Sync query and category from the URL; both are also user-editable.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setQuery(params.get('q') || '');
     setActiveCategory(params.get('category') || null);
   }, [location.search]);

--- a/src/pages/insights/index.js
+++ b/src/pages/insights/index.js
@@ -127,7 +127,11 @@ export default function InsightsIndex() {
     });
   }, [allItems, query, activeTags]);
 
-  useEffect(() => { setPage(0); }, [query, activeTags]);
+  useEffect(() => {
+    // Reset to the first page when the query or active tags change.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPage(0);
+  }, [query, activeTags]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PER_PAGE));
   const start = page * PER_PAGE;

--- a/src/pages/insights/supply/index.js
+++ b/src/pages/insights/supply/index.js
@@ -147,8 +147,9 @@ function DonutChartEcharts({ chartData }) {
 function PageContent() {
   const { siteConfig: { customFields } } = useDocusaurusContext();
   const API_URL = customFields.CARDANO_ORG_API_URL;
-  const apiRef = useRef(null);
-  if (!apiRef.current && API_URL) apiRef.current = makeApiClient(API_URL);
+  // Create the API client once via a lazy initializer instead of writing a
+  // ref during render.
+  const [apiClient] = useState(() => (API_URL ? makeApiClient(API_URL) : null));
   
   const location = useLocation();
   const initialUrlEpoch = new URLSearchParams(location.search).get('epoch');
@@ -179,7 +180,7 @@ function PageContent() {
     }
     setIsLoading(true);
     setErrorInfo(null);
-    const api = apiRef.current ?? makeApiClient(API_URL);
+    const api = apiClient ?? makeApiClient(API_URL);
 	
     try {
       // parse & validate current URL epoch
@@ -271,6 +272,8 @@ function PageContent() {
 
   // first mount: load (uses initialUrlEpoch via window.location since we read inside fetchData)
   useEffect(() => {
+    // Trigger the initial data fetch on mount.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [API_URL, initialUrlEpoch]); // initialUrlEpoch just to fire once with router-provided query

--- a/src/pages/insights/supply/summary.js
+++ b/src/pages/insights/supply/summary.js
@@ -184,7 +184,7 @@ function LineChartEcharts({ chartData, title, yAxisName = 'ada', hasSecondYAxis 
         yAxisIndex: s.yAxisIndex || 0
       }))
     };
-  }, [chartData, isDark, yAxisName, hasSecondYAxis]);
+  }, [chartData, isDark, yAxisName, hasSecondYAxis, yAxisMin, yAxisMax]);
 
   useEffect(() => {
     if (!chartInstanceRef.current || !option) return;
@@ -218,8 +218,9 @@ function LineChartEcharts({ chartData, title, yAxisName = 'ada', hasSecondYAxis 
 function PageContent() {
   const { siteConfig: { customFields } } = useDocusaurusContext();
   const API_URL = customFields.CARDANO_ORG_API_URL;
-  const apiRef = useRef(null);
-  if (!apiRef.current && API_URL) apiRef.current = makeApiClient(API_URL);
+  // Create the API client once via a lazy initializer instead of writing a
+  // ref during render.
+  const [apiClient] = useState(() => (API_URL ? makeApiClient(API_URL) : null));
   
   const location = useLocation();
   
@@ -230,7 +231,6 @@ function PageContent() {
   const [currentEpochNo, setCurrentEpochNo] = useState(null);
   const [startEpoch, setStartEpoch] = useState(MIN_EPOCH + 1);
   const [endEpoch, setEndEpoch] = useState(null);
-  const [epochData, setEpochData] = useState([]); // Filtered data for selected range
   const [allEpochData, setAllEpochData] = useState({}); // All loaded epoch data (cache)
   const [allWithdrawalsData, setAllWithdrawalsData] = useState({}); // All withdrawals (cache)
   const [allWithdrawalsDetails, setAllWithdrawalsDetails] = useState([]); // Individual withdrawal records
@@ -253,7 +253,7 @@ function PageContent() {
     const fetchCurrentEpoch = async () => {
       if (!API_URL) return;
       try {
-        const api = apiRef.current ?? makeApiClient(API_URL);
+        const api = apiClient ?? makeApiClient(API_URL);
         const tipRes = await api.get('/tip');
         const tipEpoch = tipRes.data?.[0]?.epoch_no;
         setCurrentEpochNo(tipEpoch);
@@ -297,7 +297,7 @@ function PageContent() {
       }
     };
     fetchCurrentEpoch();
-  }, [API_URL]);
+  }, [API_URL, apiClient]);
 
   // Fetch ALL epoch data once on initial load
   const fetchAllEpochData = async () => {
@@ -306,7 +306,7 @@ function PageContent() {
     setIsLoading(true);
     setIsInitialLoad(true);
     setErrorInfo(null);
-    const api = apiRef.current ?? makeApiClient(API_URL);
+    const api = apiClient ?? makeApiClient(API_URL);
     
     try {
       const minEpoch = MIN_EPOCH + 1;
@@ -420,14 +420,14 @@ function PageContent() {
     return filtered.sort((a, b) => a.epoch - b.epoch);
   }, [startEpoch, endEpoch, allEpochData]);
 
-  // Update filtered data when filter changes
-  useEffect(() => {
-    setEpochData(filterEpochData);
-  }, [filterEpochData]);
+  // Filtered data for the selected range; derived directly from the memo.
+  const epochData = filterEpochData;
 
   // Fetch all data on initial load (only once)
   useEffect(() => {
     if (currentEpochNo && Object.keys(allEpochData).length === 0 && !isLoading && isInitialLoad) {
+      // Trigger the one-time full data fetch once the current epoch is known.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       fetchAllEpochData();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -612,7 +612,7 @@ function PageContent() {
     }
     
     return { first, last, delta, percentChange, totalWithdrawals, totalAdditions };
-  }, [epochData, withdrawalsData, allWithdrawalsData]);
+  }, [epochData, allWithdrawalsData]);
 
   const depositsStats = useMemo(() => {
     if (!epochData.length) return null;
@@ -785,7 +785,6 @@ function PageContent() {
                     cursor: 'pointer',
                     zIndex: 4
                   }}
-                  // eslint-disable-next-line jsx-a11y/no-static-element-interactions
                   onMouseDown={(e) => {
                     if (!sliderContainerRef.current) return;
                     const containerRect = sliderContainerRef.current.getBoundingClientRect();
@@ -836,7 +835,6 @@ function PageContent() {
                     cursor: 'pointer',
                     zIndex: 4
                   }}
-                  // eslint-disable-next-line jsx-a11y/no-static-element-interactions
                   onMouseDown={(e) => {
                     if (!sliderContainerRef.current) return;
                     const containerRect = sliderContainerRef.current.getBoundingClientRect();

--- a/src/pages/insights/transactions/index.js
+++ b/src/pages/insights/transactions/index.js
@@ -227,7 +227,7 @@ function LineChartEcharts({ chartData, title, yAxisName = '', hasSecondYAxis = f
         };
       })
     };
-  }, [chartData, isDark, yAxisName, hasSecondYAxis, currentEpoch]);
+  }, [chartData, isDark, yAxisName, hasSecondYAxis, currentEpoch, yAxisMin, yAxisMax]);
 
   useEffect(() => {
     if (!chartInstanceRef.current || !option) return;
@@ -261,8 +261,9 @@ function LineChartEcharts({ chartData, title, yAxisName = '', hasSecondYAxis = f
 function PageContent() {
   const { siteConfig: { customFields } } = useDocusaurusContext();
   const API_URL = customFields.CARDANO_ORG_API_URL;
-  const apiRef = useRef(null);
-  if (!apiRef.current && API_URL) apiRef.current = makeApiClient(API_URL);
+  // Create the API client once via a lazy initializer instead of writing a
+  // ref during render.
+  const [apiClient] = useState(() => (API_URL ? makeApiClient(API_URL) : null));
 
   const location = useLocation();
 
@@ -273,7 +274,6 @@ function PageContent() {
   const [currentEpochNo, setCurrentEpochNo] = useState(null);
   const [startEpoch, setStartEpoch] = useState(MIN_EPOCH + 1);
   const [endEpoch, setEndEpoch] = useState(null);
-  const [epochData, setEpochData] = useState([]); // Filtered data for selected range
   const [allEpochData, setAllEpochData] = useState({}); // All loaded epoch data (cache)
   const [sliderStart, setSliderStart] = useState(0);
   const [sliderEnd, setSliderEnd] = useState(100);
@@ -294,7 +294,7 @@ function PageContent() {
     const fetchCurrentEpoch = async () => {
       if (!API_URL) return;
       try {
-        const api = apiRef.current ?? makeApiClient(API_URL);
+        const api = apiClient ?? makeApiClient(API_URL);
         const tipRes = await api.get('/tip');
         const tipEpoch = tipRes.data?.[0]?.epoch_no;
         setCurrentEpochNo(tipEpoch);
@@ -338,7 +338,7 @@ function PageContent() {
       }
     };
     fetchCurrentEpoch();
-  }, [API_URL]);
+  }, [API_URL, apiClient]);
 
   // Fetch ALL epoch data once on initial load
   const fetchAllEpochData = async () => {
@@ -347,7 +347,7 @@ function PageContent() {
     setIsLoading(true);
     setIsInitialLoad(true);
     setErrorInfo(null);
-    const api = apiRef.current ?? makeApiClient(API_URL);
+    const api = apiClient ?? makeApiClient(API_URL);
 
     try {
       const minEpoch = MIN_EPOCH + 1;
@@ -424,14 +424,14 @@ function PageContent() {
     return filtered.sort((a, b) => a.epoch - b.epoch);
   }, [startEpoch, endEpoch, allEpochData]);
 
-  // Update filtered data when filter changes
-  useEffect(() => {
-    setEpochData(filterEpochData);
-  }, [filterEpochData]);
+  // Filtered data for the selected range; derived directly from the memo.
+  const epochData = filterEpochData;
 
   // Fetch all data on initial load (only once)
   useEffect(() => {
     if (currentEpochNo && Object.keys(allEpochData).length === 0 && !isLoading && isInitialLoad) {
+      // Trigger the one-time full data fetch once the current epoch is known.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       fetchAllEpochData();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -726,7 +726,6 @@ function PageContent() {
                     cursor: 'pointer',
                     zIndex: 4
                   }}
-                  // eslint-disable-next-line jsx-a11y/no-static-element-interactions
                   onMouseDown={(e) => {
                     if (!sliderContainerRef.current) return;
                     const containerRect = sliderContainerRef.current.getBoundingClientRect();
@@ -777,7 +776,6 @@ function PageContent() {
                     cursor: 'pointer',
                     zIndex: 4
                   }}
-                  // eslint-disable-next-line jsx-a11y/no-static-element-interactions
                   onMouseDown={(e) => {
                     if (!sliderContainerRef.current) return;
                     const containerRect = sliderContainerRef.current.getBoundingClientRect();

--- a/src/pages/wallets/index.js
+++ b/src/pages/wallets/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect } from "react";
+import React, { useMemo, useCallback } from "react";
 import Layout from "@theme/Layout";
 import {translate} from '@docusaurus/Translate';
 import { useHistory, useLocation } from "@docusaurus/router";
@@ -58,19 +58,8 @@ function useWalletFilters() {
   const location = useLocation();
   const { push } = useHistory();
 
-  const [state, setState] = useState({
-    mode: null,
-    beginnerPlatform: null,
-    platforms: [],
-    features: [],
-    custody: null,
-    type: null,
-    openSource: null,
-  });
-
-  useEffect(() => {
-    setState(readParams(location.search));
-  }, [location]);
+  // Filter state is derived from the URL, the single source of truth.
+  const state = useMemo(() => readParams(location.search), [location.search]);
 
   const updateState = useCallback(
     (newState) => {

--- a/src/utils/appStats.js
+++ b/src/utils/appStats.js
@@ -22,7 +22,6 @@ export const STATS_GENERATED_AT = appStatsData.metadata?.generated ?? null;
 if (process.env.NODE_ENV !== "production") {
   Object.entries(Categories).forEach(([key, def]) => {
     if (typeof def.trackable !== "boolean") {
-      // eslint-disable-next-line no-console
       console.warn(`[appStats] Category "${key}" is missing the 'trackable' boolean field`);
     }
   });


### PR DESCRIPTION
- CI now runs the linter on every pull request, so accessibility violations block merges instead of slipping through unnoticed
- Resolved all outstanding React Hooks lint warnings across the site, with no behavior changes
- Removed stale lint-suppression comments that no longer applied
- Fixed a console warning on the contact page when no topic is preselected