### PR TITLE
feat: add Conway treasury donation tool

### DIFF
--- a/glossary/treasury-donation.md
+++ b/glossary/treasury-donation.md
@@ -1,0 +1,13 @@
+---
+title: Treasury Donation
+slug: treasury-donation
+short: A transaction that sends ada directly into the Cardano treasury, increasing the funds the community can later allocate.
+category: governance
+link: /governance/treasury
+aliases: ["Treasury Donate", "Donate to Treasury"]
+related: [treasury, treasury-withdrawal, governance-action, conway-era]
+---
+
+A treasury donation is a Conway-era transaction that adds ada straight to the Cardano treasury instead of paying it to a recipient address. The amount is recorded in the transaction's `donation` field, so the funds leave the sender's wallet and join the treasury pot that the community later allocates through on-chain governance.
+
+Anyone can make one from a CIP-30 wallet. You can build, sign, and submit a treasury donation directly on cardano.org: [Donate to the treasury](/governance/treasury).

--- a/src/components/TreasuryDonate/index.js
+++ b/src/components/TreasuryDonate/index.js
@@ -1,0 +1,406 @@
+import React, { useEffect, useState, useCallback } from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { translate } from "@docusaurus/Translate";
+import { makeApiClient } from "@site/src/utils/insights/api";
+import {
+  detectWallets,
+  enableWallet,
+  firstAddressBech32,
+  donateToTreasury,
+} from "@site/src/utils/cardano/wallet";
+import styles from "./styles.module.css";
+
+const EXPECTED_NETWORK_ID = 1; // mainnet
+const EXPLORER_TX_BASE = "https://explorer.cardano.org/transaction/";
+const DEFAULT_AMOUNT_ADA = "10";
+const LOVELACE_PER_ADA = 1_000_000n;
+
+// Parse a user-entered ADA string into lovelace, or null if it isn't a
+// well-formed positive decimal with at most 6 fractional digits.
+function parseAdaToLovelace(value) {
+  const trimmed = value.trim();
+  if (!/^\d+(\.\d{1,6})?$/.test(trimmed)) return null;
+  const [whole, fractional = ""] = trimmed.split(".");
+  const paddedFraction = `${fractional}000000`.slice(0, 6);
+  const lovelace = BigInt(whole) * LOVELACE_PER_ADA + BigInt(paddedFraction);
+  return lovelace > 0n ? lovelace : null;
+}
+
+function formatAda(lovelace) {
+  const ada = Number(lovelace) / 1_000_000;
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(2)}B ada`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(2)}M ada`;
+  return `${Math.round(ada).toLocaleString()} ada`;
+}
+
+function shortAddress(addr) {
+  if (!addr) return "";
+  return `${addr.slice(0, 12)}…${addr.slice(-8)}`;
+}
+
+function stringifyError(err) {
+  if (!err) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message || err.toString();
+  const parts = [];
+  if (err.message) parts.push(String(err.message));
+  if (err.info) parts.push(String(err.info));
+  if (err.code != null) parts.push(`code=${err.code}`);
+  if (!parts.length) {
+    try { return JSON.stringify(err); } catch { return String(err); }
+  }
+  return parts.join(" · ");
+}
+
+function classifyError(err) {
+  const msg = stringifyError(err);
+  // CIP-30 signTx throws code 2 for UserDeclined; only treat as a cancel when
+  // the message corroborates it so we don't swallow genuine failures.
+  if (/user\s*(declined|rejected|cancel)|declined\s*by\s*user|rejected\s*by\s*user/i.test(msg)) {
+    return "userCancelled";
+  }
+  return "generic";
+}
+
+// Read the current treasury balance from Koios; /totals lists the current epoch first.
+async function fetchLatestTreasury(api) {
+  const res = await api.get("/totals?limit=1");
+  const value = res.data?.[0]?.treasury;
+  return value ? BigInt(value) : null;
+}
+
+function WalletPicker({ onConnect, busy }) {
+  const [available, setAvailable] = useState([]);
+  const [pickerError, setPickerError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    detectWallets()
+      .then((wallets) => {
+        if (!cancelled) setAvailable(wallets);
+      })
+      .catch((err) => {
+        if (!cancelled) setPickerError(String(err?.message || err));
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const connect = async (walletId, displayName) => {
+    try {
+      const instance = await enableWallet(walletId);
+      const [address, networkId] = await Promise.all([
+        firstAddressBech32(instance),
+        instance.getNetworkId(),
+      ]);
+      onConnect({ instance, name: displayName, address, networkId });
+    } catch (err) {
+      if (classifyError(err) !== "userCancelled") {
+        setPickerError(String(err?.message || err));
+      }
+    }
+  };
+
+  if (pickerError) {
+    return (
+      <p className={styles.walletError}>
+        {translate(
+          { id: "governance.treasury.wallet.error", message: "Wallet error: {error}" },
+          { error: pickerError }
+        )}
+      </p>
+    );
+  }
+
+  if (!available.length) {
+    return (
+      <p className={styles.walletEmpty}>
+        {translate({
+          id: "governance.treasury.wallet.empty",
+          message: "No Cardano wallet detected. Install Eternl, Typhon, Begin or another CIP-30 wallet to continue.",
+        })}
+      </p>
+    );
+  }
+
+  return (
+    <div className={styles.walletPicker}>
+      {available.map((w) => {
+        const id = w?.id || w?.name;
+        const name = w?.name || String(w);
+        const icon = w?.icon;
+        return (
+          <button
+            key={id}
+            type="button"
+            disabled={busy}
+            onClick={() => connect(id, name)}
+            className={styles.walletButton}
+          >
+            {icon && <img src={icon} alt="" className={styles.walletIcon} />}
+            <span>{name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function WalletStatus({ wallet, onDisconnect }) {
+  const wrongNetwork = wallet.networkId !== EXPECTED_NETWORK_ID;
+  return (
+    <div className={`${styles.walletStatus} ${wrongNetwork ? styles.walletStatusWarning : ""}`}>
+      <div className={styles.walletStatusLeft}>
+        <span className={styles.walletDot} aria-hidden="true" />
+        <span>
+          {translate(
+            { id: "governance.treasury.wallet.connected", message: "Connected: {name} · {addr}" },
+            { name: wallet.name, addr: shortAddress(wallet.address) }
+          )}
+        </span>
+      </div>
+      <button type="button" onClick={onDisconnect} className={styles.disconnectButton}>
+        {translate({ id: "governance.treasury.wallet.disconnect", message: "Disconnect" })}
+      </button>
+    </div>
+  );
+}
+
+function NetworkWarning() {
+  return (
+    <div className={`${styles.banner} ${styles.bannerWarning}`}>
+      {translate({
+        id: "governance.treasury.networkWarning",
+        message: "Your wallet is on the wrong network. Switch to Mainnet to donate.",
+      })}
+    </div>
+  );
+}
+
+function TxBanner({ state }) {
+  if (state.status === "building") {
+    return (
+      <div className={`${styles.banner} ${styles.bannerInfo}`}>
+        {translate({
+          id: "governance.treasury.tx.building",
+          message: "Building the treasury donation. Please confirm in your wallet…",
+        })}
+      </div>
+    );
+  }
+  if (state.status === "success") {
+    return (
+      <div className={`${styles.banner} ${styles.bannerSuccess}`}>
+        <p style={{ margin: 0 }}>
+          {translate(
+            { id: "governance.treasury.tx.success", message: "Donation of {amount} submitted to the treasury." },
+            { amount: state.amount }
+          )}
+        </p>
+        <a href={EXPLORER_TX_BASE + state.txHash} target="_blank" rel="noopener noreferrer">
+          {translate({ id: "governance.treasury.tx.viewOnExplorer", message: "View on explorer" })}
+        </a>
+      </div>
+    );
+  }
+  if (state.status === "error") {
+    return (
+      <div className={`${styles.banner} ${styles.bannerError}`}>
+        {state.message}
+      </div>
+    );
+  }
+  return null;
+}
+
+export default function TreasuryDonate() {
+  const { siteConfig: { customFields } } = useDocusaurusContext();
+  const API_URL = customFields.CARDANO_ORG_API_URL;
+  const [apiClient] = useState(() => (API_URL ? makeApiClient(API_URL) : null));
+
+  const [wallet, setWallet] = useState(null);
+  const [amount, setAmount] = useState(DEFAULT_AMOUNT_ADA);
+  const [treasury, setTreasury] = useState(undefined); // undefined = loading, null = unavailable
+  const [tx, setTx] = useState({ status: "idle" });
+
+  // Pull the current treasury balance for context. It's also reused as
+  // currentTreasuryValue when building the tx, but the donate button does NOT
+  // wait on this fetch; handleDonate fetches on demand if it isn't ready yet.
+  useEffect(() => {
+    if (!apiClient) return;
+    let cancelled = false;
+    fetchLatestTreasury(apiClient)
+      .then((value) => { if (!cancelled) setTreasury(value); })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("TreasuryDonate: failed to load treasury totals", err);
+        setTreasury(null);
+      });
+    return () => { cancelled = true; };
+  }, [apiClient]);
+
+  const wrongNetwork = wallet && wallet.networkId !== EXPECTED_NETWORK_ID;
+  const txBusy = tx.status === "building";
+  const parsedAmount = parseAdaToLovelace(amount);
+  const amountValid = parsedAmount !== null;
+  const canDonate = !!wallet && !wrongNetwork && !txBusy && amountValid;
+
+  // Explain why the button is disabled, so it never looks mysteriously greyed out.
+  const disabledReason = !wallet
+    ? translate({ id: "governance.treasury.disabled.wallet", message: "Connect a wallet above to donate." })
+    : wrongNetwork
+      ? translate({ id: "governance.treasury.disabled.network", message: "Switch your wallet to Mainnet to donate." })
+      : !amountValid
+        ? translate({ id: "governance.treasury.disabled.amount", message: "Enter a positive ADA amount (up to 6 decimal places)." })
+        : null;
+
+  const handleDisconnect = useCallback(() => {
+    setWallet(null);
+    setTx({ status: "idle" });
+  }, []);
+
+  const handleDonate = useCallback(async () => {
+    if (!wallet || wrongNetwork || txBusy) return;
+    const lovelace = parseAdaToLovelace(amount);
+    if (lovelace === null) {
+      setTx({
+        status: "error",
+        message: translate({
+          id: "governance.treasury.error.amount",
+          message: "Enter a positive ADA amount (up to 6 decimal places).",
+        }),
+      });
+      return;
+    }
+
+    setTx({ status: "building" });
+    try {
+      // Re-check the network live in case the user switched it after connecting.
+      const liveNetworkId = await wallet.instance.getNetworkId();
+      if (liveNetworkId !== EXPECTED_NETWORK_ID) {
+        throw new Error(translate({
+          id: "governance.treasury.error.wrongNetwork",
+          message: "Wallet is on the wrong network. Switch to Mainnet and try again.",
+        }));
+      }
+      // The background fetch usually has this already; fetch on demand otherwise
+      // so a slow or failed background load never blocks the donation.
+      let currentTreasury = treasury;
+      if (currentTreasury == null) {
+        currentTreasury = await fetchLatestTreasury(apiClient);
+        if (currentTreasury != null) setTreasury(currentTreasury);
+      }
+      if (currentTreasury == null) {
+        throw new Error(translate({
+          id: "governance.treasury.error.treasury",
+          message: "Could not read the current treasury value. Please try again in a moment.",
+        }));
+      }
+      const txHash = await donateToTreasury({
+        api: wallet.instance,
+        amountLovelace: lovelace,
+        currentTreasuryValue: currentTreasury,
+        koiosUrl: API_URL,
+      });
+      setTx({ status: "success", txHash, amount: formatAda(lovelace) });
+    } catch (err) {
+      if (classifyError(err) === "userCancelled") {
+        setTx({ status: "idle" });
+        return;
+      }
+      console.error("TreasuryDonate: donation failed", err);
+      setTx({
+        status: "error",
+        message: translate(
+          { id: "governance.treasury.error.generic", message: "Donation failed: {error}" },
+          { error: stringifyError(err) }
+        ),
+      });
+    }
+  }, [wallet, wrongNetwork, txBusy, amount, treasury, API_URL, apiClient]);
+
+  if (!API_URL) return null;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.intro}>
+        <p className={styles.introCopy}>
+          {translate({
+            id: "governance.treasury.intro",
+            message: "This builds a real Conway treasury donation, not a payment to an address. Your wallet selects the inputs, signs the transaction, and submits it. The ada leaves your wallet and is added directly to the Cardano treasury.",
+          })}
+        </p>
+        <div className={styles.treasuryFact}>
+          <span className={styles.factLabel}>
+            {translate({ id: "governance.treasury.balanceLabel", message: "Current treasury balance" })}
+          </span>
+          <span className={styles.factValue}>
+            {treasury === undefined
+              ? translate({ id: "governance.treasury.balanceLoading", message: "Loading…" })
+              : treasury === null
+                ? translate({ id: "governance.treasury.balanceUnavailable", message: "Unavailable" })
+                : formatAda(treasury)}
+          </span>
+        </div>
+      </div>
+
+      <div className={styles.walletSection}>
+        {wallet ? (
+          <WalletStatus wallet={wallet} onDisconnect={handleDisconnect} />
+        ) : (
+          <>
+            <h3 className={styles.sectionHeading}>
+              {translate({ id: "governance.treasury.wallet.heading", message: "Connect a wallet to donate" })}
+            </h3>
+            <WalletPicker onConnect={setWallet} busy={txBusy} />
+          </>
+        )}
+        {wrongNetwork && <NetworkWarning />}
+      </div>
+
+      <TxBanner state={tx} />
+
+      <div className={styles.donateSection}>
+        <h3 className={styles.sectionHeading}>
+          {translate({ id: "governance.treasury.amount.heading", message: "Donation amount" })}
+        </h3>
+        <div className={styles.donateRow}>
+          <div className={styles.amountField}>
+            <input
+              type="number"
+              min="1"
+              step="0.1"
+              inputMode="decimal"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              className={styles.amountInput}
+              aria-label={translate({
+                id: "governance.treasury.amount.label",
+                message: "Donation amount in ADA",
+              })}
+            />
+            <span className={styles.amountUnit}>ADA</span>
+          </div>
+          <button
+            type="button"
+            className="button button--primary"
+            disabled={!canDonate}
+            onClick={handleDonate}
+          >
+            {txBusy
+              ? translate({ id: "governance.treasury.amount.ctaBusy", message: "Building…" })
+              : translate({ id: "governance.treasury.amount.cta", message: "Donate to treasury" })}
+          </button>
+        </div>
+        {!canDonate && !txBusy && disabledReason && (
+          <p className={styles.donateHint}>{disabledReason}</p>
+        )}
+        <p className={styles.footnote}>
+          {translate({
+            id: "governance.treasury.footnote",
+            message: "Treasury donations are irreversible and must be submitted in the same epoch they are built.",
+          })}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TreasuryDonate/styles.module.css
+++ b/src/components/TreasuryDonate/styles.module.css
@@ -1,0 +1,234 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.intro {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.introCopy {
+  margin: 0;
+  color: var(--ifm-color-emphasis-800);
+  line-height: 1.55;
+}
+
+.treasuryFact {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  align-self: flex-start;
+  padding: 0.75rem 1rem;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 10px;
+}
+
+.factLabel {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.factValue {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-900);
+}
+
+.sectionHeading {
+  font-size: 1.1rem;
+  margin: 0 0 0.75rem 0;
+  color: var(--ifm-color-emphasis-900);
+}
+
+.walletSection,
+.donateSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.donateRow {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+
+.amountField {
+  display: flex;
+  align-items: center;
+  flex: 1 1 240px;
+  min-width: 0;
+  border: 1px solid var(--ifm-color-emphasis-400);
+  border-radius: 8px;
+  background: white;
+  padding-right: 0.85rem;
+}
+
+.amountField:focus-within {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 2px rgba(9, 61, 176, 0.15);
+}
+
+.amountInput {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.6rem 0.85rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--ifm-color-emphasis-900);
+}
+
+.amountInput:focus {
+  outline: none;
+}
+
+.amountUnit {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.donateHint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.footnote {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+  line-height: 1.45;
+}
+
+.walletPicker {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.walletButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.9rem;
+  background: white;
+  border: 1px solid var(--ifm-color-emphasis-400);
+  border-radius: 999px;
+  cursor: pointer;
+  color: var(--ifm-color-emphasis-900);
+  text-transform: capitalize;
+}
+
+.walletButton:hover:not(:disabled) {
+  border-color: var(--ifm-color-primary);
+}
+
+.walletButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.walletIcon {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+}
+
+.walletEmpty,
+.walletError {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.walletError {
+  color: var(--ifm-color-danger);
+}
+
+.walletStatus {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.85rem;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+.walletStatusWarning {
+  background: rgba(255, 193, 7, 0.1);
+}
+
+.walletStatusLeft {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+  word-break: break-all;
+}
+
+.walletDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2ea44f;
+  flex-shrink: 0;
+}
+
+.disconnectButton {
+  background: transparent;
+  border: 1px solid var(--ifm-color-emphasis-400);
+  border-radius: 6px;
+  padding: 0.3rem 0.7rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.disconnectButton:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.banner {
+  padding: 0.85rem 1rem;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.bannerInfo {
+  background: rgba(0, 127, 255, 0.08);
+  color: #093db0;
+}
+
+.bannerSuccess {
+  background: rgba(46, 164, 79, 0.1);
+  color: #1a5d2b;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.bannerError {
+  background: rgba(220, 53, 69, 0.08);
+  color: #842029;
+}
+
+.bannerWarning {
+  background: rgba(255, 193, 7, 0.15);
+  color: #6b5200;
+}

--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -1065,6 +1065,18 @@ export const Showcases = [
     beginnerFriendly: false,
   },
   {
+    title: "Treasury Donation",
+    description:
+      "Connect a CIP-30 wallet and donate ada directly to the Cardano treasury in a single, non-custodial transaction. Hosted on cardano.org.",
+    tagline: "Donate ada to the Cardano treasury",
+    website: "https://cardano.org/governance/treasury",
+    source: null,
+    category: "governance",
+    properties: [],
+    maintainerPick: false,
+    beginnerFriendly: false,
+  },
+  {
     title: "Chang Watch",
     description:
       "Cardano governance dashboard with donut charts and tables that visualize vote distribution, DRep concentration, and governance action outcomes.",

--- a/src/pages/governance/treasury.js
+++ b/src/pages/governance/treasury.js
@@ -1,0 +1,66 @@
+import React, { Suspense, lazy } from "react";
+import Layout from "@theme/Layout";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import SiteHero from "@site/src/components/Layout/SiteHero";
+import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
+import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
+import SpacerBox from "@site/src/components/Layout/SpacerBox";
+import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
+import { translate } from "@docusaurus/Translate";
+
+const TreasuryDonate = lazy(() =>
+  import(/* webpackChunkName: "treasury-donate" */ "@site/src/components/TreasuryDonate")
+);
+
+function TreasuryHero() {
+  return (
+    <SiteHero
+      title={translate({ id: "governance.treasury.hero.title", message: "Donate to the treasury" })}
+      description={translate({
+        id: "governance.treasury.hero.description",
+        message: "Connect your wallet and add ada directly to the Cardano treasury. A real Conway treasury donation, signed and submitted by your wallet, with no recipient address.",
+      })}
+      bannerType="braidBlue"
+    />
+  );
+}
+
+const loadingFallback = (
+  <div style={{ textAlign: "center", padding: "3rem 0" }}>
+    {translate({ id: "governance.treasury.loading", message: "Loading donation tool…" })}
+  </div>
+);
+
+export default function TreasuryPage() {
+  return (
+    <Layout
+      title={translate({ id: "governance.treasury.layout.title", message: "Donate to the Treasury - Cardano Governance" })}
+      description={translate({
+        id: "governance.treasury.layout.description",
+        message: "Make a Conway treasury donation directly from cardano.org. Connect your wallet and add ada to the Cardano treasury in one transaction.",
+      })}
+    >
+      <OpenGraphInfo
+        pageName="governance"
+        title={translate({ id: "governance.treasury.og.title", message: "Donate to the treasury" })}
+        description={translate({
+          id: "governance.treasury.og.description",
+          message: "Connect your wallet and add ada directly to the Cardano treasury in one transaction.",
+        })}
+      />
+      <TreasuryHero />
+      <BackgroundWrapper backgroundType={"zoom"}>
+        <BoundaryBox>
+          <BrowserOnly fallback={loadingFallback}>
+            {() => (
+              <Suspense fallback={loadingFallback}>
+                <TreasuryDonate />
+              </Suspense>
+            )}
+          </BrowserOnly>
+          <SpacerBox size="small" />
+        </BoundaryBox>
+      </BackgroundWrapper>
+    </Layout>
+  );
+}

--- a/src/utils/cardano/wallet.js
+++ b/src/utils/cardano/wallet.js
@@ -160,3 +160,80 @@ export async function delegateVote({ api, target, koiosUrl }) {
   const signedTx = Transaction.addVKeyWitnessesHex(unsignedTx, witnessSet);
   return api.submitTx(signedTx);
 }
+
+// Bech32-encode a decoded output address, tolerating exotic address types.
+function tryAddressBech32(Address, address) {
+  try {
+    return Address.toBech32(address);
+  } catch {
+    return null;
+  }
+}
+
+// Build, sign and submit a Conway treasury donation transaction. The builder
+// has no treasury-donation op, so we pay the amount to ourselves to make coin
+// selection reserve the funds and compute fee/change, then rewrite the body:
+// drop that self-payment output and carry the same lovelace as the Conway
+// donation instead (with currentTreasuryValue, which the ledger requires to
+// match the treasury at submission). Returns the submitted tx hash.
+export async function donateToTreasury({ api, amountLovelace, currentTreasuryValue, koiosUrl }) {
+  const { Client, mainnet, Transaction, Address, Assets } = await loadEvolution();
+
+  const donation = BigInt(amountLovelace);
+  if (donation <= 0n) {
+    throw new Error("Donation amount must be greater than zero.");
+  }
+
+  const ownAddress = await firstAddressBech32(api);
+  if (!ownAddress) {
+    throw new Error("Wallet did not return a usable address.");
+  }
+
+  const client = Client.make(mainnet)
+    .withKoios({ baseUrl: koiosUrl })
+    .withCip30(api);
+  // autoMinUtxo:false keeps the output at exactly `donation` lovelace so the
+  // body rewrite below can match and drop it (a bumped output wouldn't match).
+  const built = await client
+    .newTx()
+    .payToAddress({
+      address: Address.fromBech32(ownAddress),
+      assets: Assets.fromLovelace(donation),
+      autoMinUtxo: false,
+    })
+    .build();
+
+  const tx = await built.toTransaction();
+  const body = tx.body;
+
+  let removed = false;
+  const keptOutputs = [];
+  for (const output of body.outputs) {
+    const assets = output.assets;
+    const isSelfPayment =
+      !removed &&
+      assets != null &&
+      assets.multiAsset === undefined &&
+      assets.lovelace === donation &&
+      tryAddressBech32(Address, output.address) === ownAddress;
+    if (isSelfPayment) {
+      removed = true;
+      continue;
+    }
+    keptOutputs.push(output);
+  }
+  if (!removed) {
+    throw new Error("Could not locate the temporary self-payment output for the treasury donation.");
+  }
+
+  // The SDK's body/output objects are plain mutable instances; mutate in place
+  // rather than reconstructing the tagged classes.
+  body.outputs = keptOutputs;
+  body.currentTreasuryValue = BigInt(currentTreasuryValue);
+  body.donation = donation;
+
+  const unsignedTx = Transaction.toCBORHex(tx);
+  const witnessSet = await api.signTx(unsignedTx, false);
+  const signedTx = Transaction.addVKeyWitnessesHex(unsignedTx, witnessSet);
+  return api.submitTx(signedTx);
+}

--- a/src/utils/cardano/wallet.js
+++ b/src/utils/cardano/wallet.js
@@ -6,9 +6,53 @@
 
 let evolutionPromise;
 
+// The SDK's HTTP layer (@effect/platform) adds tracing headers (traceparent, b3)
+// to every request. They aren't CORS-safelisted, so the browser preflights them
+// and the Koios proxy (which allows only Content-Type) rejects it, breaking all
+// SDK Koios calls with "Failed to fetch". We can't disable propagation on the
+// SDK's internal client, so we strip these headers at global fetch; they carry
+// no client-side meaning, so removing them is safe.
+const TRACING_HEADERS = [
+  "traceparent",
+  "tracestate",
+  "b3",
+  "x-b3-traceid",
+  "x-b3-spanid",
+  "x-b3-sampled",
+  "x-b3-parentspanid",
+];
+let fetchPatched = false;
+
+function stripTracingHeadersFromGlobalFetch() {
+  if (fetchPatched) return;
+  if (typeof globalThis === "undefined" || typeof globalThis.fetch !== "function") return;
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = (input, init) => {
+    try {
+      if (typeof Request !== "undefined" && input instanceof Request) {
+        const headers = new Headers(input.headers);
+        let changed = false;
+        for (const name of TRACING_HEADERS) {
+          if (headers.has(name)) { headers.delete(name); changed = true; }
+        }
+        if (changed) input = new Request(input, { headers });
+      } else if (init && init.headers) {
+        const headers = new Headers(init.headers);
+        for (const name of TRACING_HEADERS) headers.delete(name);
+        init = { ...init, headers };
+      }
+    } catch {
+      // Never let header cleanup break a request; fall through to the original.
+    }
+    return originalFetch(input, init);
+  };
+  fetchPatched = true;
+}
+
 // Memoized dynamic import of the Evolution SDK.
 export function loadEvolution() {
   if (!evolutionPromise) {
+    stripTracingHeadersFromGlobalFetch();
     evolutionPromise = import("@evolution-sdk/evolution");
   }
   return evolutionPromise;


### PR DESCRIPTION
- [x] I have read the Contributing Guidelines.
- [x] I have run yarn build after adding my changes without getting any errors.
- [x] I have not committed any changes to yarn.lock.

Adds a treasury donation tool to cardano.org and fixes a live bug that currently breaks transaction building in the browser.

**What this adds**

  - New page /governance/treasury: connect a CIP-30 wallet and submit a treasury donation.
  - Listed in the Governance tools grid on /governance/, and a new glossary term Treasury Donation at /glossary/treasury-donation that links to the tool.

**What this fixes**

The Evolution SDK's HTTP layer (@effect/platform) adds traceparent/b3 tracing headers to every request. These are not CORS-safelisted, so the browser preflights them and the data.cardano.org Koios proxy (which allows only Content-Type) rejects the preflight, failing every SDK → Koios call with "Failed to fetch". This currently breaks delegation submit on /governance/delegate in production (it dies at getProtocolParameters the moment you click Delegate). The fix strips these tracing headers at the global fetch choke point; they carry no client-side meaning, so removing them is safe.