### PR TITLE
chore: build only default locale in PR CI check

### DIFF
--- a/.github/workflows/yarn-build.yml
+++ b/.github/workflows/yarn-build.yml
@@ -19,4 +19,6 @@ jobs:
       - run: corepack enable
       - run: yarn install --frozen-lockfile
       - run: yarn lint
-      - run: yarn build
+      # PR check only verifies the build compiles. Build the default locale
+      # only (~5x faster); all locales are built on the production deploy.
+      - run: yarn build --locale en


### PR DESCRIPTION
PR build verification now builds only the default locale instead of all five, cutting CI build time roughly 5x. All locales are still built on the production deploy.