### PR TITLE
i18n: restore Crowdin translations for all locales

### DIFF
--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -8,55 +8,55 @@
     "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
   },
   "theme.docs.sidebar.expandButtonTitle": {
-    "message": "Expand sidebar",
+    "message": "Seitenleiste ausklappen",
     "description": "The ARIA label and title attribute for expand button of doc sidebar"
   },
   "theme.docs.sidebar.expandButtonAriaLabel": {
-    "message": "Expand sidebar",
+    "message": "Seitenleiste ausklappen",
     "description": "The ARIA label and title attribute for expand button of doc sidebar"
   },
   "theme.ErrorPageContent.title": {
-    "message": "This page crashed.",
+    "message": "Die Seite ist abgestürzt.",
     "description": "The title of the fallback page when the page crashed"
   },
   "theme.blog.archive.title": {
-    "message": "Archive",
+    "message": "Archiv",
     "description": "The page & hero title of the blog archive page"
   },
   "theme.blog.archive.description": {
-    "message": "Archive",
+    "message": "Archiv",
     "description": "The page & hero description of the blog archive page"
   },
   "theme.BackToTopButton.buttonAriaLabel": {
-    "message": "Scroll back to top",
+    "message": "Zurück nach oben scrollen",
     "description": "The ARIA label for the back to top button"
   },
   "theme.blog.paginator.navAriaLabel": {
-    "message": "Blog list page navigation",
+    "message": "Navigation der Blog-Listenseite",
     "description": "The ARIA label for the blog pagination"
   },
   "theme.blog.paginator.newerEntries": {
-    "message": "Newer entries",
+    "message": "Neuere Einträge",
     "description": "The label used to navigate to the newer blog posts page (previous page)"
   },
   "theme.blog.paginator.olderEntries": {
-    "message": "Older entries",
+    "message": "Ältere Einträge",
     "description": "The label used to navigate to the older blog posts page (next page)"
   },
   "theme.blog.post.paginator.navAriaLabel": {
-    "message": "Blog post page navigation",
+    "message": "Blog Post Seiten Navigation",
     "description": "The ARIA label for the blog posts pagination"
   },
   "theme.blog.post.paginator.newerPost": {
-    "message": "Newer post",
+    "message": "Neuer Post",
     "description": "The blog post button label to navigate to the newer/previous post"
   },
   "theme.blog.post.paginator.olderPost": {
-    "message": "Older post",
+    "message": "Älterer Post",
     "description": "The blog post button label to navigate to the older/next post"
   },
   "theme.tags.tagsPageLink": {
-    "message": "View all tags",
+    "message": "Alle Tags anzeigen",
     "description": "The label of the link targeting the tag list page"
   },
   "theme.colorToggle.ariaLabel.mode.system": {
@@ -64,15 +64,15 @@
     "description": "The name for the system color mode"
   },
   "theme.colorToggle.ariaLabel.mode.light": {
-    "message": "light mode",
+    "message": "heller Modus",
     "description": "The name for the light color mode"
   },
   "theme.colorToggle.ariaLabel.mode.dark": {
-    "message": "dark mode",
+    "message": "dunkler Modus",
     "description": "The name for the dark color mode"
   },
   "theme.colorToggle.ariaLabel": {
-    "message": "Switch between dark and light mode (currently {mode})",
+    "message": "Umschalten zwischen dunkler und heller Ansicht (momentan {mode})",
     "description": "The ARIA label for the color mode toggle"
   },
   "theme.docs.breadcrumbs.navAriaLabel": {
@@ -80,74 +80,74 @@
     "description": "The ARIA label for the breadcrumbs"
   },
   "theme.docs.DocCard.categoryDescription.plurals": {
-    "message": "1 item|{count} items",
+    "message": "1 Eintrag|{count} Einträge",
     "description": "The default description for a category card in the generated index about how many items this category includes"
   },
   "theme.docs.paginator.navAriaLabel": {
-    "message": "Docs pages",
+    "message": "Dokumentation Seiten",
     "description": "The ARIA label for the docs pagination"
   },
   "theme.docs.paginator.previous": {
-    "message": "Previous",
+    "message": "Zurück",
     "description": "The label used to navigate to the previous doc"
   },
   "theme.docs.paginator.next": {
-    "message": "Next",
+    "message": "Weiter",
     "description": "The label used to navigate to the next doc"
   },
   "theme.docs.tagDocListPageTitle.nDocsTagged": {
-    "message": "One doc tagged|{count} docs tagged",
+    "message": "Ein doc getaggt|{count} docs getaggt",
     "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.docs.tagDocListPageTitle": {
-    "message": "{nDocsTagged} with \"{tagName}\"",
+    "message": "{nDocsTagged} mit \"{tagName}\"",
     "description": "The title of the page for a docs tag"
   },
   "theme.docs.versionBadge.label": {
     "message": "Version: {versionLabel}"
   },
   "theme.docs.versions.unreleasedVersionLabel": {
-    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "message": "Das ist die unveröffentlichte Dokumentation für {siteTitle} {versionLabel}.",
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "message": "Das ist die Dokumentation für {siteTitle} {versionLabel} und wird nicht weiter gewartet.",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
   },
   "theme.docs.versions.latestVersionSuggestionLabel": {
-    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "message": "Für die aktuellste Dokumentation bitte auf {latestVersionLink} ({versionLabel}) gehen.",
     "description": "The label used to tell the user to check the latest version"
   },
   "theme.docs.versions.latestVersionLinkLabel": {
-    "message": "latest version",
+    "message": "letzte Version",
     "description": "The label used for the latest version suggestion link label"
   },
   "theme.common.editThisPage": {
-    "message": "Edit this page",
+    "message": "Diese Seite bearbeiten",
     "description": "The link label to edit the current page"
   },
   "theme.common.headingLinkTitle": {
-    "message": "Direct link to {heading}",
+    "message": "Direkter Link zur {heading}",
     "description": "Title for link to heading"
   },
   "theme.lastUpdated.atDate": {
-    "message": " on {date}",
+    "message": " am {date}",
     "description": "The words used to describe on which date a page has been last updated"
   },
   "theme.lastUpdated.byUser": {
-    "message": " by {user}",
+    "message": " von {user}",
     "description": "The words used to describe by who the page has been last updated"
   },
   "theme.lastUpdated.lastUpdatedAtBy": {
-    "message": "Last updated{atDate}{byUser}",
+    "message": "Letztes Update{atDate}{byUser}",
     "description": "The sentence used to display when a page has been last updated, and by who"
   },
   "theme.NotFound.title": {
-    "message": "Page Not Found",
+    "message": "Seite nicht gefunden",
     "description": "The title of the 404 page"
   },
   "theme.navbar.mobileVersionsDropdown.label": {
-    "message": "Versions",
+    "message": "Versionen",
     "description": "The label for the navbar versions dropdown on mobile view"
   },
   "theme.tags.tagsListLabel": {
@@ -155,11 +155,11 @@
     "description": "The label alongside a tag list"
   },
   "theme.admonition.caution": {
-    "message": "caution",
+    "message": "vorsicht",
     "description": "The default label used for the Caution admonition (:::caution)"
   },
   "theme.admonition.danger": {
-    "message": "danger",
+    "message": "gefahr",
     "description": "The default label used for the Danger admonition (:::danger)"
   },
   "theme.admonition.info": {
@@ -167,23 +167,23 @@
     "description": "The default label used for the Info admonition (:::info)"
   },
   "theme.admonition.note": {
-    "message": "note",
+    "message": "hinweis",
     "description": "The default label used for the Note admonition (:::note)"
   },
   "theme.admonition.tip": {
-    "message": "tip",
+    "message": "tipp",
     "description": "The default label used for the Tip admonition (:::tip)"
   },
   "theme.admonition.warning": {
-    "message": "warning",
+    "message": "warnung",
     "description": "The default label used for the Warning admonition (:::warning)"
   },
   "theme.AnnouncementBar.closeButtonAriaLabel": {
-    "message": "Close",
+    "message": "Schließen",
     "description": "The ARIA label for close button of announcement bar"
   },
   "theme.blog.sidebar.navAriaLabel": {
-    "message": "Blog recent posts navigation",
+    "message": "Navigation der letzten Beiträge im Blog",
     "description": "The ARIA label for recent posts in the blog sidebar"
   },
   "theme.DocSidebarItem.expandCategoryAriaLabel": {
@@ -203,43 +203,43 @@
     "description": "The ARIA label for the main navigation"
   },
   "theme.navbar.mobileLanguageDropdown.label": {
-    "message": "Languages",
+    "message": "Sprachen",
     "description": "The label for the mobile language switcher dropdown"
   },
   "theme.TOCCollapsible.toggleButtonLabel": {
-    "message": "On this page",
+    "message": "Auf dieser Seite",
     "description": "The label used by the button on the collapsible TOC component"
   },
   "theme.NotFound.p1": {
-    "message": "We could not find what you were looking for.",
+    "message": "Wir konnten nicht finden, wonach du gesucht hast.",
     "description": "The first paragraph of the 404 page"
   },
   "theme.NotFound.p2": {
-    "message": "Please contact the owner of the site that linked you to the original URL and let them know their link is broken.",
+    "message": "Bitte kontaktiere den Betreiber der Seite, die dich hierher verlinkt hat – der Link funktioniert nicht mehr.",
     "description": "The 2nd paragraph of the 404 page"
   },
   "theme.blog.post.readMore": {
-    "message": "Read more",
+    "message": "Mehr lesen",
     "description": "The label used in blog post item excerpts to link to full blog posts"
   },
   "theme.blog.post.readMoreLabel": {
-    "message": "Read more about {title}",
+    "message": "Mehr lesen über {title}",
     "description": "The ARIA label for the link to full blog posts from excerpts"
   },
   "theme.blog.post.readingTime.plurals": {
-    "message": "One min read|{readingTime} min read",
+    "message": "Eine Minute Lesezeit|{readingTime} Minuten Lesezeit",
     "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.CodeBlock.copy": {
-    "message": "Copy",
+    "message": "Kopieren",
     "description": "The copy button label on code blocks"
   },
   "theme.CodeBlock.copied": {
-    "message": "Copied",
+    "message": "Kopiert",
     "description": "The copied button label on code blocks"
   },
   "theme.CodeBlock.copyButtonAriaLabel": {
-    "message": "Copy code to clipboard",
+    "message": "In die Zwischenablage kopieren",
     "description": "The ARIA label for copy code blocks button"
   },
   "theme.CodeBlock.wordWrapToggle": {
@@ -251,11 +251,11 @@
     "description": "The ARIA label for the home page in the breadcrumbs"
   },
   "theme.docs.sidebar.collapseButtonTitle": {
-    "message": "Collapse sidebar",
+    "message": "Seitenleiste einklappen",
     "description": "The title attribute for collapse button of doc sidebar"
   },
   "theme.docs.sidebar.collapseButtonAriaLabel": {
-    "message": "Collapse sidebar",
+    "message": "Seitenleiste einklappen",
     "description": "The title attribute for collapse button of doc sidebar"
   },
   "theme.docs.sidebar.navAriaLabel": {
@@ -267,7 +267,7 @@
     "description": "The ARIA label for close button of mobile sidebar"
   },
   "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
-    "message": "Back to main menu",
+    "message": "Zurück zum Hauptmenü",
     "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
   },
   "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
@@ -275,42 +275,42 @@
     "description": "The ARIA label for hamburger menu button of mobile navigation"
   },
   "theme.SearchBar.seeAll": {
-    "message": "See all {count} results"
+    "message": "Alle {count} Ergebnisse anzeigen"
   },
   "theme.SearchPage.documentsFound.plurals": {
-    "message": "One document found|{count} documents found",
+    "message": "Ein Dokument gefunden|{count} Dokumente gefunden",
     "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.SearchPage.existingResultsTitle": {
-    "message": "Search results for \"{query}\"",
+    "message": "Suchergebnisse für \"{query}\"",
     "description": "The search page title for non-empty query"
   },
   "theme.SearchPage.emptyResultsTitle": {
-    "message": "Search the documentation",
+    "message": "Suche in der Dokumentation",
     "description": "The search page title for empty query"
   },
   "theme.SearchPage.inputPlaceholder": {
-    "message": "Type your search here",
+    "message": "Suchbegriff eingeben",
     "description": "The placeholder for search page input"
   },
   "theme.SearchPage.inputLabel": {
-    "message": "Search",
+    "message": "Suche",
     "description": "The ARIA label for search page input"
   },
   "theme.SearchPage.algoliaLabel": {
-    "message": "Powered by Algolia",
+    "message": "Unterstützt von Algolia",
     "description": "The description label for Algolia mention"
   },
   "theme.SearchPage.noResultsText": {
-    "message": "No results were found",
+    "message": "Es wurden keine Ergebnisse gefunden",
     "description": "The paragraph for empty search result"
   },
   "theme.SearchPage.fetchingNewResults": {
-    "message": "Fetching new results...",
+    "message": "Neue Ergebnisse abrufen...",
     "description": "The paragraph for fetching new search results"
   },
   "theme.SearchBar.label": {
-    "message": "Search",
+    "message": "Suche",
     "description": "The ARIA label and placeholder for search button"
   },
   "theme.SearchModal.searchBox.resetButtonTitle": {
@@ -318,39 +318,39 @@
     "description": "The label and ARIA label for search box reset button"
   },
   "theme.SearchModal.searchBox.cancelButtonText": {
-    "message": "Cancel",
+    "message": "Abbrechen",
     "description": "The label and ARIA label for search box cancel button"
   },
   "theme.SearchModal.searchBox.placeholderText": {
-    "message": "Search docs",
+    "message": "Dokumentation durchsuchen",
     "description": "The placeholder text for the main search input field"
   },
   "theme.SearchModal.searchBox.placeholderTextAskAi": {
-    "message": "Ask another question...",
+    "message": "Weitere Frage stellen...",
     "description": "The placeholder text when in AI question mode"
   },
   "theme.SearchModal.searchBox.placeholderTextAskAiStreaming": {
-    "message": "Answering...",
+    "message": "Antwortet...",
     "description": "The placeholder text for search box when AI is streaming an answer"
   },
   "theme.SearchModal.searchBox.enterKeyHint": {
-    "message": "search",
+    "message": "suchen",
     "description": "The hint for the search box enter key text"
   },
   "theme.SearchModal.searchBox.enterKeyHintAskAi": {
-    "message": "enter",
+    "message": "eingeben",
     "description": "The hint for the Ask AI search box enter key text"
   },
   "theme.SearchModal.searchBox.searchInputLabel": {
-    "message": "Search",
+    "message": "Suchen",
     "description": "The ARIA label for search input"
   },
   "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
-    "message": "Back to keyword search",
+    "message": "Zurück zur Stichwortsuche",
     "description": "The text for back to keyword search button"
   },
   "theme.SearchModal.searchBox.backToKeywordSearchButtonAriaLabel": {
-    "message": "Back to keyword search",
+    "message": "Zurück zur Stichwortsuche",
     "description": "The ARIA label for back to keyword search button"
   },
   "theme.SearchModal.startScreen.recentSearchesTitle": {
@@ -378,11 +378,11 @@
     "description": "The title for remove favorite search button"
   },
   "theme.SearchModal.startScreen.recentConversationsTitle": {
-    "message": "Recent conversations",
+    "message": "Letzte Gespräche",
     "description": "The title for recent conversations"
   },
   "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
-    "message": "Remove this conversation from history",
+    "message": "Dieses Gespräch aus dem Verlauf entfernen",
     "description": "The title for remove recent conversation button"
   },
   "theme.SearchModal.errorScreen.titleText": {
@@ -394,63 +394,63 @@
     "description": "The help text for error screen"
   },
   "theme.SearchModal.resultsScreen.askAiPlaceholder": {
-    "message": "Ask AI: ",
+    "message": "KI fragen: ",
     "description": "The placeholder text for Ask AI input"
   },
   "theme.SearchModal.askAiScreen.disclaimerText": {
-    "message": "Answers are generated with AI which can make mistakes. Verify responses.",
+    "message": "Antworten werden von KI generiert und können Fehler enthalten. Bitte überprüfe die Antworten.",
     "description": "The disclaimer text for AI answers"
   },
   "theme.SearchModal.askAiScreen.relatedSourcesText": {
-    "message": "Related sources",
+    "message": "Verwandte Quellen",
     "description": "The text for related sources"
   },
   "theme.SearchModal.askAiScreen.thinkingText": {
-    "message": "Thinking...",
+    "message": "Denkt nach...",
     "description": "The text when AI is thinking"
   },
   "theme.SearchModal.askAiScreen.copyButtonText": {
-    "message": "Copy",
+    "message": "Kopieren",
     "description": "The text for copy button"
   },
   "theme.SearchModal.askAiScreen.copyButtonCopiedText": {
-    "message": "Copied!",
+    "message": "Kopiert!",
     "description": "The text for copy button when copied"
   },
   "theme.SearchModal.askAiScreen.copyButtonTitle": {
-    "message": "Copy",
+    "message": "Kopieren",
     "description": "The title for copy button"
   },
   "theme.SearchModal.askAiScreen.likeButtonTitle": {
-    "message": "Like",
+    "message": "Gefällt mir",
     "description": "The title for like button"
   },
   "theme.SearchModal.askAiScreen.dislikeButtonTitle": {
-    "message": "Dislike",
+    "message": "Gefällt mir nicht",
     "description": "The title for dislike button"
   },
   "theme.SearchModal.askAiScreen.thanksForFeedbackText": {
-    "message": "Thanks for your feedback!",
+    "message": "Danke für Ihr Feedback!",
     "description": "The text for thanks for feedback"
   },
   "theme.SearchModal.askAiScreen.preToolCallText": {
-    "message": "Searching...",
+    "message": "Suche...",
     "description": "The text before tool call"
   },
   "theme.SearchModal.askAiScreen.duringToolCallText": {
-    "message": "Searching for ",
+    "message": "Suche nach ",
     "description": "The text during tool call"
   },
   "theme.SearchModal.askAiScreen.afterToolCallText": {
-    "message": "Searched for",
+    "message": "Gesucht nach ",
     "description": "The text after tool call"
   },
   "theme.SearchModal.footer.selectText": {
-    "message": "Select",
+    "message": "to select",
     "description": "The select text for footer"
   },
   "theme.SearchModal.footer.submitQuestionText": {
-    "message": "Submit question",
+    "message": "Frage absenden",
     "description": "The submit question text for footer"
   },
   "theme.SearchModal.footer.selectKeyAriaLabel": {
@@ -458,7 +458,7 @@
     "description": "The ARIA label for select key in footer"
   },
   "theme.SearchModal.footer.navigateText": {
-    "message": "Navigate",
+    "message": "to navigate",
     "description": "The navigate text for footer"
   },
   "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
@@ -470,7 +470,7 @@
     "description": "The ARIA label for navigate down key in footer"
   },
   "theme.SearchModal.footer.closeText": {
-    "message": "Close",
+    "message": "to close",
     "description": "The close text for footer"
   },
   "theme.SearchModal.footer.closeKeyAriaLabel": {
@@ -482,11 +482,11 @@
     "description": "The 'Powered by' text for footer"
   },
   "theme.SearchModal.footer.backToSearchText": {
-    "message": "Back to search",
+    "message": "Zurück zur Suche",
     "description": "The back to search text for footer"
   },
   "theme.SearchModal.noResultsScreen.noResultsText": {
-    "message": "No results found for",
+    "message": "No results for",
     "description": "The text when there are no results"
   },
   "theme.SearchModal.noResultsScreen.suggestedQueryText": {
@@ -502,35 +502,35 @@
     "description": "The link text for reporting missing results"
   },
   "theme.SearchModal.placeholder": {
-    "message": "Search docs",
+    "message": "Dokumentation durchsuchen",
     "description": "The placeholder of the input of the DocSearch pop-up modal"
   },
   "theme.IdealImageMessage.loading": {
-    "message": "Loading...",
+    "message": "Wird geladen...",
     "description": "When the full-scale image is loading"
   },
   "theme.IdealImageMessage.load": {
-    "message": "Click to load{sizeMessage}",
+    "message": "Zum Laden klicken {sizeMessage}",
     "description": "To prompt users to load the full image. sizeMessage is a parenthesized size figure."
   },
   "theme.IdealImageMessage.offline": {
-    "message": "Your browser is offline. Image not loaded",
+    "message": "Browser ist offline. Bild nicht geladen",
     "description": "When the user is viewing an offline document"
   },
   "theme.IdealImageMessage.404error": {
-    "message": "404. Image not found",
+    "message": "404. Bild nicht gefunden.",
     "description": "When the image is not found"
   },
   "theme.IdealImageMessage.error": {
-    "message": "Error. Click to reload",
+    "message": "Fehler. Zum neu laden klicken",
     "description": "When the image fails to load for unknown error"
   },
   "theme.blog.post.plurals": {
-    "message": "One post|{count} posts",
+    "message": "Ein Post|{count} Posts",
     "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.blog.tagTitle": {
-    "message": "{nPosts} tagged with \"{tagName}\"",
+    "message": "{nPosts} getaggt mit \"{tagName}\"",
     "description": "The title of the page for a blog tag"
   },
   "theme.blog.author.pageTitle": {
@@ -542,7 +542,7 @@
     "description": "The title of the authors page"
   },
   "theme.blog.authorsList.viewAll": {
-    "message": "View all authors",
+    "message": "View All Authors",
     "description": "The label of the link targeting the blog authors page"
   },
   "theme.blog.author.noPosts": {
@@ -562,15 +562,15 @@
     "description": "The draft content banner title"
   },
   "theme.contentVisibility.draftBanner.message": {
-    "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
+    "message": "Diese Seite ist ein Entwurf. Sie wird nur im Entwicklungsmodus sichtbar und wird von der Produktionsseite ausgeschlossen.",
     "description": "The draft content banner message"
   },
   "theme.ErrorPageContent.tryAgain": {
-    "message": "Try again",
+    "message": "Nochmal versuchen",
     "description": "The label of the button to try again rendering when the React error boundary captures an error"
   },
   "theme.common.skipToMainContent": {
-    "message": "Skip to main content",
+    "message": "Zum Hauptinhalt springen",
     "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
   },
   "theme.tags.tagsPageTitle": {
@@ -578,13 +578,13 @@
     "description": "The title of the tag list page"
   },
   "whatIsAda.hero.title": {
-    "message": "What is ada?"
+    "message": "Was ist Ada?"
   },
   "whatIsAda.hero.description1": {
-    "message": "A new type of currency. A new means of transaction."
+    "message": "Neue Währung. Neuer Weg zu handeln."
   },
   "whatIsAda.hero.description2": {
-    "message": "Direct. Secure. From Anywhere. For Everyone."
+    "message": "Direkt. Sicher. Von überall. Für jeden."
   },
   "whatIsAda.meta.title": {
     "message": "What Is ada, the Native Token of Cardano"
@@ -593,148 +593,148 @@
     "message": "ada is the native cryptocurrency of the Cardano blockchain. Use it for transactions, staking, governance voting, and interacting with decentralized applications."
   },
   "whatIsAda.section.headline": {
-    "message": "What is ada?"
+    "message": "Was ist Ada?"
   },
   "whatIsAda.section.title": {
-    "message": "Ada Is The Native Token Of Cardano"
+    "message": "Ada ist der native Token von Cardano"
   },
   "whatIsAda.section.description1": {
-    "message": "It is named after Ada Lovelace: a 19th-century mathematician who is recognized as the first computer programmer, and is the daughter of the poet Lord Byron."
+    "message": "Sie ist nach Ada Lovelace benannt: einer Mathematikerin des 19. Jahrhunderts, die als erste Computerprogrammiererin gilt und die Tochter des Dichters Lord Byron war."
   },
   "whatIsAda.section.description2": {
-    "message": "Ada is a digital currency. Any user, located anywhere in the world, can use ada as a secure exchange of value – without requiring a third party to mediate the exchange. Every transaction is permanently, securely, and transparently recorded on the Cardano blockchain."
+    "message": "Ada ist eine digitale Währung. Egal wo auf der Welt – mit Ada lassen sich Werte sicher austauschen, ganz ohne Mittelsmänner. Jede Transaktion wird dauerhaft, sicher und transparent auf der Cardano-Blockchain gespeichert."
   },
   "whatIsAda.section.description3": {
-    "message": "Every ada holder also holds a stake in the Cardano network. Ada stored in a wallet can be delegated to a stake pool to earn rewards – to participate in the successful running of the network – or found and run your own stake pool to increase the pool's likelihood of receiving rewards. In time, ada will also be usable for a variety of applications and services on the Cardano platform."
+    "message": "Wer Ada besitzt, hat auch einen Anteil am Cardano-Netzwerk. Du kannst deine Ada an einen Stake-Pool delegieren und damit Belohnungen verdienen – oder sogar einen eigenen Stake-Pool betreiben. Langfristig wird Ada auch für immer mehr Anwendungen und Dienste auf Cardano nutzbar sein."
   },
   "whatIsAda.section.quote": {
-    "message": "What can I do with ada?"
+    "message": "Was kann ich mit Ada machen?"
   },
   "howToBuyAda.title": {
-    "message": "How Do I Buy/Sell Ada?"
+    "message": "Wie kaufe/verkaufe ich Ada?"
   },
   "howToBuyAda.description1": {
-    "message": "There are many ways to obtain ada to use the Cardano blockchain. Find out on {whereToGetAdaLink}"
+    "message": "Es gibt viele Wege, Ada zu bekommen und Cardano zu nutzen. Mehr dazu unter {whereToGetAdaLink}"
   },
   "howToBuyAda.whereToGetAdaLink": {
-    "message": "where to get ada?"
+    "message": "Wo bekomme ich Ada?"
   },
   "howToBuyAda.description2": {
-    "message": "As an ada holder, it is important to keep your funds secure, and that means you need to keep your private keys private. It is highly recommended to avoid keeping your cryptocurrency in an exchange longer than necessary, and instead to use a cryptocurrency wallet."
+    "message": "Wer Ada besitzt, sollte die eigenen Schlüssel schützen. Lass deine Kryptowährung nicht länger als nötig auf einer Börse – nutze stattdessen eine eigene Wallet."
   },
   "walletSection.typhon.title": {
     "message": "Typhon Wallet"
   },
   "walletSection.typhon.text": {
-    "message": "Blazing fast, feature-rich, secure, beautiful web and extension Cardano wallet. Delegate to multiple pools of your choice with multi-accounts."
+    "message": "Schnelle, funktionsreiche und sichere Cardano-Wallet für Browser und als Erweiterung. Delegiere an mehrere Pools deiner Wahl mit Multi-Accounts."
   },
   "walletSection.typhon.subtext": {
-    "message": "Browser extension for Chrome, Brave and Edge"
+    "message": "Browser-Erweiterung für Chrome, Brave und Edge"
   },
   "walletSection.typhon.label": {
-    "message": "Get Typhon"
+    "message": "Typhon holen"
   },
   "walletSection.vespr.title": {
     "message": "VESPR Wallet"
   },
   "walletSection.vespr.text": {
-    "message": "VESPR is a non-custodial mobile light wallet for the Cardano network, prioritizing the security and safety of your digital assets while ensuring exceptional ease-of-use."
+    "message": "VESPR ist eine mobile Light-Wallet für Cardano – nicht-kustodial, sicher und besonders einfach zu bedienen."
   },
   "walletSection.vespr.subtext": {
-    "message": "App for iOS and Android"
+    "message": "App für iOS und Android"
   },
   "walletSection.vespr.label": {
-    "message": "Get VESPR"
+    "message": "VESPR holen"
   },
   "walletSection.yoroi.title": {
     "message": "Yoroi Wallet"
   },
   "walletSection.yoroi.text": {
-    "message": "A user-friendly, [open-source](https://github.com/Emurgo/yoroi-frontend) Cardano wallet with a browser-based interface, providing a convenient way to manage ada holdings securely. Yoroi is also available as mobile app."
+    "message": "Eine benutzerfreundliche [Open-Source](https://github.com/Emurgo/yoroi-frontend)-Cardano-Wallet im Browser – ideal, um Ada sicher zu verwalten. Yoroi gibt es auch als mobile App."
   },
   "walletSection.yoroi.subtext": {
-    "message": "Browser extension and app for iOS and Android"
+    "message": "Browser-Erweiterung und App für iOS und Android"
   },
   "walletSection.yoroi.label": {
-    "message": "Get Yoroi"
+    "message": "Yoroi holen"
   },
   "walletSection.eternl.title": {
     "message": "Eternl Wallet"
   },
   "walletSection.eternl.text": {
-    "message": "The alternative Cardano light wallet in the browser. Aims to add features most requested by the Cardano community. Eternl is also available as mobile app."
+    "message": "Die alternative Cardano-Light-Wallet im Browser – mit den Features, die sich die Community am meisten wünscht. Eternl gibt es auch als mobile App."
   },
   "walletSection.eternl.subtext": {
-    "message": "Browser extension and app for iOS and Android"
+    "message": "Browser-Erweiterung und App für iOS und Android"
   },
   "walletSection.eternl.label": {
-    "message": "Get Eternl"
+    "message": "Eternl holen"
   },
   "walletSection.lace.title": {
     "message": "Lace Wallet"
   },
   "walletSection.lace.text": {
-    "message": "An [open-source](https://github.com/input-output-hk/lace) light wallet platform from IOG, one of the creators of Cardano. Manually verified by an independent auditor, Lace lets you quickly, easily, and securely manage your digital assets and enjoy Web3."
+    "message": "Eine [Open-Source](https://github.com/input-output-hk/lace)-Light-Wallet von IOG, einem der Gründer von Cardano. Unabhängig geprüft – für schnelles, einfaches und sicheres Verwalten digitaler Assets."
   },
   "walletSection.lace.subtext": {
-    "message": "Browser extension for Chrome, Brave"
+    "message": "Browser-Erweiterung für Chrome, Brave"
   },
   "walletSection.lace.label": {
-    "message": "Get Lace"
+    "message": "Lace holen"
   },
   "walletSection.daedalus.title": {
     "message": "Daedalus Wallet"
   },
   "walletSection.daedalus.text": {
-    "message": "The [open-source](https://github.com/input-output-hk/daedalus) full node wallet for Cardano. It offers enhanced control and security by maintaining a complete copy of the blockchain, but this comes at the cost of a more complex user experience. As a result, they are typically geared towards professional users who require these advanced features."
+    "message": "Die [Open-Source](https://github.com/input-output-hk/daedalus)-Full-Node-Wallet für Cardano. Bietet maximale Kontrolle und Sicherheit durch eine vollständige Kopie der Blockchain – richtet sich aber eher an erfahrene Nutzer."
   },
   "walletSection.daedalus.subtext": {
-    "message": "Only for powerful desktop PCs"
+    "message": "Nur für leistungsstarke Desktop-PCs"
   },
   "walletSection.daedalus.label": {
-    "message": "Get Daedalus"
+    "message": "Daedalus holen"
   },
   "walletSection.explore.title": {
-    "message": "Explore Apps"
+    "message": "Apps entdecken"
   },
   "walletSection.explore.text": {
-    "message": "Discover a wide variety of wallets designed to facilitate your interaction."
+    "message": "Entdecke weitere Wallets für den Umgang mit Cardano."
   },
   "walletSection.explore.label": {
-    "message": "More Wallets"
+    "message": "Mehr Wallets"
   },
   "walletSection.divider": {
     "message": "Cardano Wallets"
   },
   "walletSection.disclaimer": {
-    "message": "The example applications are provided for informational purposes only and not endorsed or approved. Their use is strictly at your own risk. The descriptions have been provided by the respective project teams."
+    "message": "Die aufgeführten Anwendungen dienen nur zur Information und sind weder empfohlen noch geprüft. Die Nutzung erfolgt auf eigenes Risiko. Die Beschreibungen stammen von den jeweiligen Projektteams."
   },
   "walletSection.storageTitle": {
-    "message": "How Do I Store My Ada And Keep It Safe?"
+    "message": "Wie bewahre ich meine Ada sicher auf?"
   },
   "walletSection.storageDescription1": {
-    "message": "A cryptocurrency wallet is a software program designed to store your public and private keys, send and receive digital currencies, monitor your balance, and interact with supported blockchains."
+    "message": "Eine Krypto-Wallet ist eine Software, die deine öffentlichen und privaten Schlüssel verwaltet. Damit kannst du digitale Währungen senden und empfangen, dein Guthaben einsehen und mit der Blockchain interagieren."
   },
   "walletSection.storageDescription2": {
-    "message": "In addition to the variation of wallets available, there are also two types of wallets: a hot wallet and a cold wallet."
+    "message": "Neben den verschiedenen Wallet-Anbietern gibt es zwei grundlegende Typen: Hot Wallets und Cold Wallets."
   },
   "walletSection.hotWalletText": {
-    "message": "A hot wallet is connected to the internet and can be accessed at any time with the requisite keys. Examples of hot wallets include mobile and software wallets, and funds stored on exchanges."
+    "message": "Eine Hot Wallet ist mit dem Internet verbunden und jederzeit zugänglich. Beispiele sind mobile Wallets, Software-Wallets und Guthaben auf Börsen."
   },
   "walletSection.coldWalletText": {
-    "message": "A cold wallet is an offline wallet. It is not connected to the internet and is used for securing storing funds that do not have to be frequently accessed. Examples include hardware wallets - which is a secure hardware device that stores the wallet's private keys - and paper wallets. Cardano is supported by both Trezor and Ledger hardware wallets."
+    "message": "Eine Cold Wallet ist offline und eignet sich für Ada, auf die du nicht ständig zugreifen musst. Beispiele sind Hardware-Wallets – spezielle Geräte, die deine privaten Schlüssel sicher speichern – und Paper-Wallets. Cardano wird von Trezor und Ledger unterstützt."
   },
   "whatIsAda.button.getStarted": {
-    "message": "Get started with Cardano"
+    "message": "Erste Schritte mit Cardano"
   },
   "whatIsAda.button.whereToGetAda": {
-    "message": "Where to get ada?"
+    "message": "Wo bekommt man Ada?"
   },
   "getStarted.hero.title": {
-    "message": "Get started with Cardano"
+    "message": "Erste Schritte mit Cardano"
   },
   "getStarted.hero.description": {
-    "message": "Step into the new world yourself and learn all the basics in just few steps."
+    "message": "Lerne die Grundlagen und starte in wenigen Schritten."
   },
   "getStarted.meta.title": {
     "message": "Get Started with Cardano, Your First Steps"
@@ -743,136 +743,136 @@
     "message": "Set up a Cardano wallet, get ada, and start exploring DApps and staking in a few simple steps. Your beginner's guide to the Cardano ecosystem."
   },
   "getStarted.step1.title": {
-    "message": "Download a wallet"
+    "message": "Wallet herunterladen"
   },
   "getStarted.step1.description": {
-    "message": "A wallet is an app that allows you to receive, send cryptocurrencies and manage your Cardano account."
+    "message": "Eine Wallet ist eine App, mit der du Kryptowährungen empfangen, senden und dein Cardano-Konto verwalten kannst."
   },
   "getStarted.step1.heading": {
-    "message": "Download a wallet"
+    "message": "Wallet herunterladen"
   },
   "getStarted.step1.text1": {
-    "message": "A Cardano wallet is your personal interface to the blockchain, much like a web browser is your interface to the internet. It lets you securely manage your ada, use dApps, and interact with the network."
+    "message": "Eine Cardano-Wallet ist dein persönlicher Zugang zur Blockchain – ähnlich wie ein Browser dein Zugang zum Internet ist. Damit verwaltest du deine Ada, nutzt dApps und interagierst mit dem Netzwerk."
   },
   "getStarted.step1.text2": {
-    "message": "You will create your wallet in the next steps. Downloading alone does not create one."
+    "message": "Deine Wallet erstellst du in den nächsten Schritten. Der Download allein reicht noch nicht."
   },
   "getStarted.step1.securityNote": {
-    "message": "Your recovery phrase is required to regain access to your wallet. Cardano wallets are non-custodial, which means there is no central service, help desk, or recovery mechanism."
+    "message": "Deine Recovery Phrase brauchst du, um wieder Zugang zu deiner Wallet zu bekommen. Cardano-Wallets sind nicht-kustodial – es gibt keinen zentralen Dienst, keinen Helpdesk und keine Möglichkeit zur Wiederherstellung."
   },
   "getStarted.step1.checkbox": {
-    "message": "I downloaded a wallet."
+    "message": "Ich habe eine Wallet heruntergeladen."
   },
   "getStarted.common.scamLink": {
-    "message": "Be aware of the most common scams."
+    "message": "Informiere dich über die häufigsten Betrugsmaschen."
   },
   "getStarted.step2.title": {
-    "message": "Backup your recovery phrase"
+    "message": "Recovery Phrase sichern"
   },
   "getStarted.step2.description": {
-    "message": "When you create a new wallet, you'll receive a set of 12, 15, or 24 words. This is your recovery phrase, also called a seed phrase. It is the master key to your wallet. Keep it safe!"
+    "message": "Beim Erstellen einer neuen Wallet erhältst du 12, 15 oder 24 Wörter. Das ist deine Recovery Phrase (auch Seed Phrase genannt) – der Hauptschlüssel zu deiner Wallet. Bewahre sie sicher auf!"
   },
   "getStarted.step2.heading": {
-    "message": "Save your recovery phrase"
+    "message": "Recovery Phrase sichern"
   },
   "getStarted.step2.whatToDo": {
-    "message": "What to do:"
+    "message": "So geht's:"
   },
   "getStarted.step2.tip1": {
-    "message": "Write it down on paper and store it securely offline"
+    "message": "Auf Papier aufschreiben und offline sicher aufbewahren"
   },
   "getStarted.step2.tip2": {
-    "message": "Never share it with anyone or store it digitally"
+    "message": "Niemals teilen oder digital speichern"
   },
   "getStarted.step2.tip3": {
-    "message": "Anyone with your recovery phrase can access your funds"
+    "message": "Wer deine Recovery Phrase kennt, hat Zugriff auf dein Guthaben"
   },
   "getStarted.step2.tip4": {
-    "message": "Keep multiple copies in different secure locations"
+    "message": "Mehrere Kopien an verschiedenen sicheren Orten aufbewahren"
   },
   "getStarted.step2.checkbox": {
-    "message": "I've backed up my recovery phrase."
+    "message": "Ich habe meine Recovery Phrase gesichert."
   },
   "getStarted.step3.title": {
-    "message": "Complete wallet setup"
+    "message": "Wallet-Einrichtung abschließen"
   },
   "getStarted.step3.description": {
-    "message": "Finish setting up your wallet with a password and verification."
+    "message": "Schließe die Einrichtung mit Passwort und Verifizierung ab."
   },
   "getStarted.step3.heading": {
-    "message": "Final setup steps"
+    "message": "Letzte Schritte"
   },
   "getStarted.step3.intro": {
-    "message": "After backing up your recovery phrase, complete these two important steps:"
+    "message": "Nachdem du deine Recovery Phrase gesichert hast, folgen zwei wichtige Schritte:"
   },
   "getStarted.step3.passwordLabel": {
-    "message": "Spending password:"
+    "message": "Ausgabepasswort:"
   },
   "getStarted.step3.passwordText": {
-    "message": "Create a strong password to protect everyday transactions. This password is different from your recovery phrase and secures your wallet on this device."
+    "message": "Wähle ein starkes Passwort für deine täglichen Transaktionen. Dieses Passwort ist nicht deine Recovery Phrase – es schützt deine Wallet auf diesem Gerät."
   },
   "getStarted.step3.verifyLabel": {
-    "message": "Verify your backup:"
+    "message": "Backup überprüfen:"
   },
   "getStarted.step3.verifyText": {
-    "message": "Most wallets will ask you to confirm your recovery phrase by selecting words in order. This ensures you've correctly saved it."
+    "message": "Die meisten Wallets bitten dich, deine Recovery Phrase zu bestätigen, indem du die Wörter in der richtigen Reihenfolge auswählst. So stellst du sicher, dass du sie korrekt gespeichert hast."
   },
   "getStarted.step3.ready": {
-    "message": "Once these steps are complete, your wallet is ready to use!"
+    "message": "Danach ist deine Wallet einsatzbereit!"
   },
   "getStarted.step3.securityNote": {
-    "message": "If you forget your spending password, you can restore your wallet using your recovery phrase."
+    "message": "Falls du dein Ausgabepasswort vergisst, kannst du deine Wallet mit der Recovery Phrase wiederherstellen."
   },
   "getStarted.step3.securityWarning": {
-    "message": "However, anyone who obtains your recovery phrase can fully access and empty your wallet without needing the spending password."
+    "message": "Aber: Wer deine Recovery Phrase hat, kann deine Wallet komplett leeren – ganz ohne Ausgabepasswort."
   },
   "getStarted.step3.checkbox": {
-    "message": "I've completed the wallet setup."
+    "message": "Ich habe die Wallet-Einrichtung abgeschlossen."
   },
   "getStarted.step4.title": {
-    "message": "Connect your wallet"
+    "message": "Wallet verbinden"
   },
   "getStarted.step4.description": {
-    "message": "Use your wallet as a single account for apps and projects on Cardano. A wallet connector, like the one shown below, lets websites securely connect to your wallet so you can interact without creating separate accounts or passwords."
+    "message": "Nutze deine Wallet als zentrales Konto für Apps und Projekte auf Cardano. Ein Wallet-Connector (wie unten gezeigt) verbindet Websites sicher mit deiner Wallet – ohne extra Konten oder Passwörter."
   },
   "getStarted.step4.securityNote": {
-    "message": "When you approve a connection or transaction, you are granting that site specific permissions. Always check the website address and review what you are asked to approve before continuing."
+    "message": "Bei jeder Verbindung oder Transaktion erteilst du der Website bestimmte Berechtigungen. Prüfe immer die Adresse und lies genau, was du freigibst."
   },
   "getStarted.step4.checkbox": {
-    "message": "I've connected my wallet."
+    "message": "Ich habe meine Wallet verbunden."
   },
   "getStarted.step5.title": {
-    "message": "Get ada"
+    "message": "Ada besorgen"
   },
   "getStarted.step5.description": {
-    "message": "Obtain ada, Cardano's native cryptocurrency, to start using the blockchain."
+    "message": "Besorge dir Ada – Cardanos native Kryptowährung –, um die Blockchain zu nutzen."
   },
   "getStarted.step5.heading": {
-    "message": "Where to get ada"
+    "message": "Wo bekommt man Ada?"
   },
   "getStarted.step5.text": {
-    "message": "There are several ways to obtain ada, but the most common method is buying it on cryptocurrency exchanges using fiat currency or other cryptocurrencies."
+    "message": "Es gibt verschiedene Wege, Ada zu bekommen. Am gängigsten ist der Kauf auf Kryptobörsen – mit Fiat-Währung oder anderen Kryptowährungen."
   },
   "getStarted.step5.button": {
-    "message": "View all options"
+    "message": "Alle Optionen ansehen"
   },
   "getStarted.step5.securityNote": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers."
+    "message": "Die Krypto-Welt bietet viele Chancen – aber auch Betrüger sind aktiv."
   },
   "getStarted.step5.checkbox": {
-    "message": "I have ada in my wallet."
+    "message": "Ich habe Ada in meiner Wallet."
   },
   "getStarted.step6.title": {
-    "message": "Explore the ecosystem"
+    "message": "Ökosystem entdecken"
   },
   "getStarted.step6.description": {
-    "message": "Now that you have a wallet and ada, you are ready to explore everything Cardano has to offer. A good place to start is by exploring popular apps."
+    "message": "Mit Wallet und Ada bist du startklar. Entdecke, was Cardano zu bieten hat – am besten mit den beliebtesten Apps."
   },
   "whereToGetAda.hero.title": {
-    "message": "Where to get ada?"
+    "message": "Wo bekommt man Ada?"
   },
   "whereToGetAda.hero.description": {
-    "message": "There are many ways to obtain ada to use the Cardano blockchain."
+    "message": "Es gibt viele Wege, Ada zu bekommen und Cardano zu nutzen."
   },
   "whereToGetAda.meta.title": {
     "message": "Buy ada, Where to Get Cardano's Native Token"
@@ -881,211 +881,211 @@
     "message": "Buy ada on centralized or decentralized exchanges, earn staking rewards, or receive it directly. Find the best way to get Cardano's native token."
   },
   "whereToGetAda.divider.exchanges": {
-    "message": "Buy ada using Exchanges"
+    "message": "Ada über Börsen kaufen"
   },
   "whereToGetAda.cex.title": {
-    "message": "Centralized Exchanges"
+    "message": "Zentralisierte Börsen"
   },
   "whereToGetAda.cex.description": {
-    "message": "Centralized exchanges (CEXs) are platforms where cryptocurrencies and other digital assets are traded. They act as intermediaries between buyers and sellers, facilitating transactions and often providing additional services such as custodial storage, order matching, and regulatory compliance. Note that CEXs have custody over [ada](/what-is-ada/) and other native tokens until you send them to a [wallet](/what-is-ada/#wallets) that you control."
+    "message": "Zentralisierte Börsen (CEXs) sind Plattformen, auf denen Kryptowährungen und andere digitale Assets gehandelt werden. Sie vermitteln zwischen Käufern und Verkäufern und bieten oft zusätzliche Dienste wie Verwahrung, Orderabwicklung und regulatorische Compliance. Wichtig: CEXs verwahren deine [Ada](/what-is-ada/) und andere native Token, bis du sie an eine eigene [Wallet](/what-is-ada/#wallets) sendest."
   },
   "whereToGetAda.cex.disclaimer": {
-    "message": "Listing here does not imply endorsement. This data is crowd-sourced by the community. Visit [CoinMarketCap](https://coinmarketcap.com/currencies/cardano/#Markets) to see a full list of exchanges that support [ada](/what-is-ada/)."
+    "message": "Eine Auflistung hier bedeutet keine Empfehlung. Die Daten stammen aus der Community. Eine vollständige Liste der Börsen mit [Ada](/what-is-ada/)-Unterstützung findest du auf [CoinMarketCap](https://coinmarketcap.com/currencies/cardano/#Markets)."
   },
   "whereToGetAda.dex.title": {
-    "message": "Decentralized Exchanges"
+    "message": "Dezentralisierte Börsen"
   },
   "whereToGetAda.dex.description": {
-    "message": "Decentralized exchanges (DEXs) are platforms for trading cryptocurrencies that operate without a central authority. They allow users to trade directly with each other (peer-to-peer) through automated processes facilitated by smart contracts. This approach enhances security and privacy, reducing the risk of hacking and custodial failures associated with centralized exchanges."
+    "message": "Dezentralisierte Börsen (DEXs) ermöglichen den Handel mit Kryptowährungen ohne zentrale Instanz. Nutzer handeln direkt miteinander (Peer-to-Peer) über automatisierte Smart Contracts. Das erhöht Sicherheit und Privatsphäre und reduziert Risiken wie Hacks oder den Verlust verwahrter Gelder."
   },
   "whereToGetAda.dex.disclaimer": {
-    "message": "DEXs are not suitable for beginners, as you must already have [ada](/what-is-ada/) to use them. Listing here does not imply endorsement. Transaction data is based on the last 30 days."
+    "message": "DEXs sind nichts für Anfänger – du brauchst bereits [Ada](/what-is-ada/), um sie zu nutzen. Die Auflistung ist keine Empfehlung. Transaktionsdaten basieren auf den letzten 30 Tagen."
   },
   "whereToGetAda.divider.receive": {
-    "message": "Receive ada from people around the world"
+    "message": "Ada von überall empfangen"
   },
   "whereToGetAda.receive.title": {
-    "message": "Receive ada"
+    "message": "Ada empfangen"
   },
   "whereToGetAda.receive.description1": {
-    "message": "Before receiving or buying [ada](/what-is-ada/), you need to set up a [Cardano wallet](/what-is-ada/#wallets)."
+    "message": "Bevor du [Ada](/what-is-ada/) empfangen oder kaufen kannst, brauchst du eine [Cardano-Wallet](/what-is-ada/#wallets)."
   },
   "whereToGetAda.receive.description2": {
-    "message": "Once you have a [Cardano wallet](/what-is-ada/#wallets), all you need to do is share your address to start sending and receiving [ada](/what-is-ada/) (and other native tokens) peer-to-peer."
+    "message": "Sobald du eine [Cardano-Wallet](/what-is-ada/#wallets) hast, teile einfach deine Adresse – und schon kannst du [Ada](/what-is-ada/) (und andere native Token) direkt senden und empfangen."
   },
   "whereToGetAda.receive.description3": {
-    "message": "Some [wallets](/what-is-ada/#wallets) let you purchase crypto with a debit/credit card, bank transfer, or Apple Pay. Availability depends on your location."
+    "message": "Einige [Wallets](/what-is-ada/#wallets) ermöglichen den Kauf von Krypto per Debit-/Kreditkarte, Banküberweisung oder Apple Pay. Die Verfügbarkeit hängt von deinem Standort ab."
   },
   "whereToGetAda.divider.funding": {
-    "message": "Get funded in ada"
+    "message": "Finanzierung in Ada erhalten"
   },
   "whereToGetAda.funding.title": {
     "message": "Project Catalyst"
   },
   "whereToGetAda.funding.description": {
-    "message": "Discover Cardano's innovation fund designed to support groundbreaking projects and ideas. By participating, you can receive [ada](/what-is-ada/) funding to bring your vision to life. Visit [Project Catalyst](https://projectcatalyst.io) and learn how to create a proposal."
+    "message": "Project Catalyst ist Cardanos Innovationsfonds für bahnbrechende Projekte und Ideen. Reiche einen Vorschlag ein und erhalte [Ada](/what-is-ada/)-Finanzierung für dein Vorhaben. Mehr dazu auf [Project Catalyst](https://projectcatalyst.io)."
   },
   "whereToGetAda.divider.rewards": {
-    "message": "Staking rewards"
+    "message": "Staking-Belohnungen"
   },
   "whereToGetAda.staking.title": {
-    "message": "Staking rewards"
+    "message": "Staking-Belohnungen"
   },
   "whereToGetAda.staking.description1": {
-    "message": "If you already have some [ada](/what-is-ada/), you can earn more by [delegating your ada to a stake pool](/stake-pool-delegation/). This allows you to participate in the network's proof-of-stake system and earn rewards. Alternatively, you can [run your own stake pool](/stake-pool-operation/), which requires more effort and technical knowledge but can be more rewarding."
+    "message": "Wer bereits [Ada](/what-is-ada/) besitzt, kann mehr verdienen – durch [Delegation an einen Stake-Pool](/stake-pool-delegation/). So nimmst du am Proof-of-Stake-System teil und erhältst Belohnungen. Alternativ kannst du einen [eigenen Stake-Pool betreiben](/stake-pool-operation/) – das erfordert mehr Aufwand und technisches Wissen, kann sich aber besonders lohnen."
   },
   "whereToGetAda.staking.description2": {
-    "message": "Cardano offers several advantages for staking: there is no minimum amount of [ada](/what-is-ada/) required to stake, no risk of slashing (losing your staked [ada](/what-is-ada/)), and no locking period. You always maintain custody over your delegated [ada](/what-is-ada/), ensuring that your funds remain secure and accessible at all times. Additionally, rewards are distributed by the protocol itself, not by the pools, ensuring a fair and transparent distribution process."
+    "message": "Cardano bietet beim Staking mehrere Vorteile: Es gibt keinen Mindestbetrag, kein Slashing-Risiko (kein Verlust deiner gestakten [Ada](/what-is-ada/)) und keine Sperrfrist. Deine delegierte [Ada](/what-is-ada/) bleibt jederzeit in deinem Besitz und zugänglich. Belohnungen werden direkt vom Protokoll verteilt – nicht von den Pools –, was für einen fairen und transparenten Prozess sorgt."
   },
   "commonScams.hero.title": {
-    "message": "Common Cardano scams"
+    "message": "Häufige Cardano-Betrugsmaschen"
   },
   "commonScams.hero.description": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers."
+    "message": "Der Kryptomarkt bietet viele Chancen – aber auch Betrüger nutzen ihn aus."
   },
   "commonScams.meta.title": {
     "message": "Common Cardano Scams, How to Stay Safe"
   },
   "commonScams.meta.description": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers."
+    "message": "Der Kryptomarkt bietet viele Chancen – aber auch Betrüger nutzen ihn aus."
   },
   "commonScams.quiz.title": {
-    "message": "Test Your Knowledge"
+    "message": "Teste dein Wissen"
   },
   "commonScams.quiz.description": {
-    "message": "Take the 5-question quiz to see how well you can identify and avoid common blockchain scams."
+    "message": "Beantworte 5 Fragen und finde heraus, wie gut du Betrugsmaschen in der Blockchain-Welt erkennst und vermeidest."
   },
   "commonScams.quiz.buttonText": {
-    "message": "Start Quiz"
+    "message": "Quiz starten"
   },
   "commonScams.intro.title": {
-    "message": "Protecting your ada from scammers"
+    "message": "So schützt du deine Ada vor Betrügern"
   },
   "commonScams.intro.description1": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers. Cardano (ada), one of the most popular blockchains, isn't immune to these threats. From fake giveaways to phishing attacks, scammers are constantly innovating new ways to exploit users. As artificial intelligence continues to improve, these scams are also becoming more sophisticated. This page outlines the most common scams in the Cardano ecosystem and how you can protect yourself."
+    "message": "Der Kryptomarkt bietet viele Chancen – aber auch Betrüger nutzen ihn aus. Cardano (Ada) bildet da keine Ausnahme. Von gefälschten Giveaways bis hin zu Phishing-Angriffen: Betrüger entwickeln ständig neue Methoden, um Nutzer auszutricksen. Durch den Fortschritt künstlicher Intelligenz werden diese Maschen immer raffinierter. Auf dieser Seite erfährst du, welche Betrugsmaschen im Cardano-Ökosystem am häufigsten vorkommen – und wie du dich davor schützt."
   },
   "commonScams.intro.description2": {
-    "message": "**Remember:** If someone gains access to your seed words (recovery phrase), they can take full control of your wallet—no spending password can protect you. Once your ada is stolen, it's gone forever, with no way to recover it."
+    "message": "**Wichtig:** Wer Zugang zu deinen Seed-Wörtern (Wiederherstellungsphrase) hat, kann dein Wallet komplett übernehmen – kein Passwort schützt dich dann noch. Einmal gestohlene Ada sind unwiederbringlich verloren."
   },
   "commonScams.divider.giveaway": {
     "message": "Giveaway"
   },
   "commonScams.giveaway.title": {
-    "message": "Ada Giveaway Scam"
+    "message": "Ada-Giveaway-Betrug"
   },
   "commonScams.giveaway.description1": {
-    "message": "One of the most well-known scams targeting the Cardano community is the **Ada Giveaway Scam.** Scammers promise to double your ada if you send them a certain amount first. These scams often feature fake live streams of Charles Hoskinson, or other well-known personalities, to appear legitimate. The streams may mimic genuine events and include a wallet address for you to send your ada."
+    "message": "Eine der bekanntesten Betrugsmaschen in der Cardano-Community: Betrüger versprechen, deine Ada zu verdoppeln, wenn du ihnen zuerst einen bestimmten Betrag schickst. Oft nutzen sie gefälschte Livestreams mit Charles Hoskinson oder anderen bekannten Persönlichkeiten, um seriös zu wirken. Die Streams imitieren echte Events und zeigen eine Wallet-Adresse, an die du Ada senden sollst."
   },
   "commonScams.giveaway.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "So schützt du dich:"
   },
   "commonScams.giveaway.tip1": {
-    "message": "Legitimate giveaways **never** ask for money upfront."
+    "message": "Echte Giveaways verlangen **niemals** Geld im Voraus."
   },
   "commonScams.giveaway.tip2": {
-    "message": "Avoid clicking on links in unsolicited messages or live streams."
+    "message": "Klicke nicht auf Links in unaufgeforderten Nachrichten oder Livestreams."
   },
   "commonScams.giveaway.tip3": {
-    "message": "Remember: Once sent, your ada is gone forever."
+    "message": "Denk daran: Einmal gesendete Ada sind für immer weg."
   },
   "commonScams.giveaway.tip4": {
-    "message": "Read reports and scam sightings from users in [the Cardano forum](https://forum.cardano.org/c/english/report-a-scam/184)."
+    "message": "Lies Berichte und Betrugsmeldungen anderer Nutzer im [Cardano Forum](https://forum.cardano.org/c/english/report-a-scam/184)."
   },
   "commonScams.divider.phishing": {
     "message": "Phishing"
   },
   "commonScams.phishing.title": {
-    "message": "Phishing Attacks"
+    "message": "Phishing-Angriffe"
   },
   "commonScams.phishing.description": {
-    "message": "Phishing scams involve fake websites, apps or emails designed to steal sensitive information, such as your wallet credentials or recovery phrase (seed words). These fraudulent sites often mimic popular wallets like [Typhon, VESPR or Eternl](/what-is-ada/#wallets)."
+    "message": "Phishing-Betrug funktioniert über gefälschte Websites, Apps oder E-Mails, die darauf abzielen, sensible Daten wie Wallet-Zugangsdaten oder die Wiederherstellungsphrase (Seed-Wörter) zu stehlen. Diese betrügerischen Seiten imitieren häufig beliebte Wallets wie [Typhon, VESPR oder Eternl](/what-is-ada/#wallets)."
   },
   "commonScams.phishing.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "So schützt du dich:"
   },
   "commonScams.phishing.tip1": {
-    "message": "Double-check URLs to ensure they match actual wallet websites."
+    "message": "Überprüfe URLs sorgfältig – stimmen sie mit der echten Wallet-Website überein?"
   },
   "commonScams.phishing.tip2": {
-    "message": "**Never** share your recovery phrase, **even** with \"support\" staff or \"moderators\"."
+    "message": "Teile **niemals** deine Wiederherstellungsphrase – auch nicht mit angeblichem \"Support\" oder \"Moderatoren\"."
   },
   "commonScams.phishing.tip3": {
-    "message": "Consider using hardware wallets."
+    "message": "Nutze am besten ein Hardware-Wallet."
   },
   "commonScams.phishing.tip4": {
-    "message": "Use two-factor authentication where possible."
+    "message": "Aktiviere wenn möglich Zwei-Faktor-Authentifizierung."
   },
   "commonScams.divider.investment": {
-    "message": "Fake Investment"
+    "message": "Fake-Investment"
   },
   "commonScams.investment.title": {
-    "message": "Fake Investment Opportunities"
+    "message": "Gefälschte Investmentangebote"
   },
   "commonScams.investment.description": {
-    "message": "Fraudulent investment schemes are another popular scam. Scammers promote fake projects, claiming they are \"Cardano-backed\" or \"ada-specific\" opportunities with guaranteed high returns. Victims are urged to send ada or other funds to a provided wallet address, with promises of earning exponential profits."
+    "message": "Betrügerische Investmentangebote sind ebenfalls weit verbreitet. Betrüger bewerben Fake-Projekte und behaupten, es handle sich um \"Cardano-gestützte\" oder \"Ada-spezifische\" Chancen mit garantiert hohen Renditen. Opfer werden aufgefordert, Ada oder andere Mittel an eine Wallet-Adresse zu senden – mit dem Versprechen exponentieller Gewinne."
   },
   "commonScams.investment.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "So schützt du dich:"
   },
   "commonScams.investment.tip1": {
-    "message": "Legitimate projects **never** promise guaranteed returns."
+    "message": "Seriöse Projekte versprechen **niemals** garantierte Renditen."
   },
   "commonScams.investment.tip2": {
-    "message": "Be skeptical of unsolicited investment offers."
+    "message": "Sei skeptisch bei unaufgeforderten Investmentangeboten."
   },
   "commonScams.investment.tip3": {
-    "message": "Research projects thoroughly, checking for transparency and a credible team."
+    "message": "Recherchiere Projekte gründlich – achte auf Transparenz und ein glaubwürdiges Team."
   },
   "commonScams.divider.support": {
-    "message": "Fake Support"
+    "message": "Fake-Support"
   },
   "commonScams.support.title": {
-    "message": "Fake Tech Support"
+    "message": "Gefälschter Tech-Support"
   },
   "commonScams.support.description1": {
-    "message": "In this scam, fraudsters pose as \"official\" Cardano support representatives. They often reach out via social media, forums, or email, claiming they can fix your wallet or troubleshoot an issue. They also often copy the profiles of real moderators and to \"help,\" they'll ask for your recovery phrase (seed words) or private keys."
+    "message": "Bei dieser Masche geben sich Betrüger als \"offizielle\" Cardano-Support-Mitarbeiter aus. Sie melden sich über soziale Medien, Foren oder per E-Mail und behaupten, dein Wallet reparieren oder ein Problem lösen zu können. Häufig kopieren sie Profile echter Moderatoren und fragen nach deiner Wiederherstellungsphrase (Seed-Wörtern) oder privaten Schlüsseln – angeblich um dir zu \"helfen\"."
   },
   "commonScams.support.description2": {
-    "message": "This scam is often seen when a [new user enters a channel](/docs/communities) and asks a question about a wallet. Scammers quickly respond, pretending to be official support."
+    "message": "Diese Masche tritt besonders häufig auf, wenn ein [neuer Nutzer einen Kanal betritt](/docs/communities) und eine Frage zu einem Wallet stellt. Betrüger reagieren dann blitzschnell und geben sich als offizieller Support aus."
   },
   "commonScams.support.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "So schützt du dich:"
   },
   "commonScams.support.tip1": {
-    "message": "Legitimate people on [forums and channels](/docs/communities) will **never** ask for your passwords, recovery phrases or private keys."
+    "message": "Seriöse Nutzer in [Foren und Kanälen](/docs/communities) fragen **niemals** nach deinen Passwörtern, Wiederherstellungsphrasen oder privaten Schlüsseln."
   },
   "commonScams.support.tip2": {
-    "message": "Never engage with unsolicited messages claiming to be from support."
+    "message": "Reagiere nie auf unaufgeforderte Nachrichten von angeblichem Support."
   },
   "commonScams.support.tip3": {
-    "message": "Legitimate people on forums and channels will **never** contact you first in a private message."
+    "message": "Seriöse Community-Mitglieder schreiben dich **niemals** zuerst per Privatnachricht an."
   },
   "commonScams.divider.rug": {
     "message": "Rug Pulls"
   },
   "commonScams.rug.title": {
-    "message": "Rug Pulls in Cardano Ecosystem"
+    "message": "Rug Pulls im Cardano-Ökosystem"
   },
   "commonScams.rug.description": {
-    "message": "Cardano is a public, permissionless Layer 1 blockchain and everyone can use it. Some fraudulent projects launch on Cardano, gaining attention with big promises and flashy marketing. After collecting a significant amount of ada from investors, these projects disappear—this is known as a \"rug pull.\""
+    "message": "Cardano ist eine öffentliche, genehmigungsfreie Layer-1-Blockchain – jeder kann sie nutzen. Manche betrügerischen Projekte starten auf Cardano, gewinnen mit großen Versprechen und auffälligem Marketing Aufmerksamkeit und sammeln Ada von Investoren ein. Dann verschwinden sie – das nennt man einen \"Rug Pull\"."
   },
   "commonScams.rug.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "So schützt du dich:"
   },
   "commonScams.rug.tip1": {
-    "message": "Research the project team's credentials and reputation."
+    "message": "Prüfe die Referenzen und den Ruf des Projektteams."
   },
   "commonScams.rug.tip2": {
-    "message": "Check for audits or transparent documentation."
+    "message": "Achte auf Audits oder transparente Dokumentation."
   },
   "commonScams.rug.tip3": {
-    "message": "Avoid projects with anonymous teams or unrealistic promises."
+    "message": "Meide Projekte mit anonymen Teams oder unrealistischen Versprechen."
   },
   "commonScams.rug.tip4": {
-    "message": "Only get utility tokens when you need to use the utility."
+    "message": "Kaufe Utility-Token nur, wenn du die Utility auch tatsächlich nutzen willst."
   },
   "commonScams.rug.tip5": {
-    "message": "Find out what other people think about projects in [the Cardano forum](https://forum.cardano.org/c/english/report-a-scam/184)."
+    "message": "Informiere dich im [Cardano Forum](https://forum.cardano.org/c/english/report-a-scam/184), was andere über Projekte denken."
   },
   "home.meta.title": {
     "message": "Cardano, Secure Decentralized Blockchain Platform"
@@ -1100,179 +1100,179 @@
     "message": "Cardano is the most secure, reliable and censorship-resistant blockchain for mission critical applications to power economies and societies of the future."
   },
   "home.hero.ctaWhatIsAda": {
-    "message": "What is ada?"
+    "message": "Was ist Ada?"
   },
   "home.hero.ctaGetStarted": {
-    "message": "Get Started"
+    "message": "Erste Schritte"
   },
   "home.featured.title": {
-    "message": "Our World Is Changing. Together, We Can Change It For The Better."
+    "message": "Unsere Welt verändert sich. Gemeinsam können wir sie zum Besseren verändern."
   },
   "home.featured.description1": {
-    "message": "Cardano is a proof-of-stake blockchain platform: the first to be founded on [peer-reviewed research](/research) and developed through evidence-based methods. It combines pioneering technologies to provide unparalleled security and sustainability to decentralized applications, systems, and societies."
+    "message": "Cardano ist eine Proof-of-Stake-Blockchain-Plattform: die erste, die auf [Peer-reviewter Forschung](/research) basiert und mit evidenzbasierten Methoden entwickelt wurde. Sie kombiniert wegweisende Technologien, um dezentralen Anwendungen, Systemen und Gesellschaften beispiellose Sicherheit und Nachhaltigkeit zu bieten."
   },
   "home.featured.description2": {
-    "message": "With a leading team of engineers, Cardano exists to redistribute power from unaccountable structures to the margins – to individuals – and be an enabling force for positive change and progress."
+    "message": "Getragen von einem erstklassigen Ingenieurteam gibt Cardano Macht aus undurchsichtigen Strukturen zurück an die Menschen – und ist damit eine treibende Kraft für positiven Wandel und Fortschritt."
   },
   "home.featured.quote1": {
-    "message": "A History Of Impossible,"
+    "message": "Eine Geschichte des Unmöglichen,"
   },
   "home.featured.quote2": {
-    "message": "Made Possible"
+    "message": "möglich gemacht"
   },
   "home.featured.buttonLabel": {
-    "message": "Use Cardano Apps"
+    "message": "Cardano-Apps entdecken"
   },
   "home.divider.benefits": {
-    "message": "Benefits"
+    "message": "Vorteile"
   },
   "home.quoteBox.description": {
-    "message": "Cardano restores trust to global systems – creating, through science, a more secure, transparent, and sustainable foundation for individuals to transact and exchange, systems to govern, and enterprises to grow."
+    "message": "Cardano stellt das Vertrauen in globale Systeme wieder her – und schafft durch Wissenschaft eine sicherere, transparentere und nachhaltigere Grundlage, damit Menschen handeln, Systeme gesteuert und Unternehmen wachsen können."
   },
   "home.quoteBox.quote": {
-    "message": "Cardano brings a new standard in technology – open and inclusive – to challenge the old and activate a new age of sustainable, globally-distributed innovation."
+    "message": "Cardano setzt einen neuen Technologiestandard – offen und inklusiv –, um Bestehendes herauszufordern und ein neues Zeitalter nachhaltiger, weltweit verteilter Innovation einzuläuten."
   },
   "home.benefits.ouroboros.label": {
-    "message": "Proof-of-stake and Ouroboros"
+    "message": "Proof-of-Stake und Ouroboros"
   },
   "home.benefits.ouroboros.category": {
-    "message": "Protocol"
+    "message": "Protokoll"
   },
   "home.benefits.ouroboros.title": {
-    "message": "Proof-Of-Stake And Ouroboros: The Most Environmentally Sustainable Blockchain Protocol"
+    "message": "Proof-of-Stake und Ouroboros: Das umweltfreundlichste Blockchain-Protokoll"
   },
   "home.benefits.ouroboros.body": {
-    "message": "Ouroboros is the first peer-reviewed, verifiably-secure blockchain protocol, and Cardano is the first blockchain to implement it. Ouroboros enables decentralization in the Cardano network on a sustainable scale for global requirements and most crucially, without compromising security.<br /><br />The protocol is the result of tireless efforts, based on foundational research, propelled by a vision for more secure and transparent global payment systems, and provides the means to equitably redistribute power and control."
+    "message": "Ouroboros ist das erste wissenschaftlich geprüfte und nachweislich sichere Blockchain-Protokoll – und Cardano die erste Blockchain, die es einsetzt. Ouroboros ermöglicht Dezentralisierung im Cardano-Netzwerk in einem Maßstab, der globalen Anforderungen standhält, und das ohne Kompromisse bei der Sicherheit.<br /><br />Das Protokoll ist das Ergebnis intensiver Forschungsarbeit, angetrieben von der Vision sicherer und transparenter Zahlungssysteme weltweit – und bietet die Grundlage, Macht und Kontrolle gerechter zu verteilen."
   },
   "home.benefits.ouroboros.cta": {
-    "message": "Learn about Ouroboros"
+    "message": "Mehr über Ouroboros erfahren"
   },
   "home.benefits.research.label": {
-    "message": "Evidence-based development"
+    "message": "Evidenzbasierte Entwicklung"
   },
   "home.benefits.research.category": {
-    "message": "Research"
+    "message": "Forschung"
   },
   "home.benefits.research.title": {
-    "message": "The Highest Standards In Development, Rooted In Science"
+    "message": "Höchste Entwicklungsstandards, verwurzelt in der Wissenschaft"
   },
   "home.benefits.research.body": {
-    "message": "Cardano is developed using evidence-based methods; a novel combination of formal methods, normally found in critical high-stakes applications, and an agile approach, which helps the project remain adaptable and responsive to emerging requirements and new innovations. To support global applications, systems, and solutions, we believe security assurance is not a choice: it is a requirement. Our protocol implementations and platform integrations are first researched, challenged, and mathematically modeled and tested before they are specified. These specifications then inform development which, in turn, is independently audited. The result is a codebase offering an unrivaled level of assurance."
+    "message": "Cardano wird mit evidenzbasierten Methoden entwickelt – einer neuartigen Kombination aus formalen Methoden, wie sie sonst in sicherheitskritischen Anwendungen zum Einsatz kommen, und einem agilen Ansatz, der das Projekt anpassungsfähig hält. Für globale Anwendungen, Systeme und Lösungen ist Sicherheit keine Option, sondern Grundvoraussetzung. Unsere Protokolle und Plattformintegrationen werden zunächst erforscht, hinterfragt, mathematisch modelliert und getestet, bevor sie spezifiziert werden. Diese Spezifikationen fließen dann in die Entwicklung ein, die unabhängig geprüft wird. Das Ergebnis ist eine Codebasis mit einem unerreichten Maß an Zuverlässigkeit."
   },
   "home.benefits.research.cta": {
-    "message": "Discover the research"
+    "message": "Die Forschung entdecken"
   },
   "home.benefits.secure.label": {
-    "message": "Secure"
+    "message": "Sicher"
   },
   "home.benefits.secure.category": {
-    "message": "Transact"
+    "message": "Transaktionen"
   },
   "home.benefits.secure.title": {
-    "message": "Unparalleled Security - And The Makings Of A Trustless World"
+    "message": "Beispiellose Sicherheit – und der Weg zu einer Welt ohne Mittelsmänner"
   },
   "home.benefits.secure.body": {
-    "message": "Cardano makes it possible for any actors who do not know each other - and have no reason to trust one another - to interact and transact, securely. It is a platform for building trust where none might naturally exist, opening up whole new markets and opportunities. Through Ouroboros, Cardano is provably secure against bad actors and Sybil attacks. Every transaction, interaction, and exchange is immutably and transparently recovered, and securely validated using multi-signature and a pioneering extended UTXO model."
+    "message": "Cardano ermöglicht es Parteien, die sich nicht kennen und keinen Grund haben, einander zu vertrauen, sicher miteinander zu interagieren und Transaktionen abzuwickeln. Eine Plattform, die Vertrauen schafft, wo keines existiert – und so völlig neue Märkte und Möglichkeiten eröffnet. Dank Ouroboros ist Cardano nachweislich geschützt gegen böswillige Akteure und Sybil-Angriffe. Jede Transaktion, jede Interaktion wird unveränderlich und transparent festgehalten und sicher validiert – mit Mehrfachsignaturen und einem wegweisenden erweiterten UTXO-Modell."
   },
   "home.benefits.secure.cta": {
-    "message": "Visit the roadmap"
+    "message": "Die Roadmap besuchen"
   },
   "home.benefits.participation.label": {
-    "message": "Incentivized participation"
+    "message": "Anreizbasierte Beteiligung"
   },
   "home.benefits.participation.category": {
-    "message": "Open"
+    "message": "Offen"
   },
   "home.benefits.participation.title": {
-    "message": "Open And Incentivized Participation"
+    "message": "Offene und anreizbasierte Beteiligung"
   },
   "home.benefits.participation.body": {
-    "message": "With a committed community at its core, Cardano is an open-source project developed through open participation. To ensure the longevity and health of the network, Cardano features an incentive mechanism that rewards users - either as stake pool operators or stake delegators - for their participation. The platform is built and expanded through enhancement and improvement proposals. Cardano's governance system gives everyone a democratic voice; ada holders can submit or vote on proposals to upgrade the platform or help determine the direction of development. The governance model uniquely positions Cardano for future growth and development, and provides the means to introduce new capabilities tailored to user needs. It ensures Cardano and its community can continuously fund and decide upon platform and ecosystem improvements."
+    "message": "Mit einer engagierten Community im Kern ist Cardano ein Open-Source-Projekt, das durch offene Beteiligung weiterentwickelt wird. Um die Langlebigkeit und Gesundheit des Netzwerks zu sichern, belohnt ein Anreizmechanismus die Nutzer – ob als Stake-Pool-Betreiber oder Stake-Delegierende – für ihre Teilnahme. Die Plattform wächst durch Verbesserungs- und Erweiterungsvorschläge. Cardanos Governance-System gibt jedem eine demokratische Stimme: Ada-Inhaber können Vorschläge einreichen oder darüber abstimmen, die Plattform weiterzuentwickeln oder die Richtung mitzubestimmen. Dieses Modell verschafft Cardano eine einzigartige Ausgangslage für künftiges Wachstum und ermöglicht es, neue Funktionen gezielt auf die Bedürfnisse der Nutzer zuzuschneiden. So können Cardano und seine Community dauerhaft über Verbesserungen entscheiden und diese finanzieren."
   },
   "home.benefits.participation.cta": {
-    "message": "Learn about governance"
+    "message": "Mehr über Governance erfahren"
   },
   "home.benefits.scalable.label": {
-    "message": "Scalable and sustainable"
+    "message": "Skalierbar und nachhaltig"
   },
   "home.benefits.scalable.category": {
-    "message": "Ecosystem"
+    "message": "Ökosystem"
   },
   "home.benefits.scalable.title": {
-    "message": "Extremely Scalable And Environmentally Sustainable"
+    "message": "Extrem skalierbar und umweltverträglich"
   },
   "home.benefits.scalable.body": {
-    "message": "Ouroboros allows Cardano to scale to global requirements with minimal energy consumption. Unlike other blockchains, Cardano does not require exponentially increasing energy to enhance performance and add blocks. The balance between performance and sustainability is achieved through a combination of novel approaches, including multi-ledger, side chains, and parallel transaction processing through multi-party state channels.<br /><br />The network proliferates as the number of stake pools increases, while parameters are set and adjusted to measure the attractiveness of specific stake pools. This is a network that rewards participation directly. Cardano is designed to ensure that those who act in the best interests of the network are also acting in their own best interests. This ensures the development of a healthy ecosystem with a durable, healthy, and robust network, now and into the future. The combination of sustainability and scalability allows Cardano to achieve the throughput required to meet the evolving demands of global systems— financial, logistical, identity-related, societal."
+    "message": "Ouroboros ermöglicht es Cardano, auf globale Anforderungen zu skalieren – bei minimalem Energieverbrauch. Anders als andere Blockchains benötigt Cardano keine exponentiell steigende Energie, um Leistung zu steigern und neue Blöcke zu erzeugen. Die Balance zwischen Leistung und Nachhaltigkeit gelingt durch neuartige Ansätze wie Multi-Ledger, Sidechains und parallele Transaktionsverarbeitung über Multi-Party State Channels.<br /><br />Das Netzwerk wächst mit der Zahl der Stake Pools, während Parameter so gesetzt und angepasst werden, dass sie die Attraktivität einzelner Pools steuern. Ein Netzwerk, das Teilnahme direkt belohnt. Cardano ist so aufgebaut, dass wer im Interesse des Netzwerks handelt, auch im eigenen Interesse handelt. Das sichert ein gesundes Ökosystem mit einem langlebigen und robusten Netzwerk – heute und in Zukunft. Durch die Kombination von Nachhaltigkeit und Skalierbarkeit erreicht Cardano den Durchsatz, den globale Systeme erfordern – ob im Finanzwesen, in der Logistik, bei Identitätslösungen oder in der Gesellschaft."
   },
   "home.benefits.scalable.cta": {
-    "message": "Learn about Hydra"
+    "message": "Mehr über Hydra erfahren"
   },
   "home.vision.title1": {
-    "message": "Define Your Possible."
+    "message": "Definiere dein Mögliches."
   },
   "home.vision.title2": {
-    "message": "Change Your World."
+    "message": "Verändere deine Welt."
   },
   "home.divider.makeTheChange": {
-    "message": "Make the Change"
+    "message": "Werde aktiv"
   },
   "home.discover.title": {
-    "message": "Discover Cardano"
+    "message": "Cardano entdecken"
   },
   "home.discover.description": {
-    "message": "Cardano is the first blockchain platform to be built through [peer-reviewed research](/research), to be secure enough to protect the data of billions, scalable enough to accommodate global systems, and robust enough to support foundational change."
+    "message": "Cardano ist die erste Blockchain-Plattform, die auf [Peer-reviewter Forschung](/research) aufgebaut wurde – sicher genug, um die Daten von Milliarden zu schützen, skalierbar genug, um globale Systeme zu bedienen, und robust genug, um grundlegenden Wandel zu unterstützen."
   },
   "home.discover.people": {
-    "message": "People"
+    "message": "Menschen"
   },
   "home.discover.purpose": {
-    "message": "Purpose"
+    "message": "Vision"
   },
   "home.discover.research": {
-    "message": "Research"
+    "message": "Forschung"
   },
   "home.discover.technology": {
-    "message": "Technology"
+    "message": "Technologie"
   },
   "home.discover.opportunity": {
-    "message": "Opportunity"
+    "message": "Chancen"
   },
   "home.discover.quote1": {
-    "message": "We have changed science. We have changed what it means to build global systems and sustainable models of exchange and governance."
+    "message": "Wir haben die Wissenschaft verändert. Wir haben verändert, was es bedeutet, globale Systeme und nachhaltige Modelle für Austausch und Governance zu entwickeln."
   },
   "home.discover.quote2": {
-    "message": "Alongside the community, entities, and companies building on Cardano, a new future is being defined: a decentralized future without intermediaries, where power is returned to the individual"
+    "message": "Gemeinsam mit der Community, Organisationen und Unternehmen, die auf Cardano entwickeln, entsteht eine neue Zukunft: dezentral, ohne Mittelsmänner – und mit der Macht zurück beim Einzelnen"
   },
   "home.divider.entities": {
-    "message": "Entities"
+    "message": "Organisationen"
   },
   "home.entities.description": {
-    "message": "Multiple independent entities collaborate within a decentralized team framework to drive Cardano forward, ensuring that it remains aligned with its core mission as it progresses and develops. These are a few of them:"
+    "message": "Mehrere unabhängige Organisationen arbeiten als dezentrales Team zusammen, um Cardano voranzutreiben und sicherzustellen, dass die Kernmission bei jeder Weiterentwicklung gewahrt bleibt. Hier sind einige davon:"
   },
   "home.follow.divider": {
     "message": "Social"
   },
   "home.follow.title": {
-    "message": "Get Involved"
+    "message": "Mach mit"
   },
   "navbar.mega.column.Get to know": {
-    "message": "Get to know",
+    "message": "Kennenlernen",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Take part": {
-    "message": "Take part",
+    "message": "Mitmachen",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Research": {
-    "message": "Research",
+    "message": "Forschung",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Connect": {
-    "message": "Connect",
+    "message": "Vernetzen",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Engage": {
-    "message": "Engage",
+    "message": "Engagieren",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Governance": {
@@ -1280,7 +1280,7 @@
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Get started": {
-    "message": "Get started",
+    "message": "Erste Schritte",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Tools": {
@@ -1288,31 +1288,31 @@
     "description": "Mega menu column title"
   },
   "navbar.mega.column.For Enterprise": {
-    "message": "For Enterprise",
+    "message": "Für Unternehmen",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Use Cases": {
-    "message": "Use Cases",
+    "message": "Anwendungsfälle",
     "description": "Mega menu column title"
   },
   "navbar.mega.label.What is ada?": {
-    "message": "What is ada?",
+    "message": "Was ist Ada?",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Get started with Cardano": {
-    "message": "Get started with Cardano",
+    "message": "Erste Schritte mit Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Where to get ada?": {
-    "message": "Where to get ada?",
+    "message": "Wo bekommt man Ada?",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Protect your ada": {
-    "message": "Protect your ada",
+    "message": "Schütze deine Ada",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Delegate your ada": {
-    "message": "Delegate your ada",
+    "message": "Delegiere deine Ada",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Delegate your vote": {
@@ -1320,19 +1320,19 @@
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Use Cardano Apps": {
-    "message": "Use Cardano Apps",
+    "message": "Cardano Apps nutzen",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Code of Conduct": {
-    "message": "Code of Conduct",
+    "message": "Verhaltenskodex",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Research": {
-    "message": "Cardano Research",
+    "message": "Cardano Forschung",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Insights": {
-    "message": "Cardano Insights",
+    "message": "Cardano Einblicke",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Hard Forks": {
@@ -1340,7 +1340,7 @@
     "description": "Mega menu item label"
   },
   "navbar.mega.label.News": {
-    "message": "News",
+    "message": "Neues",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Newsletter": {
@@ -1348,15 +1348,15 @@
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Online Communities": {
-    "message": "Online Communities",
+    "message": "Online-Communities",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Ambassador Program": {
-    "message": "Ambassador Program",
+    "message": "Ambassador-Programm",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Events": {
-    "message": "Cardano Events",
+    "message": "Cardano-Events",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Forum": {
@@ -1364,15 +1364,15 @@
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Get involved in cardano.org": {
-    "message": "Get involved in cardano.org",
+    "message": "Bei cardano.org mitmachen",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Participate in governance": {
-    "message": "Participate in governance",
+    "message": "An Governance teilnehmen",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Governance Tools": {
-    "message": "Governance Tools",
+    "message": "Governance-Tools",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Constitution": {
@@ -1380,63 +1380,63 @@
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Start building on Cardano": {
-    "message": "Start building on Cardano",
+    "message": "Mit Cardano entwickeln",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Integrate Cardano": {
-    "message": "Integrate Cardano",
+    "message": "Cardano integrieren",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Developer Portal": {
-    "message": "Developer Portal",
+    "message": "Entwicklerportal",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Builder Tools": {
-    "message": "Builder Tools",
+    "message": "Entwickler-Tools",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Companies building on Cardano": {
-    "message": "Companies building on Cardano",
+    "message": "Unternehmen setzen auf Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Enterprise Solutions": {
-    "message": "Enterprise Solutions",
+    "message": "Enterprise-Lösungen",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Contact the Foundation": {
-    "message": "Contact the Foundation",
+    "message": "Kontakt zur Foundation",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.All Use Cases": {
-    "message": "All Use Cases",
+    "message": "Alle Anwendungsfälle",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Identity": {
-    "message": "Identity",
+    "message": "Identität",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Supply Chain": {
-    "message": "Supply Chain",
+    "message": "Lieferkette",
     "description": "Mega menu item label"
   },
   "navbar.mega.description.What is ada?": {
-    "message": "Cardano's native token",
+    "message": "Cardanos nativer Token",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Get started with Cardano": {
-    "message": "Learn the basics and start using Cardano",
+    "message": "Die Grundlagen lernen und Cardano nutzen",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Where to get ada?": {
-    "message": "Obtain ada to use Cardano",
+    "message": "Ada erhalten und Cardano nutzen",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Protect your ada": {
-    "message": "Don't fall for scams",
+    "message": "Schutz vor Betrug",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Delegate your ada": {
-    "message": "Be a part of it and earn rewards",
+    "message": "Mitmachen und Belohnungen verdienen",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Delegate your vote": {
@@ -1444,284 +1444,284 @@
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Use Cardano Apps": {
-    "message": "Explore curated applications",
+    "message": "Kuratierte Anwendungen entdecken",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Code of Conduct": {
-    "message": "Community standards and values",
+    "message": "Standards und Werte der Community",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Research": {
-    "message": "Peer-reviewed research and papers",
+    "message": "Peer-reviewte Forschung und Publikationen",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Insights": {
-    "message": "On-chain or regularly refreshed data",
+    "message": "Aktuelle Zahlen und On-Chain-Daten",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Hard Forks": {
-    "message": "Implemented Upgrades",
+    "message": "Implementierte Upgrades",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.News": {
-    "message": "Latest Cardano news and updates",
+    "message": "Aktuelle Cardano-Nachrichten",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Newsletter": {
-    "message": "Stay updated with Cardano news",
+    "message": "Regelmäßige Updates per E-Mail",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Online Communities": {
-    "message": "Recommended Channels",
+    "message": "Empfohlene Kanäle",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Ambassador Program": {
-    "message": "Meet Cardano Ambassadors",
+    "message": "Cardano Ambassadors kennenlernen",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Events": {
-    "message": "Join Cardano community events",
+    "message": "Community-Events rund um Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Forum": {
-    "message": "Structured long-format discussions",
+    "message": "Diskussionen und Austausch im Forum",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Get involved in cardano.org": {
-    "message": "If you'd like to participate, this will get you started",
+    "message": "Hier startest du, wenn du mitmachen willst",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Participate in governance": {
-    "message": "Shape Cardano's future",
+    "message": "Cardanos Zukunft mitgestalten",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Governance Tools": {
-    "message": "Tools for transparent, community-driven decisions",
+    "message": "Tools für gemeinschaftliche Entscheidungen",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Constitution": {
-    "message": "Learn about governance",
+    "message": "Mehr über Governance erfahren",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Start building on Cardano": {
-    "message": "Developer resources and tooling",
+    "message": "Ressourcen und Tools für Entwickler",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Integrate Cardano": {
-    "message": "Exchange and integration guides",
+    "message": "Guides für Börsen und Integrationen",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Developer Portal": {
-    "message": "Cardano developer portal and docs",
+    "message": "Developer Portal und Dokumentation",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Builder Tools": {
-    "message": "Tools to build on Cardano",
+    "message": "Tools für die Entwicklung auf Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Companies building on Cardano": {
-    "message": "Companies, associations, and collaborations",
+    "message": "Unternehmen, Verbände und Kooperationen",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Enterprise Solutions": {
-    "message": "Case studies and proven deployments",
+    "message": "Fallstudien und bewährte Implementierungen",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Contact the Foundation": {
-    "message": "Partner with the Cardano Foundation",
+    "message": "Kontakt zur Cardano Foundation",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.All Use Cases": {
-    "message": "Explore blockchain applications",
+    "message": "Blockchain-Anwendungen entdecken",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Identity": {
-    "message": "Credentials & verification",
+    "message": "Digitale Nachweise und Identität",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Supply Chain": {
-    "message": "Traceability & provenance",
+    "message": "Rückverfolgbarkeit und Herkunftsnachweis",
     "description": "Mega menu item description"
   },
   "solutions.data.dpp.title": {
-    "message": "Digital Product Passport"
+    "message": "Digitaler Produktpass"
   },
   "solutions.data.dpp.description": {
-    "message": "EU-compliant digital product passports for transparency and sustainability."
+    "message": "EU-konforme digitale Produktpässe für Transparenz und Nachhaltigkeit."
   },
   "solutions.data.category.supplyChain": {
-    "message": "Supply Chain"
+    "message": "Lieferkette"
   },
   "solutions.data.traceability.title": {
-    "message": "Traceability"
+    "message": "Rückverfolgbarkeit"
   },
   "solutions.data.traceability.description": {
-    "message": "End-to-end supply chain traceability powered by blockchain."
+    "message": "Lückenlose Lieferketten-Rückverfolgbarkeit mit Blockchain."
   },
   "solutions.data.authenticity.title": {
-    "message": "Authenticity"
+    "message": "Authentizität"
   },
   "solutions.data.authenticity.description": {
-    "message": "Combat counterfeiting with blockchain-verified product authenticity."
+    "message": "Fälschungen bekämpfen mit blockchain-verifizierter Produktechtheit."
   },
   "solutions.data.sustainability.title": {
-    "message": "Sustainability"
+    "message": "Nachhaltigkeit"
   },
   "solutions.data.sustainability.description": {
-    "message": "Track and verify sustainability claims with immutable records."
+    "message": "Nachhaltigkeitsversprechen mit unveränderlichen Aufzeichnungen überprüfen."
   },
   "solutions.data.storage.title": {
-    "message": "Decentralized Storage"
+    "message": "Dezentraler Speicher"
   },
   "solutions.data.storage.description": {
-    "message": "Secure, distributed data storage solutions for enterprises."
+    "message": "Sichere, verteilte Datenspeicherlösungen für Unternehmen."
   },
   "solutions.data.category.dataTech": {
-    "message": "Data & Technology"
+    "message": "Daten & Technologie"
   },
   "solutions.data.navio.description": {
-    "message": "Blockchain-based solution for supply chain management."
+    "message": "Blockchain-basierte Lösung für Lieferkettenmanagement."
   },
   "solutions.data.caseStudies.title": {
-    "message": "Case Studies"
+    "message": "Fallstudien"
   },
   "solutions.data.caseStudies.description": {
-    "message": "Explore real-world implementations of Cardano blockchain solutions."
+    "message": "Praxisbeispiele für Cardano-Blockchain-Lösungen entdecken."
   },
   "useCases.category.identity": {
-    "message": "Identity"
+    "message": "Identität"
   },
   "useCases.card.education.title": {
-    "message": "Education"
+    "message": "Bildung"
   },
   "useCases.card.education.summary": {
-    "message": "Blockchain-verified academic credentials"
+    "message": "Blockchain-verifizierte akademische Nachweise"
   },
   "useCases.card.digitalIdentity.title": {
-    "message": "Digital Identity"
+    "message": "Digitale Identität"
   },
   "useCases.card.digitalIdentity.summary": {
-    "message": "Own and control your digital identity"
+    "message": "Deine digitale Identität selbst kontrollieren"
   },
   "useCases.card.financeKyc.title": {
-    "message": "Finance KYC"
+    "message": "Finanz-KYC"
   },
   "useCases.card.financeKyc.summary": {
-    "message": "Streamlined identity verification"
+    "message": "Vereinfachte Identitätsprüfung"
   },
   "useCases.card.government.title": {
-    "message": "Government"
+    "message": "Verwaltung"
   },
   "useCases.card.government.summary": {
-    "message": "Tamper-proof official documents"
+    "message": "Fälschungssichere Dokumente"
   },
   "useCases.category.finance": {
-    "message": "Finance"
+    "message": "Finanzen"
   },
   "useCases.card.defi.summary": {
-    "message": "Decentralized lending and exchanges"
+    "message": "Dezentrales Leihen und Handeln"
   },
   "useCases.card.payments.title": {
-    "message": "Payments"
+    "message": "Zahlungen"
   },
   "useCases.card.payments.summary": {
-    "message": "Fast, low-cost cross-border transfers"
+    "message": "Schnelle, günstige grenzüberschreitende Überweisungen"
   },
   "useCases.category.supplyChain": {
-    "message": "Supply Chain"
+    "message": "Lieferkette"
   },
   "useCases.card.agriculture.title": {
-    "message": "Agriculture"
+    "message": "Landwirtschaft"
   },
   "useCases.card.agriculture.summary": {
-    "message": "Farm-to-table traceability"
+    "message": "Rückverfolgbarkeit vom Feld bis zum Tisch"
   },
   "useCases.card.retail.title": {
-    "message": "Retail"
+    "message": "Einzelhandel"
   },
   "useCases.card.retail.summary": {
-    "message": "Combat counterfeiting with provenance"
+    "message": "Fälschungen bekämpfen durch Herkunftsnachweis"
   },
   "useCases.card.logistics.title": {
-    "message": "Logistics"
+    "message": "Logistik"
   },
   "useCases.card.logistics.summary": {
-    "message": "Real-time tracking and verification"
+    "message": "Echtzeit-Tracking und Verifizierung"
   },
   "useCases.category.socialImpact": {
-    "message": "Social Impact"
+    "message": "Soziale Wirkung"
   },
   "useCases.card.socialPrograms.title": {
-    "message": "Social Programs"
+    "message": "Sozialprogramme"
   },
   "useCases.card.socialPrograms.summary": {
-    "message": "Transparent fund distribution"
+    "message": "Transparente Mittelverteilung"
   },
   "useCases.category.dataTech": {
-    "message": "Data & Technology"
+    "message": "Daten & Technologie"
   },
   "useCases.card.dataStorage.title": {
-    "message": "Data Storage"
+    "message": "Datenspeicher"
   },
   "useCases.card.dataStorage.summary": {
-    "message": "Decentralized, secure storage"
+    "message": "Dezentrale, sichere Speicherung"
   },
   "useCases.card.tokenizedAssets.title": {
-    "message": "Tokenized Assets"
+    "message": "Tokenisierte Assets"
   },
   "useCases.card.tokenizedAssets.summary": {
-    "message": "Fractional ownership of real-world assets"
+    "message": "Anteiliges Eigentum an realen Vermögenswerten"
   },
   "useCases.category.emerging": {
-    "message": "Emerging Applications"
+    "message": "Neue Anwendungen"
   },
   "useCases.card.votingSystems.title": {
-    "message": "Voting Systems"
+    "message": "Wahlsysteme"
   },
   "useCases.card.votingSystems.summary": {
-    "message": "Secure, transparent elections"
+    "message": "Sichere, transparente Wahlen"
   },
   "useCases.card.healthcare.title": {
-    "message": "Healthcare"
+    "message": "Gesundheitswesen"
   },
   "useCases.card.healthcare.summary": {
-    "message": "Portable, secure health records"
+    "message": "Portable, sichere Gesundheitsdaten"
   },
   "useCases.card.musicIp.title": {
-    "message": "Music & IP"
+    "message": "Musik & geistiges Eigentum"
   },
   "useCases.card.musicIp.summary": {
-    "message": "Direct royalty payments to artists"
+    "message": "Tantiemen direkt an Künstler auszahlen"
   },
   "ambassadors.hero.title": {
-    "message": "Ambassadors"
+    "message": "Botschafter"
   },
   "ambassadors.hero.description": {
-    "message": "The Cardano Ambassador Program celebrates community leaders driving the expansion of the Cardano ecosystem. Established in 2018 and continuously refined by the Cardano Foundation, it empowers dedicated contributors to make a global impact."
+    "message": "Das Cardano-Ambassador-Programm würdigt Community-Mitglieder, die das Cardano-Ökosystem aktiv voranbringen. Seit 2018 von der Cardano Foundation aufgebaut und stetig weiterentwickelt, ermöglicht es engagierten Mitwirkenden, weltweit etwas zu bewegen."
   },
   "ambassadors.layout.title": {
     "message": "Cardano Ambassador Program, Join the Community"
   },
   "ambassadors.layout.description": {
-    "message": "The Cardano Ambassador Program recognizes community leaders who educate, engage, and raise awareness to drive Cardano's adoption."
+    "message": "Das Cardano-Ambassador-Programm zeichnet Community-Mitglieder aus, die durch Aufklärung, Engagement und Öffentlichkeitsarbeit die Verbreitung von Cardano vorantreiben."
   },
   "ambassadors.cta.leftTitle": {
-    "message": "Become a Cardano Ambassador"
+    "message": "Werde Cardano-Ambassador"
   },
   "ambassadors.cta.leftText1": {
-    "message": "The journey to becoming an Ambassador is built on dedication, collaboration, and meaningful contributions. Ambassadors emerge from the community by actively participating and making a lasting impact."
+    "message": "Der Weg zum Ambassador baut auf Engagement, Zusammenarbeit und wertvolle Beiträge. Ambassadors wachsen aus der Community heraus – durch aktive Teilnahme und nachhaltiges Engagement."
   },
   "ambassadors.cta.leftText2": {
-    "message": "Your first step begins in the Cardano Forum, a dynamic space for collaboration, discussion, and knowledge sharing. By contributing valuable insights, engaging in conversations, and supporting fellow community members, you build a strong foundation of trust and influence. As you progress through different levels, new opportunities for deeper involvement and leadership open up."
+    "message": "Dein erster Schritt beginnt im Cardano Forum – ein lebendiger Ort für Zusammenarbeit, Diskussion und Wissensaustausch. Durch wertvolle Beiträge, aktive Gespräche und die Unterstützung anderer Community-Mitglieder baust du Vertrauen und Einfluss auf. Mit jedem Level eröffnen sich neue Möglichkeiten für tieferes Engagement und Führungsrollen."
   },
   "ambassadors.cta.leftText3": {
-    "message": "Ambassadorship is a reflection of commitment and contribution. Those who actively support the community and help Cardano grow naturally step into this role."
+    "message": "Die Rolle als Ambassador spiegelt Engagement und Beitrag wider. Wer die Community aktiv unterstützt und Cardano voranbringt, wächst ganz natürlich in diese Rolle hinein."
   },
   "ambassadors.cta.rightButtonLabel": {
-    "message": "Get Started"
+    "message": "Loslegen"
   },
   "brandAssets.hero.title": {
-    "message": "Brand Assets"
+    "message": "Asset-Sammlung"
   },
   "brandAssets.hero.description": {
     "message": "Our brand is a reflection of everything that we create. Here are some of the things that make up our brand and how you can use them."
@@ -1733,235 +1733,235 @@
     "message": "Our brand is a reflection of everything that we create. Here are some of the things that make up our brand and how you can use them."
   },
   "codeOfConduct.hero.title": {
-    "message": "Community Code Of Conduct"
+    "message": "Community-Verhaltenskodex"
   },
   "codeOfConduct.hero.description": {
-    "message": "The Cardano community consists of people from all over the world, who have come together to grow and safeguard the spirit and the future of Cardano."
+    "message": "Die Cardano-Community besteht aus Menschen aus aller Welt, die sich zusammengeschlossen haben, um den Geist und die Zukunft von Cardano zu fördern und zu bewahren."
   },
   "codeOfConduct.layout.title": {
     "message": "Cardano Community Code of Conduct"
   },
   "codeOfConduct.layout.description": {
-    "message": "The Cardano community consists of people from all over the world, who have come together to grow and safeguard the spirit and the future of Cardano."
+    "message": "Die Cardano-Community besteht aus Menschen aus aller Welt, die sich zusammengeschlossen haben, um den Geist und die Zukunft von Cardano zu fördern und zu bewahren."
   },
   "codeOfConduct.intro.description": {
-    "message": "The Cardano community consists of people from all over the world, who have come together to grow and safeguard the spirit and the future of Cardano. All participants in the community are expected to act lawfully, honestly, ethically and in the best interest of the project. This Code of Conduct offers rules and guidelines designed to aid judgment within our community and keep it a clean and well-lighted place for civilised public discourse about the project. By joining and participating in any of the official Cardano community channels, you confirm that you agree to be bound by the Code of Conduct."
+    "message": "Die Cardano-Community besteht aus Menschen aus aller Welt, die sich zusammengeschlossen haben, um den Geist und die Zukunft von Cardano zu fördern und zu bewahren. Alle Community-Mitglieder sollen rechtmäßig, ehrlich, ethisch und im besten Interesse des Projekts handeln. Dieser Verhaltenskodex bietet Regeln und Richtlinien, die das Miteinander in unserer Community lenken und einen respektvollen öffentlichen Austausch über das Projekt ermöglichen. Wer einem offiziellen Cardano-Community-Kanal beitritt und dort teilnimmt, erklärt sich mit diesem Verhaltenskodex einverstanden."
   },
   "codeOfConduct.improveDiscussion.title": {
-    "message": "Improve the discussion"
+    "message": "Diskussionen verbessern"
   },
   "codeOfConduct.improveDiscussion.description1": {
-    "message": "Help us make the community a great place for discussion by always working to improve the discussion in some way, however small. If you are not sure your post adds to the conversation, think over what you want to say and try again later. The topics discussed in the community matter to us, and we want you to act as if they matter to you, too. Be respectful of the topics and the people discussing them, even if you disagree with some of what is being said."
+    "message": "Hilf uns, die Community zu einem großartigen Ort für Diskussionen zu machen – indem du jede Diskussion ein Stück besser machst, egal wie klein der Beitrag. Wenn du dir nicht sicher bist, ob dein Beitrag etwas zur Unterhaltung beisteuert, überdenke ihn und versuche es später erneut. Die Themen in der Community sind uns wichtig – und wir möchten, dass sie auch dir wichtig sind. Respektiere die Themen und die Menschen, die darüber diskutieren, selbst wenn du anderer Meinung bist."
   },
   "codeOfConduct.improveDiscussion.description2": {
-    "message": "One way to improve the discussion is by discovering ones that are already happening. Spend some time to search the community platform before replying and you'll have a better chance of meeting others who share your interests. Always look to add value. Discussion should be healthy and informative and members should provide meaningful contribution towards the development of Cardano. This means any content shared or uploaded online should be relevant to the community. Please also refrain from posting or spread misinformation or fake news that attempt to create fear or doubt."
+    "message": "Eine gute Möglichkeit, Diskussionen zu verbessern: Schau erst, welche Gespräche schon laufen. Nimm dir Zeit, die Community-Plattform zu durchsuchen, bevor du antwortest – so findest du leichter Gleichgesinnte. Bringe immer Mehrwert ein. Diskussionen sollten gesund und informativ sein, und Mitglieder sollten sinnvoll zur Weiterentwicklung von Cardano beitragen. Inhalte, die geteilt oder hochgeladen werden, sollten relevant für die Community sein. Bitte verbreite keine Falschinformationen oder Fake News, die Angst oder Zweifel schüren sollen."
   },
   "codeOfConduct.improveDiscussion.description3": {
-    "message": "We also do not allow trading or shilling of ada or any other tokens, goods or services."
+    "message": "Außerdem erlauben wir keinen Handel mit Ada oder anderen Token, Gütern oder Dienstleistungen und kein Shilling."
   },
   "codeOfConduct.beAgreeable.title": {
-    "message": "Be agreeable, even when you disagree"
+    "message": "Respektvoll bleiben – auch bei Meinungsverschiedenheiten"
   },
   "codeOfConduct.beAgreeable.description1": {
-    "message": "You may wish to respond to something by disagreeing with it. That's fine. But remember to criticise ideas, not people. Please avoid:"
+    "message": "Es ist völlig in Ordnung, anderer Meinung zu sein. Aber denk daran: Kritisiere Ideen, nicht Menschen. Vermeide bitte:"
   },
   "codeOfConduct.beAgreeable.list1": {
-    "message": "Name-calling"
+    "message": "Beschimpfungen"
   },
   "codeOfConduct.beAgreeable.list2": {
-    "message": "Ad hominem attacks"
+    "message": "Persönliche Angriffe (Ad-hominem-Attacken)"
   },
   "codeOfConduct.beAgreeable.list3": {
-    "message": "Responding to a post's tone instead of its actual content"
+    "message": "Auf den Ton statt auf den Inhalt eines Beitrags zu reagieren"
   },
   "codeOfConduct.beAgreeable.list4": {
-    "message": "Knee-jerk reaction"
+    "message": "Impulsive Reaktionen"
   },
   "codeOfConduct.beAgreeable.list5": {
-    "message": "Caps Lock. We consider this as electronic shouting"
+    "message": "Feststelltaste. Wir betrachten das als elektronisches Anschreien"
   },
   "codeOfConduct.beAgreeable.description2": {
-    "message": "Instead, provide reasoned counter-arguments that improve the conversation. Please also remember the rule above to add value and meaningful discussion. The Cardano community channels should not be used for personal disputes between community members."
+    "message": "Bringe stattdessen sachliche Gegenargumente, die die Diskussion bereichern. Denke auch an die oben genannte Regel, Mehrwert und sinnvolle Diskussionen einzubringen. Die Cardano-Community-Kanäle sollten nicht für persönliche Streitigkeiten zwischen Community-Mitgliedern genutzt werden."
   },
   "codeOfConduct.participation.title": {
-    "message": "Your participation counts"
+    "message": "Deine Beteiligung zählt"
   },
   "codeOfConduct.participation.description": {
-    "message": "The conversations we have in the community sets the tone for every new arrival. Help us influence the future of this community by choosing to engage in discussions that make this forum an interesting place to be --- and avoiding those that do not."
+    "message": "Die Gespräche in der Community setzen den Ton für jedes neue Mitglied. Hilf uns, die Zukunft dieser Community zu gestalten, indem du dich in Diskussionen einbringst, die dieses Forum zu einem interessanten Ort machen – und solche meidest, die das nicht tun."
   },
   "codeOfConduct.reportProblem.title": {
-    "message": "If you see a problem, report it"
+    "message": "Probleme melden"
   },
   "codeOfConduct.reportProblem.description1": {
-    "message": "Moderators have special authority within the community; they are responsible for ensuring members adhere to this conduct. But so are you. With your help, moderators can be community facilitators. When you see bad behaviour, don't reply. It encourages the bad behaviour by acknowledging it, consumes your energy, and wastes everyone's time. Just report it! Below are specific instructions on how to report violations in each channel."
+    "message": "Moderatoren haben besondere Befugnisse in der Community – sie sorgen dafür, dass sich alle an diesen Verhaltenskodex halten. Aber das gilt auch für dich. Mit deiner Hilfe können Moderatoren als Community-Vermittler wirken. Wenn du schlechtes Verhalten siehst, antworte nicht darauf. Das ermutigt nur zum Fehlverhalten, verbraucht deine Energie und verschwendet die Zeit aller. Melde es einfach! Hier sind spezifische Anweisungen zum Melden von Verstößen in den einzelnen Kanälen."
   },
   "codeOfConduct.reportProblem.list1": {
-    "message": "[Cardano Forum](https://forum.cardano.org): if you see a post that you think violates the Cardano Community Code of Conduct, click the options button and flag it as inappropriate or leave a more detailed message for the moderators."
+    "message": "[Cardano Forum](https://forum.cardano.org): Wenn du einen Beitrag siehst, der gegen den Cardano-Community-Verhaltenskodex verstößt, klicke auf die Optionsschaltfläche und markiere ihn als unangemessen oder hinterlasse eine detailliertere Nachricht für die Moderatoren."
   },
   "codeOfConduct.reportProblem.list2": {
-    "message": "[Reddit](https://www.reddit.com/r/cardano): you can report any post in Reddit by clicking on the 'Report' button underneath all posts. You are required to provide further information as to which rules or laws the post infringes. Reddit moderators will then review your request."
+    "message": "[Reddit](https://www.reddit.com/r/cardano): Du kannst jeden Beitrag auf Reddit melden, indem du auf den 'Report'-Button unter dem Beitrag klickst. Du musst angeben, gegen welche Regeln oder Gesetze der Beitrag verstößt. Reddit-Moderatoren prüfen dann deine Meldung."
   },
   "codeOfConduct.reportProblem.list3": {
-    "message": "[Telegram](https://t.me/CardanoAnnouncements): any message can be reported by right clicking on it. This will go to the platform. There is also a [Report to Admin](https://t.me/CardanoReportToAdmin) channel, specifically for reporting offensive content or abusive users. You can also forward any messages in violation of the code in a DM to any of our admins."
+    "message": "[Telegram](https://t.me/CardanoAnnouncements): Jede Nachricht kann per Rechtsklick gemeldet werden. Das geht direkt an die Plattform. Es gibt auch einen [Report to Admin](https://t.me/CardanoReportToAdmin)-Kanal speziell für die Meldung anstößiger Inhalte oder missbräuchlicher Nutzer. Du kannst Nachrichten, die gegen den Kodex verstoßen, auch per DM an einen unserer Admins weiterleiten."
   },
   "codeOfConduct.reportProblem.list4": {
-    "message": "[Facebook](https://www.facebook.com/groups/CardanoCommunity): you can report any post in our Facebook group by clicking the arrow in the top right corner of the post and selecting Report. This alerts the moderators and admins to review."
+    "message": "[Facebook](https://www.facebook.com/groups/CardanoCommunity): Du kannst jeden Beitrag in unserer Facebook-Gruppe melden, indem du auf den Pfeil oben rechts im Beitrag klickst und 'Melden' wählst. Das benachrichtigt die Moderatoren und Admins zur Prüfung."
   },
   "codeOfConduct.reportProblem.list5": {
-    "message": "[Twitter](https://twitter.com/cardano): you can report any tweet directly to Twitter by clicking on the drop down menu on the tweet itself. Please note that reports on tweets will go directly to Twitter and not the Cardano moderating team."
+    "message": "[Twitter](https://twitter.com/cardano): Du kannst jeden Tweet direkt bei Twitter melden, indem du auf das Dropdown-Menü im Tweet klickst. Beachte, dass Meldungen direkt an Twitter gehen und nicht an das Cardano-Moderationsteam."
   },
   "codeOfConduct.reportProblem.description2": {
-    "message": "In order to maintain our community, moderators reserve the right to remove any content and any user account for any reason at any time. Moderators do not preview new posts; the moderators and site operators take no responsibility for any content posted by the community."
+    "message": "Um unsere Community aufrechtzuerhalten, behalten sich Moderatoren das Recht vor, jederzeit und aus beliebigem Grund Inhalte und Benutzerkonten zu entfernen. Moderatoren überprüfen neue Beiträge nicht vorab; die Moderatoren und Betreiber übernehmen keine Verantwortung für von der Community gepostete Inhalte."
   },
   "codeOfConduct.reportProblem.description3": {
-    "message": "And on the other hand, if you feel your content has been inaccurately removed, the Community team can perform a secondary review. Please provide details of your post to community *at* cardano *dot* org. Please be aware that escalating to secondary review should only be for serious concerns and it may take some time for the community team to respond."
+    "message": "Wenn du andererseits der Meinung bist, dass dein Inhalt zu Unrecht entfernt wurde, kann das Community-Team eine Nachprüfung durchführen. Sende Details deines Beitrags an community *at* cardano *dot* org. Bitte beachte, dass eine Nachprüfung nur für ernsthafte Anliegen gedacht ist und es einige Zeit dauern kann, bis das Community-Team antwortet."
   },
   "codeOfConduct.beCivil.title": {
-    "message": "Always be civil"
+    "message": "Immer höflich bleiben"
   },
   "codeOfConduct.beCivil.description1": {
-    "message": "Nothing sabotages a healthy conversation like rudeness:"
+    "message": "Nichts schadet einer gesunden Unterhaltung so sehr wie Unhöflichkeit:"
   },
   "codeOfConduct.beCivil.list1": {
-    "message": "Be civil. Don't post anything that a reasonable person would consider offensive, abusive, or hate speech."
+    "message": "Sei höflich. Poste nichts, was ein vernünftiger Mensch als beleidigend, missbräuchlich oder als Hassrede betrachten würde."
   },
   "codeOfConduct.beCivil.list2": {
-    "message": "Keep it clean. Don't post anything obscene or sexually explicit."
+    "message": "Halte es sauber. Poste nichts Obszönes oder sexuell Explizites."
   },
   "codeOfConduct.beCivil.list3": {
-    "message": "Respect each other. Don't harass or grief anyone, impersonate people, or expose their private information."
+    "message": "Respektiere einander. Belästige oder mobbe niemanden, gib dich nicht als andere Person aus und veröffentliche keine privaten Informationen anderer."
   },
   "codeOfConduct.beCivil.list4": {
-    "message": "Respect our community. Don't post spam or otherwise vandalise the forum."
+    "message": "Respektiere unsere Community. Poste keinen Spam und vandaliere das Forum nicht."
   },
   "codeOfConduct.beCivil.list5": {
-    "message": "We take harassment seriously. Harassment includes offensive verbal comments related to gender, age, sexual orientation, disability, physical appearance, body size, race, religion, but also includes deliberate intimidation, stalking, following, sustained disruption of conversation. Harassment of members, admins or moderators will not be tolerated."
+    "message": "Wir nehmen Belästigung ernst. Belästigung umfasst beleidigende Kommentare zu Geschlecht, Alter, sexueller Orientierung, Behinderung, Aussehen, Körperbau, Ethnizität oder Religion, aber auch vorsätzliche Einschüchterung, Stalking, Verfolgen und nachhaltige Störung von Gesprächen. Belästigung von Mitgliedern, Admins oder Moderatoren wird nicht toleriert."
   },
   "codeOfConduct.beCivil.list6": {
-    "message": "Do not post another community member's personal information including but not limited to name, address, phone number, social-media accounts."
+    "message": "Veröffentliche keine persönlichen Informationen anderer Community-Mitglieder – einschließlich, aber nicht beschränkt auf Name, Adresse, Telefonnummer oder Social-Media-Konten."
   },
   "codeOfConduct.beCivil.list7": {
-    "message": "Do not repost removed or deleted information."
+    "message": "Veröffentliche keine entfernten oder gelöschten Informationen erneut."
   },
   "codeOfConduct.beCivil.description2": {
-    "message": "These are not concrete terms with precise definitions --- avoid even the appearance of any of these things. If you're unsure, ask yourself how you would feel if your post was featured on the front page of a global news website. This is a public community, and search engines index these discussions. Keep the language, links, and images safe for family and friends."
+    "message": "Das sind keine festen Begriffe mit exakten Definitionen – vermeide auch den Anschein eines solchen Verhaltens. Wenn du dir unsicher bist, frage dich, wie du dich fühlen würdest, wenn dein Beitrag auf der Titelseite einer internationalen Nachrichtenwebsite erscheinen würde. Das ist eine öffentliche Community, und Suchmaschinen indizieren diese Diskussionen. Halte Sprache, Links und Bilder familien- und freundschaftstauglich."
   },
   "codeOfConduct.keepTidy.title": {
-    "message": "Keep it tidy"
+    "message": "Ordnung halten"
   },
   "codeOfConduct.keepTidy.description": {
-    "message": "Make the effort to put things in the right place, so that we can spend more time discussing and less cleaning up. A healthy community requires conversations to be structured and categorized. So:"
+    "message": "Gib dir Mühe, Dinge am richtigen Ort zu platzieren, damit wir mehr Zeit mit Diskutieren und weniger mit Aufräumen verbringen. Eine gesunde Community braucht strukturierte und kategorisierte Gespräche. Daher:"
   },
   "codeOfConduct.keepTidy.list1": {
-    "message": "Don't start a conversation in the wrong category or channel."
+    "message": "Starte kein Gespräch in der falschen Kategorie oder im falschen Kanal."
   },
   "codeOfConduct.keepTidy.list2": {
-    "message": "Don't cross-post the same thing in multiple channels."
+    "message": "Poste nicht dasselbe in mehreren Kanälen."
   },
   "codeOfConduct.postOwnStuff.title": {
-    "message": "Post only your own stuff"
+    "message": "Nur eigene Inhalte posten"
   },
   "codeOfConduct.postOwnStuff.description": {
-    "message": "You may not post anything digital that belongs to someone else without permission. You may not post descriptions of, links to, or methods for stealing someone's intellectual property (software, video, audio, images), or for breaking any other law. Credit should always be attributed back to the original content producer."
+    "message": "Du darfst keine digitalen Inhalte posten, die jemand anderem gehören, ohne dessen Erlaubnis. Du darfst keine Beschreibungen, Links oder Methoden zum Stehlen geistigen Eigentums (Software, Video, Audio, Bilder) oder zum Brechen anderer Gesetze posten. Quellenangaben sollten immer auf den ursprünglichen Ersteller verweisen."
   },
   "codeOfConduct.multipleAccounts.title": {
-    "message": "Multiple Accounts"
+    "message": "Mehrfach-Accounts"
   },
   "codeOfConduct.multipleAccounts.description": {
-    "message": "Multiple accounts by the same user will not be allowed. This helps foster a more human experience in the online world and restricts spamming. Note that duplicate accounts may be investigated and removed."
+    "message": "Mehrere Accounts desselben Nutzers sind nicht erlaubt. Das fördert ein menschlicheres Erlebnis in der Online-Welt und schränkt Spamming ein. Beachte, dass doppelte Accounts untersucht und entfernt werden können."
   },
   "codeOfConduct.violation.title": {
-    "message": "Violation of rules"
+    "message": "Regelverstöße"
   },
   "codeOfConduct.violation.description1": {
-    "message": "If any of the rules are broken, moderators will perform the following sanctions:"
+    "message": "Bei Regelverstößen greifen folgende Maßnahmen:"
   },
   "codeOfConduct.violation.list1": {
-    "message": "First offence: warning is given and the user will be suspended from their account for 24 hours."
+    "message": "Erster Verstoß: Es wird eine Verwarnung ausgesprochen und der Nutzer wird für 24 Stunden gesperrt."
   },
   "codeOfConduct.violation.list2": {
-    "message": "Second offence: warning is given and the user will be suspended for a period of up to 1 month depending on the severity of the violation."
+    "message": "Zweiter Verstoß: Es wird eine Verwarnung ausgesprochen und der Nutzer wird je nach Schwere des Verstoßes für bis zu 1 Monat gesperrt."
   },
   "codeOfConduct.violation.list3": {
-    "message": "Third and final offence: if the user continues to repeatedly break community rules, their account will be banned from the community platform. This penalty may be applied across all community channels if necessary."
+    "message": "Dritter und letzter Verstoß: Wenn der Nutzer wiederholt gegen Community-Regeln verstößt, wird sein Account dauerhaft von der Community-Plattform ausgeschlossen. Diese Strafe kann bei Bedarf auf alle Community-Kanäle ausgeweitet werden."
   },
   "codeOfConduct.violation.description2": {
-    "message": "The community team reserves the right to deny access to the official Community channels to anyone who has violated the Cardano Community Code of Conduct."
+    "message": "Das Community-Team behält sich das Recht vor, jedem den Zugang zu den offiziellen Community-Kanälen zu verweigern, der gegen den Cardano-Community-Verhaltenskodex verstoßen hat."
   },
   "codeOfConduct.poweredByYou.title": {
-    "message": "Powered by you"
+    "message": "Von euch gestaltet"
   },
   "codeOfConduct.poweredByYou.description": {
-    "message": "This community is operated by the community staff and you, the community. If you have any further questions about how things should work here, open a new topic in the [community feedback category](https://forum.cardano.org/c/english/community-feedback/16) of the forum and let's discuss! If there is ever a critical or urgent issue please contact us directly at community *at* cardano *dot* org."
+    "message": "Diese Community wird vom Community-Team und von euch betrieben. Wenn du weitere Fragen hast, eröffne ein neues Thema in der [Community-Feedback-Kategorie](https://forum.cardano.org/c/english/community-feedback/16) des Forums und lass uns darüber diskutieren! Bei kritischen oder dringenden Anliegen kontaktiere uns direkt unter community *at* cardano *dot* org."
   },
   "constitution.error.title": {
-    "message": "Current Enacted Constitution"
+    "message": "Aktuelle gültige Verfassung"
   },
   "constitution.error.localCopy": {
-    "message": "(Local Copy)"
+    "message": "(Lokale Kopie)"
   },
   "constitution.error.fetchError": {
-    "message": "Could not fetch from data.cardano.org:"
+    "message": "Daten von data.cardano.org konnten nicht geladen werden:"
   },
   "constitution.error.showingLocal": {
-    "message": "Showing local copy below."
+    "message": "Lokale Kopie wird angezeigt."
   },
   "constitution.link.download": {
-    "message": "Download Constitution"
+    "message": "Verfassung herunterladen"
   },
   "constitution.link.viewRawMarkdown": {
-    "message": "View Raw Markdown"
+    "message": "Rohtext anzeigen"
   },
   "constitution.loading.versions": {
-    "message": "Loading constitution versions..."
+    "message": "Verfassungsversionen werden geladen ..."
   },
   "constitution.enacted.title": {
-    "message": "Current Enacted Cardano Constitution"
+    "message": "Aktuelle Cardano-Verfassung"
   },
   "constitution.enacted.description": {
-    "message": "Discover the Cardano Constitution: the governance framework of the Cardano blockchain. Read the current enacted charter, explore its ratification history, and download the full text via IPFS."
+    "message": "Die Cardano-Verfassung entdecken: das Governance-Fundament der Cardano-Blockchain. Die aktuelle Verfassung lesen, ihre Ratifizierungshistorie erkunden und den Volltext über IPFS herunterladen."
   },
   "constitution.link.viewOnIPFS": {
-    "message": "View on IPFS"
+    "message": "Auf IPFS ansehen"
   },
   "constitution.error.loadDocument": {
-    "message": "Could not load constitution document:"
+    "message": "Verfassungsdokument konnte nicht geladen werden:"
   },
   "constitution.loading.document": {
-    "message": "Loading document..."
+    "message": "Dokument wird geladen ..."
   },
   "constitution.history.title": {
-    "message": "Constitution Ratification History"
+    "message": "Ratifizierungshistorie"
   },
   "constitution.history.description": {
-    "message": "Below you can find the Cardano Constitution and its ratification history. Click any version to view the full text on IPFS."
+    "message": "Hier findest du die Cardano-Verfassung und ihre Ratifizierungshistorie. Klicke auf eine Version, um den vollständigen Text auf IPFS zu lesen."
   },
   "constitution.history.versionRatified": {
-    "message": "Version ratified at epoch"
+    "message": "Version ratifiziert in Epoche"
   },
   "constitution.history.enactedAtEpoch": {
-    "message": "Enacted at epoch"
+    "message": "In Kraft seit Epoche"
   },
   "constitution.history.hash": {
     "message": "Hash:"
   },
   "constitution.link.viewOnIPFSHistory": {
-    "message": "View this constitution on IPFS"
+    "message": "Diese Verfassung auf IPFS ansehen"
   },
   "constitution.hero.title": {
-    "message": "The Cardano Constitution"
+    "message": "Die Cardano-Verfassung"
   },
   "constitution.hero.description": {
-    "message": "Discover the Cardano Constitution: the governance framework of the Cardano blockchain."
+    "message": "Die Cardano-Verfassung – das Governance-Fundament der Cardano-Blockchain."
   },
   "constitution.layout.title": {
     "message": "The Cardano Constitution, On-Chain Governance Framework"
   },
   "constitution.layout.description": {
-    "message": "Discover the Cardano Constitution: the governance framework of the Cardano blockchain. Read the current enacted charter, explore its ratification history, and download the full text via IPFS."
+    "message": "Die Cardano-Verfassung entdecken: das Governance-Fundament der Cardano-Blockchain. Die aktuelle Verfassung lesen, ihre Ratifizierungshistorie erkunden und den Volltext über IPFS herunterladen."
   },
   "contact.hero.title": {
-    "message": "Contact"
+    "message": "Kontakte"
   },
   "contact.hero.description": {
     "message": "Cardano is supported by the Cardano Foundation, IOG, EMURGO, Intersect, PRAGMA and others. Fill out the contact form below and we will put you in touch with the team best placed to assist you."
@@ -1973,7 +1973,7 @@
     "message": "Intersect is a member-based organization for the Cardano ecosystem tasked with ensuring its continuity and future development."
   },
   "contact.intersect.buttonLabel": {
-    "message": "Join Intersect"
+    "message": "Intersect beitreten"
   },
   "contact.technicalIssue.title": {
     "message": "Report a technical issue"
@@ -2030,7 +2030,7 @@
     "message": "Making the World Work Better for All"
   },
   "artworkContest.hero.description": {
-    "message": "Cardano is a blockchain platform for changemakers, innovators, and visionaries, with the tools and technologies required to create possibility for the many, as well as the few, and bring about positive global change."
+    "message": "Cardano ist eine Blockchain-Plattform für Visionäre, Innovatoren und Macher – mit den Werkzeugen und Technologien, um Möglichkeiten für viele statt für wenige zu schaffen und positiven globalen Wandel voranzutreiben."
   },
   "artworkContest.imagePreview.alt": {
     "message": "Preview"
@@ -2039,7 +2039,7 @@
     "message": "Cardano Artwork Contest"
   },
   "artworkContest.layout.description": {
-    "message": "An open platform designed to empower billions without economic identity by offering decentralized applications for managing identity, value, and governance."
+    "message": "Eine offene Plattform für Milliarden von Menschen ohne wirtschaftliche Identität – mit dezentralen Anwendungen für Identität, Wertübertragung und Governance."
   },
   "artworkContest.content.title": {
     "message": "Artwork Contest Test Page"
@@ -2057,10 +2057,10 @@
     "message": "This happens on your machine only"
   },
   "developers.hero.title": {
-    "message": "Start Building on Cardano"
+    "message": "Auf Cardano entwickeln"
   },
   "developers.hero.description": {
-    "message": "A curated list of resources and entry points to help you get started with building on Cardano."
+    "message": "Kuratierte Ressourcen und Einstiegspunkte für den Start mit der Cardano-Entwicklung."
   },
   "developers.meta.title": {
     "message": "Build on Cardano, Developer Tools and Documentation"
@@ -2069,34 +2069,34 @@
     "message": "Start building on Cardano. Access developer tools, smart contract languages, APIs, testnets, and tutorials to launch your first decentralized application."
   },
   "developers.divider.resources": {
-    "message": "Developer Resources"
+    "message": "Entwickler-Ressourcen"
   },
   "developers.documentation.title": {
-    "message": "Documentation"
+    "message": "Dokumentation"
   },
   "developers.documentation.text": {
-    "message": "Access the essential resources and updates you need to build, integrate, and stay informed about the Cardano blockchain. Below you'll find links to the developer portal, detailed documentation, integration guides, and the latest core development updates."
+    "message": "Hier findest du die wichtigsten Ressourcen und Updates, um auf der Cardano-Blockchain zu entwickeln, zu integrieren und informiert zu bleiben. Unten findest du Links zum Developer Portal, zur ausführlichen Dokumentation, zu Integrationsanleitungen und den neuesten Core-Development-Updates."
   },
   "developers.tools.title": {
-    "message": "Developer Tools"
+    "message": "Entwickler-Tools"
   },
   "developers.tools.text": {
-    "message": "Explore the tools, projects, and updates that are shaping the Cardano ecosystem. Below you'll find links to builder tools, a showcase of projects built on Cardano, and a technical updates tracker that aggregates commits within the last 7 days from all branches of Cardano development-related repos."
+    "message": "Entdecke die Tools, Projekte und Updates, die das Cardano-Ökosystem formen. Unten findest du Links zu Entwickler-Tools, eine Übersicht der auf Cardano gebauten Projekte und einen technischen Update-Tracker, der Commits der letzten 7 Tage aus allen Branches der Cardano-Entwicklungs-Repos zusammenfasst."
   },
   "developers.support.title": {
     "message": "Support"
   },
   "developers.support.text": {
-    "message": "Join the vibrant Cardano developer community through various platforms. Below you'll find links to the Cardano Stack Exchange, the Cardano Forum, and the official Telegram group. Connect with fellow developers, ask questions, and share insights in our decentralized ecosystem."
+    "message": "Werde Teil der lebendigen Cardano-Entwickler-Community auf verschiedenen Plattformen. Unten findest du Links zum Cardano Stack Exchange, zum Cardano Forum und zur offiziellen Telegram-Gruppe. Tausch dich mit anderen Entwicklern aus, stell Fragen und teile Wissen in unserem dezentralen Ökosystem."
   },
   "developers.cta.title": {
-    "message": "Attack the protocol, fork the blockchain - or not. Explore the Ouroboros protocol firsthand in this interactive simulation."
+    "message": "Greif das Protokoll an, forke die Blockchain – oder lass es bleiben. Erlebe das Ouroboros-Protokoll hautnah in dieser interaktiven Simulation."
   },
   "developers.cta.buttonLabel": {
-    "message": "Play the game"
+    "message": "Spiel starten"
   },
   "discoverCardano.hero.title": {
-    "message": "Discover Cardano"
+    "message": "Cardano entdecken"
   },
   "discoverCardano.hero.description": {
     "message": "Cardano is the nexus of five principles: People, purpose, technology, research, and opportunity. Explore and learn this new constellation of knowledge."
@@ -2108,7 +2108,7 @@
     "message": "Discover what makes Cardano different. Built on peer-reviewed science, powered by a global community, and designed for a sustainable, decentralized future."
   },
   "discoverCardano.people.title": {
-    "message": "People"
+    "message": "Menschen"
   },
   "discoverCardano.people.subtitle": {
     "message": "Working together, we achieve more for the many."
@@ -2120,7 +2120,7 @@
     "message": "Every ada holder also holds a stake in the Cardano network. Ada stored in a wallet can be delegated to a stake pool to earn rewards – to participate in the successful running of the network – or pledged to a stake pool to increase the pool's likelihood of receiving rewards. In time, ada will also be usable for a variety of applications and services on the Cardano platform."
   },
   "discoverCardano.purpose.title": {
-    "message": "Purpose"
+    "message": "Vision"
   },
   "discoverCardano.purpose.subtitle": {
     "message": "A platform built for a sustainable future, to help people work better together, trust one another, and build global solutions to global problems."
@@ -2132,7 +2132,7 @@
     "message": "Cardano began with a vision of a world without intermediaries, in which power is not controlled by an accountable few, but by the empowered many. In this world, individuals have control over their data and how they interact and transact. Businesses have the opportunity to grow independent of monopolistic and bureaucratic power structures. Societies are able to pursue true democracy: self-governing, fair, and accountable. It is a world made possible by Cardano."
   },
   "discoverCardano.technology.title": {
-    "message": "Technology"
+    "message": "Technologie"
   },
   "discoverCardano.technology.subtitle": {
     "message": "Cardano brings a new standard in technology - open and inclusive – to challenge the old and activate a new age of sustainable, globally-distributed innovation."
@@ -2147,7 +2147,7 @@
     "message": "Our technology is underpinned by [research](/research). We have redefined what it means to create a global software platform through scientific methods. We have not compromised on our belief, or in our approach. To build a better future - secure, sustainable, and governable by the many - we have taken the road less traveled. The result of our efforts is a blockchain platform unparalleled in its capability and performance, and which is truly able to support global applications, systems, and real-life business use cases."
   },
   "discoverCardano.research.title": {
-    "message": "Research"
+    "message": "Forschung"
   },
   "discoverCardano.research.subtitle": {
     "message": "Pioneering tech begins with groundbreaking research."
@@ -2159,7 +2159,7 @@
     "message": "[Our research](/research) - led by leading academics - explores philosophy, sociology, behavior, and game theory. To achieve each outcome, we consider the minutiae of possibilities: the variables that often go unconsidered, but which may ultimately impact the integrity and sustainability of a global, decentralized platform. We take nothing for granted."
   },
   "discoverCardano.opportunity.title": {
-    "message": "Opportunity"
+    "message": "Chancen"
   },
   "discoverCardano.opportunity.subtitle": {
     "message": "The staging point for every new opportunity. Empower your business through Cardano, and discover the future of technology."
@@ -2198,49 +2198,49 @@
     "message": "add your company"
   },
   "events.hero.title": {
-    "message": "Cardano Events"
+    "message": "Cardano-Events"
   },
   "events.hero.description": {
-    "message": "Upcoming Cardano events in one place, so you never miss a chance to connect, learn, and grow with the Cardano Community."
+    "message": "Alle kommenden Cardano-Events an einem Ort – damit du keine Gelegenheit verpasst, dich mit der Cardano-Community zu vernetzen und weiterzuentwickeln."
   },
   "events.pagination.previous": {
-    "message": "Previous"
+    "message": "Zurück"
   },
   "events.pagination.next": {
-    "message": "Next"
+    "message": "Weiter"
   },
   "events.meta.title": {
     "message": "Cardano Events, Conferences and Meetups"
   },
   "events.meta.description": {
-    "message": "Upcoming Cardano events in one place, so you never miss a chance to connect, learn, and grow with the Cardano Community."
+    "message": "Alle kommenden Cardano-Events an einem Ort – damit du keine Gelegenheit verpasst, dich mit der Cardano-Community zu vernetzen und weiterzuentwickeln."
   },
   "events.divider.discoverWorldwide": {
-    "message": "Discover Cardano Events Worldwide"
+    "message": "Cardano-Events weltweit entdecken"
   },
   "events.platforms.luma": {
-    "message": "Events on Luma.com"
+    "message": "Events auf Luma.com"
   },
   "events.platforms.meetup": {
-    "message": "Events on Meetup.com"
+    "message": "Events auf Meetup.com"
   },
   "events.divider.upcomingHighlighted": {
-    "message": "Upcoming highlighted Events"
+    "message": "Kommende Event-Highlights"
   },
   "events.divider.pastHighlighted": {
-    "message": "Past Highlighted Events"
+    "message": "Vergangene Event-Highlights"
   },
   "events.recapAvailable": {
-    "message": "Recap available:"
+    "message": "Zusammenfassung verfügbar:"
   },
   "events.watchHere": {
-    "message": "Watch here"
+    "message": "Hier ansehen"
   },
   "exchanges.hero.title": {
-    "message": "Integrate Cardano"
+    "message": "Cardano integrieren"
   },
   "exchanges.hero.description": {
-    "message": "Easy integration with Cardano. All of the upgrades. None of the maintenance."
+    "message": "Einfache Integration mit Cardano. Alle Upgrades. Kein Wartungsaufwand."
   },
   "exchanges.layout.title": {
     "message": "Integrate Cardano, Exchange and Wallet Partnerships"
@@ -2249,91 +2249,91 @@
     "message": "Integrate Cardano into your exchange, wallet, or payment platform. Access documentation, resources, and partnership opportunities for ada support."
   },
   "exchanges.intro.description": {
-    "message": "There are various [ways to integrate Cardano](https://developers.cardano.org), one of which is Adrestia. The Adrestia team focuses on supporting exchange and developer integrations by providing a wallet SDK and set of APIs that make it easier for developers and exchanges to integrate and interact with Cardano across releases."
+    "message": "Es gibt verschiedene [Wege, Cardano zu integrieren](https://developers.cardano.org) – einer davon ist Adrestia. Das Adrestia-Team unterstützt Börsen- und Entwicklerintegrationen mit einem Wallet-SDK und APIs, die die Interaktion mit Cardano über Releases hinweg vereinfachen."
   },
   "exchanges.whyAdrestia.divider": {
-    "message": "Why Adrestia?"
+    "message": "Warum Adrestia?"
   },
   "exchanges.whyAdrestia.leftText": {
-    "message": "Blockchains - and especially Cardano - are fast developing. Staying up to date with releases can become a maintenance challenge. We're committed to making it as easy as possible to develop and integrate with Cardano. Through Adrestia, Cardano is adaptable to your systems and requirements."
+    "message": "Blockchains – und besonders Cardano – entwickeln sich rasant. Mit neuen Releases Schritt zu halten, kann zur Wartungsherausforderung werden. Wir machen es so einfach wie möglich, mit Cardano zu entwickeln und zu integrieren. Über Adrestia passt sich Cardano an deine Systeme und Anforderungen an."
   },
   "exchanges.whyAdrestia.rightText": {
-    "message": "Improvements to Cardano should not mean greater complexity or resource overhead. We want to innovate and deploy improvements as they're available, and as they become necessary. This might mean a few updates one month, and many the next. Adrestia is a consistent SDK and set of GraphQL APIs that make it easy for developers to create applications and maintain core compatibility and functionality with the Cardano network across releases."
+    "message": "Verbesserungen an Cardano sollen nicht mehr Komplexität oder Ressourcenaufwand bedeuten. Wir wollen Neuerungen bereitstellen, sobald sie verfügbar und nötig sind – mal wenige Updates pro Monat, mal viele. Adrestia bietet ein konsistentes SDK und GraphQL-APIs, mit denen Entwickler Anwendungen erstellen und Kernkompatibilität mit dem Cardano-Netzwerk über Releases hinweg beibehalten können."
   },
   "exchanges.cta1.title": {
-    "message": "Focus On What Matters. Leave The Rest To Us."
+    "message": "Konzentrier dich auf das Wesentliche. Den Rest übernehmen wir."
   },
   "exchanges.cta1.buttonLabel": {
-    "message": "Access Adrestia"
+    "message": "Adrestia nutzen"
   },
   "exchanges.accessAdrestia.divider": {
-    "message": "Access Adrestia"
+    "message": "Adrestia nutzen"
   },
   "exchanges.whatMakesDifferent.title": {
-    "message": "What makes Adrestia different?"
+    "message": "Was macht Adrestia besonders?"
   },
   "exchanges.whatMakesDifferent.description1": {
-    "message": "Cardano's architecture is built for modularity and adaptability. Through Adrestia, we're able to save developers and exchanges significant maintenance overhead and, most importantly, time."
+    "message": "Cardanos Architektur ist auf Modularität und Anpassungsfähigkeit ausgelegt. Über Adrestia sparen Entwickler und Börsen erheblichen Wartungsaufwand und – vor allem – Zeit."
   },
   "exchanges.whatMakesDifferent.description2": {
-    "message": "Unlike most blockchain API suites, Adrestia decouples and splits out key services from the core Cardano node. The new SDK and APIs are consistent across releases, which means developers are not required to re-learn the platform with each release. Adrestia offers a host of self-contained services and ways to query, transact, and extract information."
+    "message": "Anders als die meisten Blockchain-API-Suites entkoppelt Adrestia zentrale Services vom Cardano-Core-Node. Das SDK und die APIs bleiben über Releases hinweg konsistent – Entwickler müssen die Plattform nicht bei jedem Release neu lernen. Adrestia bietet eigenständige Services und vielfältige Möglichkeiten zum Abfragen, Transagieren und Extrahieren von Informationen."
   },
   "exchanges.benefits.reduceTime.title": {
-    "message": "Reduce Time To Market"
+    "message": "Time-to-Market verkürzen"
   },
   "exchanges.benefits.reduceTime.text": {
-    "message": "Develop applications for Cardano without worrying about new releases breaking your code."
+    "message": "Anwendungen für Cardano entwickeln, ohne dir Sorgen machen zu müssen, dass neue Releases deinen Code brechen."
   },
   "exchanges.benefits.reduceDowntime.title": {
-    "message": "Reduce Downtime"
+    "message": "Ausfallzeiten reduzieren"
   },
   "exchanges.benefits.reduceDowntime.text": {
-    "message": "Fewer backward compatibility issues mean significantly reduced downtime."
+    "message": "Weniger Abwärtskompatibilitätsprobleme bedeuten deutlich weniger Ausfallzeiten."
   },
   "exchanges.benefits.reduceMaintenance.title": {
-    "message": "Reduce Maintenance Costs"
+    "message": "Wartungskosten senken"
   },
   "exchanges.benefits.reduceMaintenance.text": {
-    "message": "Spend less time and resources on maintaining application compatibility across releases."
+    "message": "Weniger Zeit und Ressourcen für die Anwendungskompatibilität über Releases hinweg aufwenden."
   },
   "exchanges.benefits.increaseProductivity.title": {
-    "message": "Increase Productivity"
+    "message": "Produktivität steigern"
   },
   "exchanges.benefits.increaseProductivity.text": {
-    "message": "Focus on what matters - application and wallet development - and leave the updates to us."
+    "message": "Konzentrier dich auf das Wesentliche – Anwendungs- und Wallet-Entwicklung – und überlass die Updates uns."
   },
   "exchanges.cta2.title": {
-    "message": "Discover how components work and interact with the Cardano core node, and choose the right component to suit your requirements."
+    "message": "Erfahre, wie Komponenten mit dem Cardano-Core-Node zusammenarbeiten, und wähle die passende Komponente für deine Anforderungen."
   },
   "exchanges.cta2.buttonLabel": {
-    "message": "Learn the Core Node Architecture"
+    "message": "Core-Node-Architektur kennenlernen"
   },
   "exchanges.learnArchitecture.divider": {
-    "message": "Learn the Core Node Architecture"
+    "message": "Core-Node-Architektur kennenlernen"
   },
   "exchanges.howDoesItWork.title": {
-    "message": "How Does It Work?"
+    "message": "Wie funktioniert es?"
   },
   "exchanges.howDoesItWork.description": {
-    "message": "Cardano introduces an additional layer between users and developers and the core node. Within this layer, our code node team tracks and manages complex changes, potential issues, and hard forks that arise from protocol improvements. We implement necessary updates across Adrestia libraries and APIs, and take care of the maintenance so you don't have to."
+    "message": "Cardano führt eine zusätzliche Schicht zwischen Nutzern bzw. Entwicklern und dem Core-Node ein. Innerhalb dieser Schicht verfolgt und verwaltet unser Code-Node-Team komplexe Änderungen, potenzielle Probleme und Hard Forks, die aus Protokollverbesserungen entstehen. Wir implementieren nötige Updates in den Adrestia-Libraries und APIs und kümmern uns um die Wartung – damit du es nicht musst."
   },
   "exchanges.ctaTwoColumn.leftTitle": {
-    "message": "Adrestia User Guide"
+    "message": "Adrestia-Benutzerhandbuch"
   },
   "exchanges.ctaTwoColumn.leftText": {
-    "message": "Find out more about Adrestia and what it could mean for you. Our user guide is a handy, straight-forward resource to help you determine which actions to take and when."
+    "message": "Erfahre mehr über Adrestia und was es für dich bedeuten kann. Unser Benutzerhandbuch ist eine praktische, unkomplizierte Ressource, die dir hilft, die richtigen Schritte zur richtigen Zeit zu unternehmen."
   },
   "exchanges.ctaTwoColumn.leftButtonLabel": {
-    "message": "Access Adrestia"
+    "message": "Adrestia nutzen"
   },
   "exchanges.ctaTwoColumn.rightTitle": {
-    "message": "Adrestia Component Overview & Flow Chart Guide"
+    "message": "Adrestia-Komponenten & Flowchart-Guide"
   },
   "exchanges.ctaTwoColumn.rightText": {
-    "message": "Discover our new, self-contained set of libraries and APIs to decide which is right for you."
+    "message": "Entdecke unsere eigenständigen Libraries und APIs und finde heraus, welche die richtige für dich ist."
   },
   "exchanges.ctaTwoColumn.rightButtonLabel": {
-    "message": "Find out more"
+    "message": "Mehr erfahren"
   },
   "genesis.hero.title": {
     "message": "Genesis"
@@ -2393,10 +2393,10 @@
     "message": "Cardano Foundation, Switzerland: **7,168.00 BTC**"
   },
   "governance.hero.title": {
-    "message": "Governance on Cardano"
+    "message": "Governance auf Cardano"
   },
   "governance.hero.description": {
-    "message": "Cardano runs on a secure, decentralized system where ada holders shape the platform's development and influence the ecosystem's direction."
+    "message": "Cardano basiert auf einem sicheren, dezentralen System – Ada-Halter gestalten die Entwicklung der Plattform und beeinflussen die Richtung des Ökosystems."
   },
   "governance.meta.title": {
     "message": "Cardano Governance, Community-Driven Decision Making"
@@ -2405,106 +2405,106 @@
     "message": "Cardano governance gives every ada holder a voice. Delegate to a DRep, vote on proposals, or register as a delegate representative to shape the network."
   },
   "governance.divider.withinCardano": {
-    "message": "Governance Within Cardano"
+    "message": "Governance bei Cardano"
   },
   "governance.withinCardano.text1": {
-    "message": "Cardano is defined by its community. Its governance model shows that true democracy - in which individuals are incentivized to play a role and votes are immutably recorded - is possible. It is a way for token holders to decide the future of a platform, and for the community to dictate the use of Cardano's treasury funds."
+    "message": "Cardano wird von seiner Community definiert. Das Governance-Modell zeigt, dass echte Demokratie möglich ist – eine, in der jeder Einzelne zum Mitwirken motiviert wird und Abstimmungen unveränderlich festgehalten werden. Token-Halter bestimmen die Zukunft der Plattform und entscheiden über den Einsatz der Treasury-Mittel."
   },
   "governance.withinCardano.text2": {
-    "message": "This model and the pioneering technology that underpins it can be applied to any application, system, or even society. It is a blueprint for change that is decided by the many, as well as the few, and which will redistribute power, eliminating intermediaries, to improve the lives of all."
+    "message": "Dieses Modell und die wegweisende Technologie dahinter lassen sich auf jede Anwendung, jedes System und sogar auf ganze Gesellschaften übertragen. Es ist ein Entwurf für Veränderung – getragen von vielen, nicht nur von wenigen –, der Macht umverteilt, Mittelsmänner beseitigt und das Leben aller verbessert."
   },
   "governance.withinCardano.quote": {
-    "message": "Change begins with one voice. But is realized through the Combination of many."
+    "message": "Wandel beginnt mit einer Stimme – und wird Wirklichkeit durch das Zusammenwirken vieler."
   },
   "governance.withinCardano.buttonText": {
-    "message": "Stay up to date"
+    "message": "Auf dem Laufenden bleiben"
   },
   "governance.divider.delegateVoting": {
-    "message": "Delegate your voting power"
+    "message": "Stimmrecht delegieren"
   },
   "governance.delegateVoting.text": {
-    "message": "Delegation is the act of lending your voting power—equal to the ada balance in your wallet—to a Delegate Representative (DRep), who votes on your behalf like a parliamentary representative. Alternatively, you can use automatic voting options to abstain or signal \"No Confidence\" in all proposals."
+    "message": "Delegation bedeutet, dein Stimmrecht – entsprechend deinem Ada-Guthaben – einem Delegate Representative (DRep) zu übertragen, der in deinem Namen abstimmt, ähnlich einem Parlamentsabgeordneten. Alternativ kannst du automatisch abstimmen: Enthaltung oder ‚Kein Vertrauen' bei allen Vorschlägen."
   },
   "governance.delegateVoting.buttonText": {
-    "message": "Find a DRep"
+    "message": "DRep finden"
   },
   "governance.divider.becomeDRep": {
-    "message": "Become a DRep on Cardano"
+    "message": "DRep auf Cardano werden"
   },
   "governance.becomeDRep.text1": {
-    "message": "DReps are key participants in governing the Cardano network. They actively engage in governance and represent other Cardano members. DReps must stay informed on governance actions to make wise decisions."
+    "message": "DReps sind zentrale Akteure in der Cardano-Governance. Sie beteiligen sich aktiv und vertreten andere Community-Mitglieder. DReps müssen über Governance Actions informiert bleiben, um fundierte Entscheidungen zu treffen."
   },
   "governance.becomeDRep.text2": {
-    "message": "If you have the time and commitment to contribute to Cardano's governance, register as a DRep. A refundable deposit of 500 ada is required and will be returned upon retirement."
+    "message": "Wenn du die Zeit und das Engagement hast, zur Governance von Cardano beizutragen, registriere dich als DRep. Eine erstattungsfähige Kaution von 500 Ada ist erforderlich und wird bei Rücktritt zurückgezahlt."
   },
   "governance.becomeDRep.buttonText": {
-    "message": "Become a DRep"
+    "message": "DRep werden"
   },
   "governance.divider.viewActions": {
-    "message": "View Governance Actions on Cardano"
+    "message": "Governance Actions auf Cardano ansehen"
   },
   "governance.viewActions.text": {
-    "message": "Stay informed and participate in Cardano's decentralized governance. View all on-chain actions, including those recently submitted, ratified, enacted, expired, or dropped. Engage with ongoing proposals, track their progress, and understand their impact on the network. Your involvement helps shape the future of Cardano. Click below to see all current and past governance actions and make your voice heard."
+    "message": "Bleib informiert und beteilige dich an Cardanos dezentraler Governance. Sieh dir alle On-Chain-Aktionen an – eingereichte, ratifizierte, in Kraft getretene, abgelaufene und zurückgezogene. Verfolge laufende Vorschläge, beobachte ihren Fortschritt und verstehe ihre Auswirkungen auf das Netzwerk. Deine Beteiligung hilft, die Zukunft von Cardano zu gestalten."
   },
   "governance.viewActions.buttonText": {
     "message": "Governance Actions"
   },
   "governance.divider.whyVoltaire": {
-    "message": "Why Voltaire"
+    "message": "Warum Voltaire"
   },
   "governance.divider.actionCharts": {
     "message": "Governance Action Charts"
   },
   "governance.actionCharts.text": {
-    "message": "Discover how Cardano governance works with an interactive set of charts that illuminate each governance action. Navigate processes, rules, and thresholds at a glance, with visual explanations that make exploration fast and practical."
+    "message": "Entdecke, wie Cardano-Governance funktioniert – mit interaktiven Charts, die jede Governance Action veranschaulichen. Prozesse, Regeln und Schwellenwerte auf einen Blick – visuell erklärt für schnelles Verständnis."
   },
   "governance.actionCharts.buttonText": {
     "message": "Governance Action Charts"
   },
   "hardforks.timeline.byron.description": {
-    "message": "The launch of the Cardano mainnet and introduction of the ada cryptocurrency."
+    "message": "Start des Cardano-Mainnets und Einführung der Kryptowährung Ada."
   },
   "hardforks.timeline.label.epoch": {
-    "message": "Epoch"
+    "message": "Epoche"
   },
   "hardforks.timeline.label.protocolVersion": {
-    "message": "Protocol Version"
+    "message": "Protokollversion"
   },
   "hardforks.timeline.label.transactionId": {
-    "message": "Transaction ID"
+    "message": "Transaktions-ID"
   },
   "hardforks.timeline.shelley.description": {
-    "message": "Introduced staking and decentralization features, transitioning from a federated to a decentralized system."
+    "message": "Einführung von Staking und Dezentralisierungsfunktionen – der Übergang von einem föderierten zu einem dezentralen System."
   },
   "hardforks.timeline.allegra.description": {
-    "message": "Added token locking capabilities, which was a prerequisite for the smart contract functionality."
+    "message": "Token-Locking-Funktionen als Voraussetzung für die spätere Smart-Contract-Funktionalität."
   },
   "hardforks.timeline.mary.description": {
-    "message": "Brought native token functionality to Cardano, allowing users to create and transact with custom tokens."
+    "message": "Native-Token-Funktionalität für Cardano – Nutzer können eigene Token erstellen und damit handeln."
   },
   "hardforks.timeline.alonzo.description": {
-    "message": "Introduced smart contract capabilities using Plutus, enabling the deployment of decentralized applications (dApps)."
+    "message": "Smart-Contract-Fähigkeiten mit Plutus – und damit die Möglichkeit, dezentrale Anwendungen (dApps) zu erstellen."
   },
   "hardforks.timeline.vasil.description": {
-    "message": "Improved the scalability and performance of the network, named after Vasil Dabov, a Cardano community member."
+    "message": "Verbesserung der Skalierbarkeit und Performance des Netzwerks – benannt nach Vasil Dabov, einem Mitglied der Cardano-Community."
   },
   "hardforks.timeline.label.transactionIds": {
-    "message": "Transaction IDs"
+    "message": "Transaktions-IDs"
   },
   "hardforks.timeline.valentine.description": {
-    "message": "Introduced further improvements to Plutus smart contract functionality and overall network performance."
+    "message": "Weitere Verbesserungen der Plutus-Smart-Contract-Funktionalität und der Netzwerk-Performance."
   },
   "hardforks.timeline.chang1.description": {
-    "message": "Introducing the first batch of decentralized governance features of CIP-1694. Enabling only parameter changes and hard fork initiations."
+    "message": "Erste dezentrale Governance-Funktionen aus CIP-1694 – zunächst nur Parameteränderungen und Hard-Fork-Initiierungen."
   },
   "hardforks.timeline.plomin.description": {
-    "message": "Introducing the second batch of decentralized governance features of CIP-1694. Enabling the full set of governance actions and the DRep role."
+    "message": "Zweite Welle der dezentralen Governance-Funktionen aus CIP-1694 – mit dem vollständigen Set an Governance-Aktionen und der DRep-Rolle."
   },
   "hardforks.hero.title": {
-    "message": "Hard forks"
+    "message": "Hard Forks"
   },
   "hardforks.hero.description": {
-    "message": "What hard forks were implemented, and what functionalities did they introduce?"
+    "message": "Welche Hard Forks gab es bisher – und welche Neuerungen haben sie gebracht?"
   },
   "hardforks.layout.title": {
     "message": "Cardano Hard Forks, Network Upgrade History"
@@ -2516,22 +2516,22 @@
     "message": "Cardano Hard Forks"
   },
   "hardforks.content.description": {
-    "message": "Hard forks in Cardano do not signify division and differences within the ecosystem. On the contrary, they define a specific and collectively agreed-upon exact time (slot) when all nodes switch from the current era to a new one, applying new functions, validation rules, or parameter values. All stake pool operators need to install the upgrade, and they also have a say and must agree to it. A Cardano hard fork is, therefore, not a separation but a precise collective evolution."
+    "message": "Hard Forks bedeuten bei Cardano keine Spaltung oder Meinungsverschiedenheiten innerhalb des Ökosystems. Im Gegenteil: Sie markieren einen exakten, gemeinschaftlich vereinbarten Zeitpunkt (Slot), an dem alle Nodes von der aktuellen Ära zur nächsten wechseln – mit neuen Funktionen, Validierungsregeln oder Parameterwerten. Alle Stake-Pool-Betreiber müssen das Upgrade installieren und haben dabei ein Mitspracherecht. Ein Hard Fork bei Cardano ist also keine Trennung, sondern eine präzise kollektive Weiterentwicklung."
   },
   "hardforks.divider.timeline": {
-    "message": "Timeline"
+    "message": "Zeitstrahl"
   },
   "hardforks.loading": {
-    "message": "Loading..."
+    "message": "Wird geladen..."
   },
   "hardforks.divider.transactionIds": {
-    "message": "hard fork transaction ids"
+    "message": "Hard-Fork-Transaktions-IDs"
   },
   "hardforks.transactionIds.description": {
-    "message": "Note that some hard forks, particularly Byron and Shelley, transitioned through a series of updates and may not have a single specific transaction id associated with them. For the others, the provided transaction ids correspond to significant parameter updates leading to the hard forks."
+    "message": "Einige Hard Forks – insbesondere Byron und Shelley – wurden durch eine Reihe von Updates umgesetzt und haben daher keine einzelne Transaktions-ID. Bei den übrigen entsprechen die angegebenen Transaktions-IDs den wesentlichen Parameteränderungen im Zuge der Hard Forks."
   },
   "learn.hero.title": {
-    "message": "Learn"
+    "message": "Lernen"
   },
   "learn.hero.description": {
     "message": "Empowering the digital architects of the future."
@@ -2543,31 +2543,31 @@
     "message": "Learn how Cardano works, from proof-of-stake consensus and smart contracts to staking, governance, and building decentralized applications."
   },
   "newsletter.hero.title": {
-    "message": "Stay Informed"
+    "message": "Bleib informiert"
   },
   "newsletter.hero.description": {
-    "message": "Get access to the latest Cardano news and content, and the hottest topics happening around the Cardano ecosystem."
+    "message": "Erhalte Zugang zu den neuesten Cardano-Neuigkeiten und den heißesten Themen rund um das Cardano-Ökosystem."
   },
   "newsletter.layout.title": {
     "message": "Cardano Community Digest, Weekly News and Updates"
   },
   "newsletter.layout.description": {
-    "message": "Get access to the latest Cardano news and content, and the hottest topics happening around the Cardano ecosystem."
+    "message": "Erhalte Zugang zu den neuesten Cardano-Neuigkeiten und den heißesten Themen rund um das Cardano-Ökosystem."
   },
   "newsletter.divider.text": {
-    "message": "Stay informed"
+    "message": "Bleib informiert"
   },
   "newsletter.content.title": {
     "message": "Cardano Community Digest"
   },
   "newsletter.content.description": {
-    "message": "Get your bi-weekly dose of the latest hot topics, development updates, a list of upcoming meetups, delegation strategy updates, what our Cardano Ambassadors are up to, and much more."
+    "message": "Alle zwei Wochen das Wichtigste: aktuelle Themen, Entwicklungs-Updates, bevorstehende Meetups, Delegationsstrategie-Updates, Neuigkeiten von unseren Cardano-Ambassadors und vieles mehr."
   },
   "ouroboros.hero.title": {
     "message": "Ouroboros"
   },
   "ouroboros.hero.description": {
-    "message": "An environmentally sustainable, verifiably secure proof-of-stake protocol with rigorous security guarantees."
+    "message": "Ein umweltfreundliches, nachweislich sicheres Proof-of-Stake-Protokoll mit rigorosen Sicherheitsgarantien."
   },
   "ouroboros.meta.title": {
     "message": "Ouroboros, Cardano's Proof-of-Stake Protocol"
@@ -2639,16 +2639,16 @@
     "message": "Ouroboros solves the greatest challenge faced by existing blockchains: the need for more and more energy to achieve consensus. Using Ouroboros, Cardano is able to securely, sustainably, and ethically scale, with up to [four million times the energy efficiency of bitcoin](https://iohk.io/en/blog/posts/2020/03/23/from-classic-to-hydra-the-implementations-of-ouroboros-explained/)."
   },
   "ouroboros.cta.title": {
-    "message": "Attack the protocol, fork the blockchain - or not. Explore the Ouroboros protocol firsthand in this interactive simulation."
+    "message": "Greif das Protokoll an, forke die Blockchain – oder lass es bleiben. Erlebe das Ouroboros-Protokoll hautnah in dieser interaktiven Simulation."
   },
   "ouroboros.cta.buttonLabel": {
-    "message": "Play the game"
+    "message": "Spiel starten"
   },
   "research.hero.title": {
-    "message": "Research"
+    "message": "Forschung"
   },
   "research.hero.description": {
-    "message": "Cardano relevant research papers and specifications."
+    "message": "Forschungspapiere und Spezifikationen rund um Cardano."
   },
   "research.meta.title": {
     "message": "Cardano Research, Peer-Reviewed Blockchain Science"
@@ -2660,22 +2660,22 @@
     "message": "Signal your interest in Cardano Governance"
   },
   "signalGovernance.layout.description": {
-    "message": "We'll keep you updated on DReps, proposals and how to get involved."
+    "message": "Wir halten dich über DReps, Proposals und Beteiligungsmöglichkeiten auf dem Laufenden."
   },
   "signalGovernance.openGraph.title": {
-    "message": "Signal your interest in Governance"
+    "message": "Interesse an Governance bekunden"
   },
   "signalGovernance.openGraph.description": {
-    "message": "We'll keep you updated on DReps, proposals and how to get involved."
+    "message": "Wir halten dich über DReps, Proposals und Beteiligungsmöglichkeiten auf dem Laufenden."
   },
   "signalGovernance.hero.title": {
-    "message": "Signal your interest in Governance"
+    "message": "Interesse an Governance bekunden"
   },
   "signalGovernance.hero.description": {
-    "message": "We'll keep you updated on DReps, proposals and how to get involved."
+    "message": "Wir halten dich über DReps, Proposals und Beteiligungsmöglichkeiten auf dem Laufenden."
   },
   "signalGovernance.divider.text": {
-    "message": "governance"
+    "message": "Governance"
   },
   "signalOperator.layout.title": {
     "message": "Signal your interest in Cardano Stake Pool Operations"
@@ -2720,187 +2720,187 @@
     "message": "Available Topics"
   },
   "solutions.hero.title": {
-    "message": "Enterprise Solutions"
+    "message": "Enterprise-Lösungen"
   },
   "solutions.hero.description": {
-    "message": "Proven blockchain solutions for supply chain, identity, and beyond."
+    "message": "Erprobte Blockchain-Lösungen für Lieferketten, Identität und mehr."
   },
   "solutions.layout.title": {
     "message": "Cardano Enterprise Solutions, Blockchain for Business"
   },
   "solutions.layout.description": {
-    "message": "Discover proven enterprise blockchain solutions built on Cardano. From supply chain traceability to digital product passports, explore real-world implementations."
+    "message": "Erprobte Enterprise-Blockchain-Lösungen auf Cardano entdecken – von Lieferketten-Rückverfolgbarkeit bis zu digitalen Produktpässen."
   },
   "solutions.intro.description": {
-    "message": "Cardano powers enterprise solutions across industries, combining the security and transparency of blockchain with practical business applications. Our proven deployments demonstrate how organizations can leverage decentralized technology for supply chain management, product authentication, and sustainability tracking."
+    "message": "Cardano treibt Enterprise-Lösungen in verschiedensten Branchen voran – mit der Sicherheit und Transparenz der Blockchain kombiniert mit praxisnahen Geschäftsanwendungen. Unsere erprobten Einsätze zeigen, wie Organisationen dezentrale Technologie für Lieferkettenmanagement, Produktauthentifizierung und Nachhaltigkeitsmonitoring nutzen."
   },
   "solutions.divider.explore": {
-    "message": "Explore Use Cases"
+    "message": "Anwendungsfälle entdecken"
   },
   "solutions.explore.description": {
-    "message": "Looking for specific blockchain applications? Explore our comprehensive use case library covering identity, finance, supply chain, and more."
+    "message": "Du suchst bestimmte Blockchain-Anwendungen? Entdecke unsere Übersicht mit Anwendungsfällen aus den Bereichen Identität, Finanzen, Lieferkette und mehr."
   },
   "solutions.explore.button": {
-    "message": "View All Use Cases"
+    "message": "Alle Anwendungsfälle ansehen"
   },
   "solutions.cta.title": {
-    "message": "Ready to build on Cardano? Connect with the Cardano Foundation to explore partnership opportunities."
+    "message": "Bereit, auf Cardano zu entwickeln? Kontaktiere die Cardano Foundation und entdecke Partnerschaftsmöglichkeiten."
   },
   "solutions.cta.button": {
-    "message": "Contact Us"
+    "message": "Kontakt aufnehmen"
   },
   "delegation.faq.q1": {
-    "message": "What is a stake pool?"
+    "message": "Was ist ein Stake Pool?"
   },
   "delegation.faq.a1.p1": {
-    "message": "Stake pools are run by stake pool operators. These are network participants with the skills to reliably ensure consistent uptime of a node, which is essential in ensuring the success of the Ouroboros protocol and the Cardano network as a whole."
+    "message": "Stake Pools werden von Stake-Pool-Betreibern geführt. Das sind Netzwerkteilnehmer mit dem Know-how, einen Node zuverlässig rund um die Uhr zu betreiben – entscheidend für das Ouroboros-Protokoll und das gesamte Cardano-Netzwerk."
   },
   "delegation.faq.a1.p2": {
-    "message": "The protocol uses a probabilistic mechanism to select a leader for each slot, who will be expected to create the next block in the chain. The chance of a stake pool node being selected as slot leader increases proportionately to the amount of stake delegated to that node. Each time a stake pool node is selected as a slot leader and successfully creates a block, it receives a reward, which is shared with the pool proportionate to the amount each member has delegated. Stake pool operators can deduct their running costs from the awarded ada, as well as specify a profit margin for providing the service."
+    "message": "Das Protokoll wählt per Zufallsverfahren einen Leader für jeden Slot, der den nächsten Block erzeugt. Je mehr Stake an einen Node delegiert ist, desto höher die Chance, ausgewählt zu werden. Für jeden erfolgreich erzeugten Block erhält der Pool eine Belohnung, die proportional zum delegierten Anteil aufgeteilt wird. Pool-Betreiber können ihre Betriebskosten und eine Gewinnmarge abziehen."
   },
   "delegation.faq.q2": {
-    "message": "Can I re-delegate my stake to another pool?"
+    "message": "Kann ich meinen Stake an einen anderen Pool übertragen?"
   },
   "delegation.faq.a2.p1": {
-    "message": "Delegated stake can be re-delegated to another pool at any time. Re-delegated stake will remain in the current pool until the epoch after next (from the point of re-delegation), after which your delegation preferences will be updated on the chain and your stake moved to the new stake pool. Rewards are distributed from the end of each epoch, so you'll continue to receive rewards from your original stake pool for two epochs before your new delegation preferences are applied."
+    "message": "Ja. Du kannst deinen Stake jederzeit an einen anderen Pool delegieren. Der Stake bleibt bis zur übernächsten Epoch im bisherigen Pool, danach wird deine neue Delegation auf der Chain aktualisiert. Da Belohnungen am Ende jeder Epoch verteilt werden, erhältst du noch für zwei Epochen Belohnungen vom alten Pool."
   },
   "delegation.faq.q3": {
-    "message": "Can I delegate to multiple stake pools?"
+    "message": "Kann ich an mehrere Stake Pools gleichzeitig delegieren?"
   },
   "delegation.faq.a3.p1": {
-    "message": "Some wallets offer different solutions for delegating to different stake pools at the same time. [Discover wallets](/what-is-ada#wallets)."
+    "message": "Einige Wallets bieten Lösungen, um gleichzeitig an verschiedene Stake Pools zu delegieren. [Wallets entdecken](/what-is-ada#wallets)."
   },
   "delegation.faq.q4": {
-    "message": "What is stake pool performance?"
+    "message": "Was ist Stake-Pool-Performance?"
   },
   "delegation.faq.a4.p1": {
-    "message": "The performance metric is an indicator of how well a stake pool is performing. Considering that the slot leader election process is private, it is only possible to estimate how often the stake pool should be elected based on the number of actually produced blocks. A pool can be nominated more often than expected based on its stake. For example, if a pool only produces half the number of blocks that it was nominated for, its performance rating is 50%. This could happen because the pool has a poor network connection, or has been turned off by its operator."
+    "message": "Die Performance zeigt, wie zuverlässig ein Stake Pool arbeitet. Da die Slot-Leader-Wahl privat erfolgt, lässt sich nur schätzen, wie oft ein Pool gewählt werden sollte – basierend auf den tatsächlich erzeugten Blöcken. Produziert ein Pool z. B. nur die Hälfte der erwarteten Blöcke, liegt seine Performance bei 50 %. Das kann an einer schlechten Netzwerkverbindung oder daran liegen, dass der Betreiber den Pool abgeschaltet hat."
   },
   "delegation.faq.a4.p2": {
-    "message": "Performance ratings make more sense over a longer period of time. If a pool has not yet been selected to produce a block in the current epoch, its performance rating will be 0%, even if it is likely to produce blocks later in the epoch. Performance ratings of over 100% are possible if a pool creates more blocks than it was nominated to produce."
+    "message": "Performance-Werte werden über einen längeren Zeitraum aussagekräftiger. Wurde ein Pool in der aktuellen Epoch noch nicht ausgewählt, steht seine Performance bei 0 % – selbst wenn er später noch Blöcke erzeugen wird. Werte über 100 % sind möglich, wenn ein Pool mehr Blöcke produziert als erwartet."
   },
   "delegation.faq.q5": {
-    "message": "What is stake pool saturation?"
+    "message": "Was ist Stake-Pool-Sättigung?"
   },
   "delegation.faq.a5.p1": {
-    "message": "Saturation is a term used to indicate that a particular stake pool has more stake delegated to it than is ideal for the network, and once a pool reaches the point of saturation it will offer diminishing rewards. The saturation mechanism was designed to prevent centralization by encouraging delegators to delegate to different stake pools, and operators to set up alternative pools so that they can continue earning maximum rewards. Saturation, therefore, exists to preserve the interests of both ada holders delegating their stake and stake pool operators."
+    "message": "Sättigung bedeutet, dass ein Pool mehr Stake hat als für das Netzwerk ideal ist – ab diesem Punkt sinken die Belohnungen. Dieser Mechanismus soll Zentralisierung verhindern: Delegierende werden ermutigt, ihren Stake auf verschiedene Pools zu verteilen, und Betreiber, weitere Pools aufzusetzen."
   },
   "delegation.faq.a5.p2": {
-    "message": "The goal is to avoid any single pool becoming too large – thereby disincentivizing delegation to other pools – and receiving a disproportionate amount of the rewards. The health of the network is partly determined by having a high number of active stake pools with a balanced amount of stake delegated to them. The more numerous and geographically diverse the network's pools, the better. Each stake pool's saturation percentage is shown within the Daedalus stake pool selection menu."
+    "message": "Ziel ist es, einzelne Pools nicht zu groß werden zu lassen, damit die Belohnungen fair verteilt bleiben. Die Gesundheit des Netzwerks hängt von vielen aktiven Pools mit ausgewogenem Stake ab – je zahlreicher und geografisch vielfältiger, desto besser. Der Sättigungsgrad jedes Pools wird im Daedalus-Auswahlmenü angezeigt."
   },
   "delegation.faq.q6": {
-    "message": "What is stake pool desirability?"
+    "message": "Was ist die Attraktivität eines Stake Pools?"
   },
   "delegation.faq.a6.p1": {
-    "message": "Desirability measures how desirable a stake pool is to an ada holder seeking to delegate their stake. It is influenced by a number of factors – including a stake pool's margin, fee, performance, the total reward available in the current epoch, and saturation percentage – and contributes to determining a stake pool's ranking."
+    "message": "Die Attraktivität misst, wie interessant ein Stake Pool für Delegierende ist. Sie wird von mehreren Faktoren beeinflusst – darunter die Marge des Pools, seine Gebühren, Performance, die verfügbare Gesamtbelohnung in der aktuellen Epoch und der Sättigungsgrad – und fließt in das Ranking ein."
   },
   "delegation.faq.q7": {
-    "message": "How are stake pools ranked?"
+    "message": "Wie werden Stake Pools gerankt?"
   },
   "delegation.faq.a7.p1": {
-    "message": "Stake pools are ranked mainly through a combination of their desirability and performance, in addition to other factors. It is worth mentioning here that the wallet developers make this decision for their wallet. [Discover wallets](/what-is-ada#wallets)."
+    "message": "Stake Pools werden hauptsächlich nach Attraktivität und Performance gerankt, zusammen mit weiteren Faktoren. Wichtig: Die Wallet-Entwickler entscheiden, wie das Ranking in ihrer Wallet umgesetzt wird. [Wallets entdecken](/what-is-ada#wallets)."
   },
   "delegation.faq.q8": {
-    "message": "How should I choose a stake pool?"
+    "message": "Wie wähle ich den richtigen Stake Pool?"
   },
   "delegation.faq.a8.p1": {
-    "message": "Choosing a stake pool involves several factors to consider to ensure you make a well-informed decision. So-called [pool tools](/apps?tags=pooltool) can help you choose a stake pool. Points to consider:"
+    "message": "Bei der Wahl eines Stake Pools spielen mehrere Faktoren eine Rolle. [Pool-Tools](/apps?tags=pooltool) können dir bei der Entscheidung helfen. Worauf du achten solltest:"
   },
   "delegation.faq.a8.p2": {
-    "message": "**Performance:** Look at the pool's historical performance, which reflects its success rate in producing blocks. A consistently high performance is a good indicator of the pool's reliability and effective operation."
+    "message": "**Performance:** Achte auf die historische Performance – sie zeigt, wie zuverlässig der Pool Blöcke erzeugt. Konstant hohe Werte sprechen für einen gut betriebenen Pool."
   },
   "delegation.faq.a8.p3": {
-    "message": "**Uptime:** Ensure the pool has high uptime. This means the pool's servers are running without interruption, increasing the chances of being selected to produce a block."
+    "message": "**Verfügbarkeit:** Der Pool sollte möglichst unterbrechungsfrei laufen. Hohe Verfügbarkeit steigert die Chancen, für die Blockerzeugung ausgewählt zu werden."
   },
   "delegation.faq.a8.p4": {
-    "message": "**Margin Fees:** Stake pools charge a percentage fee on the rewards earned. Lower fees can mean more rewards, but consider the balance between low fees and high pool performance."
+    "message": "**Marge:** Stake Pools erheben eine prozentuale Gebühr auf die Belohnungen. Niedrigere Gebühren bedeuten mehr Ertrag – aber achte auf das Verhältnis zu Performance und Zuverlässigkeit."
   },
   "delegation.faq.a8.p5": {
-    "message": "**Fixed Fees:** There is often a minimum fixed fee (set by the protocol) that pools will charge. Check what fixed fee the pool charges."
+    "message": "**Fixgebühr:** Es gibt eine vom Protokoll festgelegte Mindestgebühr. Prüfe, welche Fixgebühr der Pool erhebt."
   },
   "delegation.faq.a8.p6": {
-    "message": "**Saturation Point:** A pool becomes saturated when it has more stake than an optimal amount set by the protocol. Staking with a saturated pool can decrease your rewards, so it's advisable to choose a pool below this threshold."
+    "message": "**Sättigungspunkt:** Ein Pool ist gesättigt, wenn er mehr Stake hat als das Protokoll als optimal vorsieht. Bei einem gesättigten Pool sinken die Belohnungen – wähle besser einen Pool unter dieser Schwelle."
   },
   "delegation.faq.a8.p7": {
-    "message": "**Community Engagement:** Look for pools that actively engage with the Cardano community. This can be through educational content, community support, or contributions to the Cardano ecosystem."
+    "message": "**Community-Engagement:** Pools, die sich aktiv in der Cardano-Community einbringen – durch Bildung, Support oder Beiträge zum Ökosystem – sind oft eine gute Wahl."
   },
   "delegation.faq.a8.p8": {
-    "message": "**Mission-Driven Pools:** Some pools donate a portion of their fees to charitable causes or are dedicated to specific missions like environmental sustainability or education. If this aligns with your values, it might influence your choice."
+    "message": "**Pools mit Mission:** Manche Pools spenden einen Teil ihrer Gebühren für wohltätige Zwecke oder setzen sich für Nachhaltigkeit oder Bildung ein. Wenn dir das wichtig ist, kann das deine Wahl beeinflussen."
   },
   "delegation.faq.q9": {
-    "message": "How much will I earn in rewards?"
+    "message": "Wie viel verdiene ich an Belohnungen?"
   },
   "delegation.faq.a9.p1": {
-    "message": "You can use the [rewards calculator](/calculator) to get an idea of how much you will earn in rewards. It's important to note that the calculator produces only reward estimates and shouldn't be considered definitive or a guarantee of reward amounts. In the future, we will likely test different parameters that may affect reward margins. Amounts calculated are therefore subject to change, but represent a realistic and sensible level of return."
+    "message": "Mit dem [Belohnungsrechner](/calculator) bekommst du eine Schätzung deiner möglichen Belohnungen. Wichtig: Die Ergebnisse sind nur Richtwerte und keine Garantie. In Zukunft können sich Parameter ändern, die die Belohnungen beeinflussen. Die berechneten Beträge sind aber realistisch und sinnvoll."
   },
   "delegation.faq.q10": {
-    "message": "What wallets are supported and where do I find them?"
+    "message": "Welche Wallets werden unterstützt und wo finde ich sie?"
   },
   "delegation.faq.a10.p1": {
-    "message": "There are various wallets to choose from. Please make sure that you only download wallets from trustworthy sites. [Discover wallets](/what-is-ada#wallets)."
+    "message": "Es gibt verschiedene Wallets zur Auswahl. Achte darauf, Wallets nur von vertrauenswürdigen Seiten herunterzuladen. [Wallets entdecken](/what-is-ada#wallets)."
   },
   "delegation.faq.q11": {
-    "message": "Can I restore an ada balance from a hardware wallet?"
+    "message": "Kann ich ein Ada-Guthaben von einer Hardware-Wallet wiederherstellen?"
   },
   "delegation.faq.a11.p1": {
-    "message": "Yes. You can use Daedalus to restore an ada balance from a hardware wallet. However, we advise caution doing so. Entering your hardware wallet recovery phrase in Daedalus can expose your hardware wallet private keys to additional security risks. Recommendations to minimize security issues are available via Daedalus during the hardware wallet recovery process."
+    "message": "Ja. Du kannst Daedalus nutzen, um ein Ada-Guthaben von einer Hardware-Wallet wiederherzustellen. Aber Vorsicht: Die Eingabe deiner Hardware-Wallet-Recovery-Phrase in Daedalus kann deine privaten Schlüssel zusätzlichen Sicherheitsrisiken aussetzen. Empfehlungen dazu findest du während des Wiederherstellungsprozesses in Daedalus."
   },
   "delegation.faq.q12": {
-    "message": "Will the ada rewards I earn be added to my delegated stake?"
+    "message": "Werden meine Ada-Belohnungen dem delegierten Stake hinzugefügt?"
   },
   "delegation.faq.a12.p1": {
-    "message": "Yes. Rewards earned accrue with your original stake. When rewards are received, the balance of your reward account increases – and, consequently, the delegated stake is increased."
+    "message": "Ja. Belohnungen werden deinem bestehenden Stake zugerechnet. Sobald Belohnungen eingehen, steigt dein Guthaben – und damit auch dein delegierter Stake."
   },
   "stakePoolDelegation.hero.title": {
-    "message": "Delegate Your Stake"
+    "message": "Stake delegieren"
   },
   "stakePoolDelegation.hero.description": {
-    "message": "To build the network, earn rewards, and become part of the Cardano journey."
+    "message": "Stärke das Netzwerk, verdiene Belohnungen und werde Teil der Cardano-Reise."
   },
   "stakePoolDelegation.meta.title": {
     "message": "Delegate ada, Cardano Staking Made Simple"
   },
   "stakePoolDelegation.meta.description": {
-    "message": "Delegate your stake to build the network, earn rewards, and become part of the Cardano journey."
+    "message": "Delegiere deinen Stake, um das Netzwerk zu stärken, Belohnungen zu verdienen und Teil der Cardano-Reise zu werden."
   },
   "stakePoolDelegation.whatIsStake.divider": {
-    "message": "What is stake?"
+    "message": "Was ist Stake?"
   },
   "stakePoolDelegation.whatIsStake.text1": {
-    "message": "Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to delegate or pledge a stake is fundamental to how Cardano works."
+    "message": "Ada auf dem Cardano-Netzwerk repräsentiert einen Anteil (Stake) am Netzwerk – proportional zur Menge der gehaltenen Ada. Die Möglichkeit, Stake zu delegieren oder zu pledgen, ist grundlegend für die Funktionsweise von Cardano."
   },
   "stakePoolDelegation.whatIsStake.text2": {
-    "message": "There are two ways an ada holder can earn rewards: by delegating their stake to a stake pool run by someone else, or running their own stake pool. The amount of stake delegated to a given stake pool is the primary way the Ouroboros protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so."
+    "message": "Ada-Inhaber können auf zwei Wegen Belohnungen verdienen: indem sie ihren Stake an einen Stake Pool delegieren, der von jemand anderem betrieben wird, oder indem sie einen eigenen Stake Pool betreiben. Die Menge des an einen Pool delegierten Stakes bestimmt maßgeblich, wen das Ouroboros-Protokoll auswählt, den nächsten Block zur Blockchain hinzuzufügen – und dafür eine Belohnung zu erhalten."
   },
   "stakePoolDelegation.whatIsStake.text3": {
-    "message": "The more stake is delegated to a stake pool (up to a certain point), the more likely it is to make the next block – and the rewards are shared between everyone who delegated their stake to that stake pool."
+    "message": "Je mehr Stake an einen Pool delegiert wird (bis zu einem bestimmten Punkt), desto wahrscheinlicher erzeugt er den nächsten Block – und die Belohnungen werden unter allen aufgeteilt, die ihren Stake an diesen Pool delegiert haben."
   },
   "stakePoolDelegation.whatIsDelegation.divider": {
-    "message": "What is stake delegation?"
+    "message": "Was ist Stake-Delegation?"
   },
   "stakePoolDelegation.whatIsDelegation.text": {
-    "message": "Delegation is the process by which ada holders delegate the stake associated with their ada to a stake pool. It allows ada holders that do not have the skills or desire to run a node to participate in the network and be rewarded in proportion to the amount of stake delegated."
+    "message": "Delegation ist der Vorgang, bei dem Ada-Inhaber den mit ihrer Ada verbundenen Stake an einen Stake Pool übertragen. So können auch Nutzer am Netzwerk teilnehmen und proportional zu ihrem delegierten Stake Belohnungen verdienen – ohne selbst einen Node betreiben zu müssen."
   },
   "stakePoolDelegation.whyIncentives.divider": {
-    "message": "Why incentives?"
+    "message": "Warum Anreize?"
   },
   "stakePoolDelegation.whyIncentives.text": {
-    "message": "Incentives are used to ensure the longevity and health of the Cardano network and ecosystem. The incentive mechanism is underpinned by scientific research that combines mathematics, economic theory, and game theory."
+    "message": "Anreize sichern die Langlebigkeit und Gesundheit des Cardano-Netzwerks und -Ökosystems. Der Anreizmechanismus basiert auf wissenschaftlicher Forschung und vereint Mathematik, Wirtschaftstheorie und Spieltheorie."
   },
   "stakePoolDelegation.walletsCta.title": {
     "message": "Cardano Wallets"
   },
   "stakePoolDelegation.walletsCta.text": {
-    "message": "Discover a wide variety of wallets designed to facilitate your interaction with the Cardano ecosystem."
+    "message": "Entdecke eine große Auswahl an Wallets, die dir den Zugang zum Cardano-Ökosystem erleichtern."
   },
   "stakePoolDelegation.walletsCta.buttonLabel": {
-    "message": "Discover Now"
+    "message": "Jetzt entdecken"
   },
   "stakePoolDelegation.calculatorCta.title": {
-    "message": "Try our staking calculator to see how much ada you could be rewarded for delegating to a stake pool."
+    "message": "Probiere unseren Staking-Rechner aus und sieh, wie viel Ada du durch Delegation an einen Stake Pool verdienen könntest."
   },
   "stakePoolDelegation.calculatorCta.buttonLabel": {
-    "message": "Try Out"
+    "message": "Ausprobieren"
   },
   "stakePoolOperation.hero.title1": {
     "message": "Designed For Mass Participation"
@@ -2921,7 +2921,7 @@
     "message": "What is staking?"
   },
   "stakePoolOperation.whatIsStaking.leftText": {
-    "message": "Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to delegate or pledge a stake is fundamental to how Cardano works."
+    "message": "Ada auf dem Cardano-Netzwerk repräsentiert einen Anteil (Stake) am Netzwerk – proportional zur Menge der gehaltenen Ada. Die Möglichkeit, Stake zu delegieren oder zu pledgen, ist grundlegend für die Funktionsweise von Cardano."
   },
   "stakePoolOperation.whatIsStaking.rightText1": {
     "message": "There are two ways an ada holder can earn rewards: by delegating their stake to a stake pool run by someone else, or by running their own stake pool."
@@ -2981,13 +2981,13 @@
     "message": "Try our staking calculator to see how much ada you could receive by running a stake pool."
   },
   "stakePoolOperation.calculatorCta.buttonLabel": {
-    "message": "Try Out"
+    "message": "Ausprobieren"
   },
   "useCases.hero.title": {
-    "message": "Use Cases"
+    "message": "Anwendungsfälle"
   },
   "useCases.hero.description": {
-    "message": "How Cardano blockchain solves real-world problems across industries."
+    "message": "Wie die Cardano-Blockchain reale Probleme branchenübergreifend löst."
   },
   "useCases.layout.title": {
     "message": "Cardano Enterprise Solutions and Real-World Use Cases"
@@ -2996,16 +2996,16 @@
     "message": "Explore real-world Cardano use cases across supply chain, identity, finance, and education. See how enterprises leverage blockchain for transparency and efficiency."
   },
   "useCases.intro.description": {
-    "message": "Explore blockchain applications across industries. From identity verification to supply chain tracking, Cardano provides secure, scalable solutions for real-world challenges."
+    "message": "Blockchain-Anwendungen aus verschiedenen Branchen entdecken – von Identitätsprüfung bis Lieferkettenverfolgung. Cardano bietet sichere, skalierbare Lösungen für reale Herausforderungen."
   },
   "useCases.divider.enterprise": {
-    "message": "Enterprise Solutions"
+    "message": "Enterprise-Lösungen"
   },
   "useCases.enterprise.description": {
-    "message": "Looking for proven enterprise deployments? Explore case studies and real-world implementations by the Cardano Foundation and partners."
+    "message": "Du suchst erprobte Enterprise-Einsätze? Entdecke Fallstudien und praxisnahe Implementierungen der Cardano Foundation und ihrer Partner."
   },
   "useCases.enterprise.button": {
-    "message": "View Enterprise Solutions"
+    "message": "Enterprise-Lösungen ansehen"
   },
   "why.hero.title": {
     "message": "Why Cardano?"
@@ -3077,25 +3077,25 @@
     "message": "₳dd your project"
   },
   "apps.filters.title": {
-    "message": "Filters"
+    "message": "Filter"
   },
   "apps.filters.projectCount.singular": {
-    "message": "1 project"
+    "message": "1 Projekt"
   },
   "apps.filters.projectCount.plural": {
-    "message": "{count} projects"
+    "message": "{count} Projekte"
   },
   "apps.filters.clearButton": {
-    "message": "Clear filters"
+    "message": "Filter zurücksetzen"
   },
   "apps.filters.showLess": {
-    "message": "Show less filters"
+    "message": "Weniger Filter anzeigen"
   },
   "apps.filters.showMore": {
-    "message": "Show {count} more filters"
+    "message": "{count} weitere Filter anzeigen"
   },
   "apps.noResult": {
-    "message": "No result"
+    "message": "Keine Ergebnisse"
   },
   "apps.maintainerPicks": {
     "message": "Maintainer picks"
@@ -3104,10 +3104,10 @@
     "message": "Curated by page maintainers as strong starting points. Selection criteria: see /docs/get-involved/maintainer-picks."
   },
   "apps.allProjects": {
-    "message": "All Projects"
+    "message": "Alle Projekte"
   },
   "apps.searchPlaceholder": {
-    "message": "Search apps..."
+    "message": "Apps suchen..."
   },
   "apps.intent.title": {
     "message": "Find apps for"
@@ -3122,7 +3122,7 @@
     "message": "Vote"
   },
   "apps.intent.build": {
-    "message": "Build"
+    "message": "Entwickeln"
   },
   "apps.intent.mintNfts": {
     "message": "Mint NFTs"
@@ -3245,10 +3245,10 @@
     "message": "The newest apps in the showcase"
   },
   "apps.carousel.prev": {
-    "message": "Previous"
+    "message": "Zurück"
   },
   "apps.carousel.next": {
-    "message": "Next"
+    "message": "Weiter"
   },
   "apps.mostActive.leaderboardLink": {
     "message": "Live from the transaction leaderboard"
@@ -3281,7 +3281,7 @@
     "message": "Have a say in Cardano"
   },
   "apps.guidedPaths.developers": {
-    "message": "Build on Cardano"
+    "message": "Auf Cardano bauen"
   },
   "apps.submit.enableTracking": {
     "message": "Enable tracking"
@@ -3293,52 +3293,52 @@
     "message": "tx"
   },
   "insights.card.openInsight": {
-    "message": "Open insight"
+    "message": "Insight öffnen"
   },
   "insights.layout.title": {
     "message": "Cardano Insights, Data and Analytics"
   },
   "insights.layout.description": {
-    "message": "Explore interactive Cardano insights across governance, staking, consensus, economics, and more."
+    "message": "Interaktive Cardano-Insights zu Governance, Staking, Konsens, Ökonomie und mehr."
   },
   "insights.hero.title": {
     "message": "Insights"
   },
   "insights.hero.description": {
-    "message": "Explore Cardano topics through on-chain data and visual charts."
+    "message": "Cardano-Themen durch On-Chain-Daten und visuelle Charts erkunden."
   },
   "insights.search.placeholder": {
-    "message": "Search or filter by tags below..."
+    "message": "Suchen oder nach Tags filtern..."
   },
   "insights.search.ariaLabel": {
-    "message": "Search insights"
+    "message": "Insights durchsuchen"
   },
   "insights.filter.label": {
-    "message": "Filter by topic"
+    "message": "Nach Thema filtern"
   },
   "insights.filter.clear": {
-    "message": "Clear"
+    "message": "Zurücksetzen"
   },
   "insights.pagination.prevAriaLabel": {
-    "message": "Previous page"
+    "message": "Vorherige Seite"
   },
   "insights.pagination.prev": {
-    "message": "Prev"
+    "message": "Zurück"
   },
   "insights.pagination.pageOf": {
-    "message": "Page {current} of {total}"
+    "message": "Seite {current} von {total}"
   },
   "insights.pagination.nextAriaLabel": {
-    "message": "Next page"
+    "message": "Nächste Seite"
   },
   "insights.pagination.next": {
-    "message": "Next"
+    "message": "Weiter"
   },
   "insights.noResults": {
-    "message": "No insights matched your filters."
+    "message": "Keine Insights gefunden."
   },
   "ambassadors.roles.contentCreation.title": {
-    "message": "Content Creation"
+    "message": "Content-Erstellung"
   },
   "ambassadors.roles.contentCreation.description": {
     "message": "Articles, videos, podcasts and translations across languages."
@@ -3350,7 +3350,7 @@
     "message": "Organizing local meetups, workshops, hackathons and conferences."
   },
   "ambassadors.roles.education.title": {
-    "message": "Education & Advocacy"
+    "message": "Bildung & Advocacy"
   },
   "ambassadors.roles.education.description": {
     "message": "Teaching, onboarding new users and raising awareness."
@@ -3691,6 +3691,9 @@
   "ambassadors.directory.socialAria.youtube": {
     "message": "YouTube channel"
   },
+  "ambassadors.directory.socialAria.github": {
+    "message": "GitHub profile"
+  },
   "ambassadors.stories.divider": {
     "message": "Impact Stories"
   },
@@ -3740,91 +3743,91 @@
     "message": "Open-source contributions that make Cardano easier to use for developers everywhere."
   },
   "enterprise.label.solutions": {
-    "message": "Solutions"
+    "message": "Lösungen"
   },
   "enterprise.label.products": {
-    "message": "Products"
+    "message": "Produkte"
   },
   "enterprise.learnMore": {
-    "message": "Learn more"
+    "message": "Mehr erfahren"
   },
   "governance.blue.title": {
-    "message": "A Model To Marginalize None, And Give Power To All."
+    "message": "Ein Modell, das niemanden ausgrenzt und allen Macht verleiht."
   },
   "governance.blue.text": {
-    "message": "Our current systems do not work for everyone. A better, more positive future is possible. If the world is to serve the many, it must be agreed to by the many. Consensus must drive progress and where disagreement occurs, it must drive creative solutions."
+    "message": "Unsere heutigen Systeme funktionieren nicht für alle. Eine bessere, positivere Zukunft ist möglich. Soll die Welt den Vielen dienen, muss sie von den Vielen getragen werden. Konsens muss den Fortschritt antreiben – und wo Uneinigkeit herrscht, kreative Lösungen hervorbringen."
   },
   "governanceCharts.searchPlaceholder": {
-    "message": "Search for charts or parameters..."
+    "message": "Charts durchsuchen ..."
   },
   "governanceCharts.parametersButton": {
-    "message": "Parameters ▼"
+    "message": "Parameter"
   },
   "governanceCharts.availableParameters": {
-    "message": "Available Parameters:"
+    "message": "Verfügbare Parameter"
   },
   "governanceCharts.clearAll": {
-    "message": "Clear All"
+    "message": "Alle zurücksetzen"
   },
   "governanceCharts.selectCategory": {
-    "message": "Select a category:"
+    "message": "Kategorie wählen"
   },
   "governanceCharts.searchAndParamResults": {
-    "message": "Search Results & Parameter Filtered Charts:"
+    "message": "Such- & Parameter-gefilterte Charts"
   },
   "governanceCharts.searchResults": {
-    "message": "Search Results:"
+    "message": "Suchergebnisse"
   },
   "governanceCharts.paramFilteredCharts": {
-    "message": "Parameter Filtered Charts:"
+    "message": "Parameter-gefilterte Charts"
   },
   "governanceCharts.parameterDetails": {
-    "message": "Parameter Details"
+    "message": "Parameter-Details"
   },
   "governanceCharts.noResults.searchAndParams": {
-    "message": "No charts found matching \"{searchTerm}\" with the selected parameters."
+    "message": "Keine Charts gefunden für ‚{searchTerm}' mit den gewählten Parametern."
   },
   "governanceCharts.noResults.search": {
-    "message": "No charts found matching \"{searchTerm}\""
+    "message": "Keine Charts gefunden für ‚{searchTerm}'"
   },
   "governanceCharts.noResults.params": {
-    "message": "No charts found with the selected parameters."
+    "message": "Keine Charts mit den gewählten Parametern gefunden."
   },
   "governanceCharts.selectChart": {
-    "message": "Select a chart:"
+    "message": "Chart auswählen:"
   },
   "governanceCharts.emptyState": {
-    "message": "No charts available for this category yet."
+    "message": "Noch keine Charts für diese Kategorie verfügbar."
   },
   "governanceCharts.initialPrompt": {
-    "message": "Please select a category to view available governance charts, or use the search to find specific charts."
+    "message": "Wähle eine Kategorie, um Governance Charts anzuzeigen, oder nutze die Suche."
   },
   "governanceGraphs.fallback.unavailable": {
-    "message": "Graph visualization unavailable"
+    "message": "Diagramm-Darstellung nicht verfügbar"
   },
   "governanceGraphs.fallback.preview": {
-    "message": "Data preview:"
+    "message": "Datenvorschau:"
   },
   "governanceGraphs.downloading": {
-    "message": "Downloading..."
+    "message": "Wird heruntergeladen ..."
   },
   "governanceGraphs.downloadImage": {
-    "message": "Download Image"
+    "message": "Bild herunterladen"
   },
   "governance.voltaire.text1": {
-    "message": "Decentralization begins with the technology - with Shelley - but is only truly achieved when no single entity is in control. The governing principle of decentralization is the redistribution of control: global networks that are defined not from the middle, but by every participant. This is the purpose of Voltaire."
+    "message": "Dezentralisierung beginnt mit der Technologie – mit Shelley –, wird aber erst dann wirklich erreicht, wenn keine einzelne Instanz die Kontrolle hat. Das Leitprinzip: Umverteilung der Macht. Globale Netzwerke, die nicht von einer Zentrale definiert werden, sondern von jedem Teilnehmer. Das ist der Zweck von Voltaire."
   },
   "governance.voltaire.text2": {
-    "message": "Voltaire adds the ability for the Cardano community to make impactful decisions about software updates, technical improvements and funding decisions. Known as"
+    "message": "Voltaire gibt der Cardano-Community die Möglichkeit, wichtige Entscheidungen über Software-Updates, technische Verbesserungen und Finanzierung zu treffen. Diese sogenannten"
   },
   "governance.voltaire.text2b": {
-    "message": ", these allow the future of Cardano to be determined by its community and funded from the platform's treasury."
+    "message": " ermöglichen es, die Zukunft von Cardano durch die Community zu bestimmen und aus dem Treasury der Plattform zu finanzieren."
   },
   "governance.voltaire.text3": {
-    "message": "The era will also play host to a series of experiments, as we discuss topics such as decentralised governance, the dynamics of democracy and consent, evolving Voltaire from research to reality. If Shelley was the foundation of a globally coordinated network without a central authority, then Voltaire will explore the apparatus for shared decision making: the language of decentralization."
+    "message": "Die Ära bringt auch eine Reihe von Experimenten mit sich – zu Themen wie dezentraler Governance, den Dynamiken von Demokratie und Konsens –, um Voltaire von der Forschung in die Praxis zu überführen. Wenn Shelley das Fundament eines global koordinierten Netzwerks ohne zentrale Autorität gelegt hat, dann erkundet Voltaire den Apparat für gemeinsame Entscheidungsfindung: die Sprache der Dezentralisierung."
   },
   "governance.voltaire.buttonText": {
-    "message": "Read the research"
+    "message": "Forschung lesen"
   },
   "governance.delegate.layout.title": {
     "message": "Delegate to a DRep — Cardano Governance"
@@ -3965,91 +3968,91 @@
     "message": "Dashboard to monitor DReps and governance actions."
   },
   "quiz.ui.noQuestions": {
-    "message": "No quiz questions available."
+    "message": "Keine Quizfragen verfügbar."
   },
   "quiz.ui.greatJob": {
-    "message": "Great job!"
+    "message": "Gut gemacht!"
   },
   "quiz.ui.keepLearning": {
-    "message": "Keep learning!"
+    "message": "Weiter lernen!"
   },
   "quiz.ui.scoreText": {
-    "message": "You scored {score} out of {totalQuestions}"
+    "message": "Du hast {score} von {totalQuestions} richtig"
   },
   "quiz.ui.tryAgain": {
-    "message": "Try again"
+    "message": "Nochmal versuchen"
   },
   "quiz.ui.correct": {
-    "message": "Correct!"
+    "message": "Richtig!"
   },
   "quiz.ui.incorrect": {
-    "message": "Incorrect"
+    "message": "Falsch"
   },
   "quiz.ui.explanation": {
-    "message": "Explanation"
+    "message": "Erklärung"
   },
   "quiz.ui.checkAnswer": {
-    "message": "Check answer"
+    "message": "Antwort prüfen"
   },
   "quiz.ui.nextQuestion": {
-    "message": "Next question"
+    "message": "Nächste Frage"
   },
   "quiz.ui.finishQuiz": {
-    "message": "Finish quiz"
+    "message": "Quiz beenden"
   },
   "research.headings.papers": {
     "message": "Papers"
   },
   "research.headings.specifications": {
-    "message": "Specifications"
+    "message": "Spezifikationen"
   },
   "research.byron.subtitle": {
-    "message": "Foundation"
+    "message": "Grundstein"
   },
   "research.byron.description": {
-    "message": "A period dedicated to building a foundational federated network that enabled the purchase and sale of ada. The network ran the proof-of-stake Ouroboros consensus protocol."
+    "message": "Eine Phase, in der ein föderiertes Netzwerk aufgebaut wurde, das den Kauf und Verkauf von Ada ermöglichte. Das Netzwerk lief mit dem Proof-of-Stake-Konsensprotokoll Ouroboros."
   },
   "research.shelley.subtitle": {
-    "message": "Decentralization"
+    "message": "Dezentralisierung"
   },
   "research.shelley.description": {
-    "message": "A period of growth and development occurred for the network, focusing on ensuring greater decentralization. This phase led to enhanced security and a more robust environment, following the transition where the majority of nodes became operated by network participants."
+    "message": "Eine Phase des Wachstums mit Fokus auf Dezentralisierung. Mehr Sicherheit und ein robusteres Netzwerk – ermöglicht durch den Übergang zu einem System, in dem die Mehrheit der Nodes von Netzwerkteilnehmern betrieben wird."
   },
   "research.goguen.subtitle": {
     "message": "Smart Contracts"
   },
   "research.goguen.description": {
-    "message": "The Goguen era introduced smart-contract functionality, enabling the construction of decentralized applications while supporting multifunctional assets, fungible, and non-fungible token standards."
+    "message": "Die Goguen-Ära brachte Smart-Contract-Funktionalität und ermöglichte dezentrale Anwendungen – mit Unterstützung für Multi-Asset-Token, fungible und nicht-fungible Token-Standards."
   },
   "research.basho.subtitle": {
-    "message": "Scaling"
+    "message": "Skalierung"
   },
   "research.basho.description": {
-    "message": "An era of optimization, improving the scalability and interoperability of the network. Enhancing the network performance, Basho will introduce sidechains, new blockchains, interoperable with the main Cardano chain, with immense potential to extend the network's capabilities."
+    "message": "Eine Ära der Optimierung – mit Fokus auf Skalierbarkeit und Interoperabilität. Basho führt Sidechains ein: neue Blockchains, die mit der Cardano-Hauptchain interagieren und das Potenzial des Netzwerks erheblich erweitern."
   },
   "research.voltaire.subtitle": {
     "message": "Governance"
   },
   "research.voltaire.description": {
-    "message": "The development era is currently enabling the Cardano network to become a self-sustaining system. Voltaire is introducing a voting and treasury system that allows network participants to use their stake and voting rights to influence the future development of the blockchain."
+    "message": "Die aktuelle Entwicklungsphase macht Cardano zu einem sich selbst tragenden System. Voltaire führt ein Abstimmungs- und Treasury-System ein, mit dem Netzwerkteilnehmer ihren Stake und ihre Stimmrechte nutzen können, um die Zukunft der Blockchain mitzugestalten."
   },
   "solutions.card.learnMore": {
-    "message": "Learn more"
+    "message": "Mehr erfahren"
   },
   "solutions.section.title": {
-    "message": "Enterprise Solutions"
+    "message": "Enterprise-Lösungen"
   },
   "termExplainer.divider": {
-    "message": "{category} Terms you should know"
+    "message": "{category}-Begriffe, die du kennen solltest"
   },
   "apps.stickyButton": {
-    "message": "ADD YOUR APP"
+    "message": "APP HINZUFÜGEN"
   },
   "insightsGovernance.meta.pageTitle": {
     "message": "Cardano Governance Action Charts"
   },
   "insightsGovernance.meta.pageDescription": {
-    "message": "Visual representation of Cardano Governance Action process flows."
+    "message": "Visuelle Darstellung der Cardano Governance Action-Prozessabläufe."
   },
   "insightsGovernance.meta.title": {
     "message": "Cardano Governance Actions"
@@ -4058,154 +4061,154 @@
     "message": "Cardano Governance Actions"
   },
   "insightsGovernance.og.description": {
-    "message": "Explore the Cardano Governance Action flow logic."
+    "message": "Die Ablauflogik der Cardano Governance Actions erkunden."
   },
   "insightsGovernance.page.title": {
     "message": "Cardano Governance Action Charts"
   },
   "insightsGovernance.page.description": {
-    "message": "Explore the Cardano Governance Action Flows in a visual chart visualization"
+    "message": "Cardano Governance Action-Abläufe als visuelle Charts erkunden"
   },
   "insightsGovernance.page.keywords": {
-    "message": "Cardano, governance, action, DRep, SPO, voting, threshold"
+    "message": "Cardano, Governance, Action, DRep, SPO, Abstimmung, Schwellenwert"
   },
   "insightsGovernance.intro.paragraph1": {
-    "message": "**Governance Actions Insights** visualizes the seven Cardano governance action types as flowcharts. Each chart shows the lifecycle (submission → ratification → enactment), who votes (DReps, SPOs, Constitutional Committee) and the thresholds. Most actions require approval from **at least two of the three** bodies; some require **all three**. For definitions and full thresholds, see the [Developer Portal: Governance Actions](https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/)."
+    "message": "**Governance Actions Insights** visualisiert die sieben Cardano Governance Action-Typen als Flowcharts. Jeder Chart zeigt den Lebenszyklus (Einreichung → Ratifizierung → Inkrafttreten), wer abstimmt (DReps, SPOs, Constitutional Committee) und die Schwellenwerte. Die meisten Actions erfordern die Zustimmung von **mindestens zwei der drei** Gremien; einige erfordern **alle drei**. Definitionen und vollständige Schwellenwerte findest du im [Developer Portal: Governance Actions](https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/)."
   },
   "insightsGovernance.intro.paragraph2": {
-    "message": "Pick a **category** (General, Info Actions, Protocol Parameter Changes, Critical Parameter Changes), then choose a **chart**. Follow the nodes; **purple boxes** indicate thresholds and enactment order. You can **download** the diagram or simply **share the URL**, the address bar updates to the chart you're viewing. For the formal basis, see the **Cardano Constitution – Appendix I: Guardrails** [constitution](/constitution)."
+    "message": "Wähle eine **Kategorie** (General, Info Actions, Protocol Parameter Changes, Critical Parameter Changes) und dann einen **Chart**. Folge den Knoten; **violette Boxen** zeigen Schwellenwerte und Reihenfolge des Inkrafttretens. Du kannst das Diagramm **herunterladen** oder einfach die **URL teilen** – die Adressleiste aktualisiert sich passend zum angezeigten Chart. Die formale Grundlage findest du in der **Cardano Constitution – Appendix I: Guardrails** [Verfassung](/constitution)."
   },
   "insightsGovernance.intro.paragraph3": {
-    "message": "For **Protocol Parameter Changes**, the charts separate routine updates (typically **DReps + CC**) from **security-critical parameters**, which also need **SPO approval**, i.e., all three bodies. Appendix I lists the critical parameters and their permitted ranges/scope."
+    "message": "Bei **Protocol Parameter Changes** unterscheiden die Charts zwischen routinemäßigen Updates (typischerweise **DReps + CC**) und **sicherheitskritischen Parametern**, die zusätzlich die **Zustimmung der SPOs** erfordern – also alle drei Gremien. Appendix I listet die kritischen Parameter und ihre erlaubten Wertebereiche auf."
   },
   "insightsGovernance.divider.charts": {
     "message": "Governance Action Charts"
   },
   "insightsSupply.meta.pageTitle": {
-    "message": "Cardano Supply Overview"
+    "message": "Cardano-Angebotsübersicht"
   },
   "insightsSupply.meta.pageDescription": {
-    "message": "Visual representation of ada supply distribution across key categories in the Cardano network."
+    "message": "Visuelle Darstellung der Ada-Angebotsverteilung in den wichtigsten Kategorien des Cardano-Netzwerks."
   },
   "insightsSupply.meta.title": {
-    "message": "Cardano Supply Overview"
+    "message": "Cardano-Angebotsübersicht"
   },
   "insightsSupply.og.title": {
-    "message": "Cardano Supply Distribution"
+    "message": "Cardano-Angebotsverteilung"
   },
   "insightsSupply.og.description": {
-    "message": "Explore how ada is distributed across reserves, circulation, treasury, and rewards."
+    "message": "Erfahre, wie Ada auf Reserven, Umlauf, Treasury und Rewards verteilt ist."
   },
   "insightsSupply.error.configTitle": {
-    "message": "Missing configuration"
+    "message": "Fehlende Konfiguration"
   },
   "insightsSupply.error.configMessage": {
-    "message": "API URL is missing."
+    "message": "API-URL fehlt."
   },
   "insightsSupply.error.invalidEpochTitle": {
-    "message": "Invalid epoch"
+    "message": "Ungültige Epoche"
   },
   "insightsSupply.error.invalidEpochMessage": {
-    "message": "Epoch must be ≥ {minEpoch}."
+    "message": "Epoche muss ≥ {minEpoch} sein."
   },
   "insightsSupply.error.retrying": {
-    "message": "Retrying…"
+    "message": "Wird wiederholt…"
   },
   "insightsSupply.error.retry": {
-    "message": "Retry"
+    "message": "Erneut versuchen"
   },
   "insightsSupply.loading.preparing": {
-    "message": "Preparing…"
+    "message": "Wird vorbereitet…"
   },
   "insightsSupply.chart.circulation": {
-    "message": "Circulation"
+    "message": "Umlauf"
   },
   "insightsSupply.chart.circulationInfo": {
-    "message": "Sum of all circulating UTxOs"
+    "message": "Summe aller UTxOs im Umlauf"
   },
   "insightsSupply.chart.treasury": {
     "message": "Treasury"
   },
   "insightsSupply.chart.treasuryInfo": {
-    "message": "All ada currently in the treasury pot"
+    "message": "Gesamte Ada aktuell im Treasury-Topf"
   },
   "insightsSupply.chart.rewards": {
     "message": "Rewards"
   },
   "insightsSupply.chart.rewardsInfo": {
-    "message": "All unclaimed rewards"
+    "message": "Alle nicht abgehobenen Rewards"
   },
   "insightsSupply.chart.depositsStake": {
     "message": "Deposits Stake"
   },
   "insightsSupply.chart.depositsStakeInfo": {
-    "message": "Deposit pot for registered stake pools and staking accounts"
+    "message": "Deposit-Topf für registrierte Stake Pools und Staking-Konten"
   },
   "insightsSupply.chart.depositsDRep": {
     "message": "Deposits DRep"
   },
   "insightsSupply.chart.depositsDRepInfo": {
-    "message": "Deposit pot for registered DReps"
+    "message": "Deposit-Topf für registrierte DReps"
   },
   "insightsSupply.chart.depositsProposal": {
     "message": "Deposits Proposal"
   },
   "insightsSupply.chart.depositsProposalInfo": {
-    "message": "Deposit pot for active governance actions"
+    "message": "Deposit-Topf für aktive Governance Actions"
   },
   "insightsSupply.chart.fees": {
-    "message": "Fees"
+    "message": "Gebühren"
   },
   "insightsSupply.chart.feesInfo": {
-    "message": "Fees collected"
+    "message": "Eingenommene Gebühren"
   },
   "insightsSupply.chart.totalSupply": {
-    "message": "Total Supply"
+    "message": "Gesamtangebot"
   },
   "insightsSupply.chart.totalSupplyInfo": {
-    "message": "All ada in circulation + unclaimed rewards + deposits + fees + treasury"
+    "message": "Gesamte Ada im Umlauf + nicht abgehobene Rewards + Deposits + Gebühren + Treasury"
   },
   "insightsSupply.chart.reserves": {
-    "message": "Reserves"
+    "message": "Reserven"
   },
   "insightsSupply.chart.reservesInfo": {
-    "message": "Difference between maximum and total supply"
+    "message": "Differenz zwischen maximalem und Gesamtangebot"
   },
   "insightsSupply.chart.maximumSupply": {
-    "message": "Maximum supply"
+    "message": "Maximales Angebot"
   },
   "insightsSupply.chart.maximumSupplyInfo": {
-    "message": "The maximum amount of ada that can ever exist, based on the genesis block definition."
+    "message": "Die maximale Menge an Ada, die jemals existieren kann – definiert im Genesis-Block."
   },
   "insightsSupply.table.category": {
-    "message": "Category"
+    "message": "Kategorie"
   },
   "insightsSupply.table.ada": {
-    "message": "ada"
+    "message": "Ada"
   },
   "insightsSupply.table.description": {
-    "message": "Description"
+    "message": "Beschreibung"
   },
   "insightsSupply.faq.heading": {
-    "message": "Epoch {epoch} facts:"
+    "message": "Fakten zu Epoche {epoch}:"
   },
   "insightsSupply.faq.q1.question": {
-    "message": "Q: How did the values change compared to the previous Epoch?"
+    "message": "F: Wie haben sich die Werte im Vergleich zur vorherigen Epoche verändert?"
   },
   "insightsSupply.faq.q2.question": {
-    "message": "Q: How much ada was added to the treasury?"
+    "message": "F: Wie viel Ada wurde dem Treasury hinzugefügt?"
   },
   "insightsSupply.faq.q3.question": {
-    "message": "Q: How many fees were collected and distributed?"
+    "message": "F: Wie viele Gebühren wurden eingenommen und verteilt?"
   },
   "insightsSupply.faq.q4.question": {
-    "message": "Q: Were there withdrawals from the treasury in epoch {epoch}?"
+    "message": "F: Gab es in Epoche {epoch} Auszahlungen aus dem Treasury?"
   },
   "insightsSupply.faq.q4.noWithdrawals": {
-    "message": "A: There were no treasury withdrawals during this epoch."
+    "message": "A: In dieser Epoche gab es keine Treasury-Auszahlungen."
   },
   "insightsSupply.faq.q5.question": {
-    "message": "Q: Where can I learn more about the Cardano Mainnet reward calculation?"
+    "message": "F: Wo erfahre ich mehr über die Cardano-Mainnet-Reward-Berechnung?"
   },
   "insightsSupplySummary.meta.pageTitle": {
     "message": "Cardano Supply Summary"
@@ -4226,28 +4229,28 @@
     "message": "**Explore historical trends in Cardano ada supply distribution** across reserves, rewards, treasury, and deposits. Select an epoch range to analyze how these key metrics evolved over time."
   },
   "insightsSupplySummary.epochSelect.title": {
-    "message": "Select Epoch Range"
+    "message": "Epochenbereich wählen"
   },
   "insightsSupplySummary.epochSelect.start": {
     "message": "Start:"
   },
   "insightsSupplySummary.epochSelect.end": {
-    "message": "End:"
+    "message": "Ende:"
   },
   "insightsSupplySummary.loading.initial": {
-    "message": "Loading all epoch data (this may take a moment)..."
+    "message": "Lade alle Epochendaten (das kann einen Moment dauern)..."
   },
   "insightsSupplySummary.loading.data": {
-    "message": "Loading data..."
+    "message": "Lade Daten..."
   },
   "insightsSupplySummary.loading.loaded": {
-    "message": "Loaded {count} epochs. Adjust the slider to filter the range."
+    "message": "{count} Epochen geladen. Passe den Regler an, um den Bereich zu filtern."
   },
   "insightsSupplySummary.loading.currentEpoch": {
-    "message": "Loading current epoch..."
+    "message": "Lade aktuelle Epoche..."
   },
   "insightsSupplySummary.toc.title": {
-    "message": "Contents"
+    "message": "Inhalt"
   },
   "insightsSupplySummary.toc.reserves": {
     "message": "Reserves Evolution"
@@ -4274,7 +4277,7 @@
     "message": "Treasury Withdrawals in Selected Range"
   },
   "insightsSupplySummary.treasuryWithdrawals.table.epoch": {
-    "message": "Epoch"
+    "message": "Epoche"
   },
   "insightsSupplySummary.treasuryWithdrawals.table.title": {
     "message": "Title"
@@ -4316,99 +4319,99 @@
     "message": "For internal links use:"
   },
   "insightsTemplate.content.internalLinkText": {
-    "message": "where to get ada?"
+    "message": "Wo bekomme ich Ada?"
   },
   "insightsTemplate.content.externalLinksLabel": {
     "message": "For external links use:"
   },
   "insightsTransactions.meta.pageTitle": {
-    "message": "Cardano Transaction Trends"
+    "message": "Cardano-Transaktionstrends"
   },
   "insightsTransactions.meta.pageDescription": {
-    "message": "Historical analysis of Cardano transaction counts, fees, and block production across epochs."
+    "message": "Historische Analyse der Cardano-Transaktionszahlen, Gebühren und Blockproduktion über Epochen."
   },
   "insightsTransactions.meta.title": {
-    "message": "Cardano Transaction Trends"
+    "message": "Cardano-Transaktionstrends"
   },
   "insightsTransactions.og.title": {
-    "message": "Cardano Transaction Trends"
+    "message": "Cardano-Transaktionstrends"
   },
   "insightsTransactions.og.description": {
-    "message": "Explore historical trends in Cardano transactions, fees collected, and block production over time."
+    "message": "Historische Trends bei Cardano-Transaktionen, eingenommenen Gebühren und Blockproduktion erkunden."
   },
   "insightsTransactions.intro.description": {
-    "message": "**Explore historical trends in Cardano transactions** including transaction counts, fees collected, and block production. Select an epoch range to analyze how network activity evolved over time."
+    "message": "**Historische Trends bei Cardano-Transaktionen erkunden** – einschließlich Transaktionszahlen, eingenommener Gebühren und Blockproduktion. Wähle einen Epochenbereich, um die Netzwerkaktivität im Zeitverlauf zu analysieren."
   },
   "insightsTransactions.epochSelect.title": {
-    "message": "Select Epoch Range"
+    "message": "Epochenbereich wählen"
   },
   "insightsTransactions.epochSelect.start": {
     "message": "Start:"
   },
   "insightsTransactions.epochSelect.epoch": {
-    "message": "Epoch"
+    "message": "Epoche"
   },
   "insightsTransactions.epochSelect.end": {
-    "message": "End:"
+    "message": "Ende:"
   },
   "insightsTransactions.loading.initial": {
-    "message": "Loading all epoch data (this may take a moment)..."
+    "message": "Lade alle Epochendaten (das kann einen Moment dauern)..."
   },
   "insightsTransactions.loading.data": {
-    "message": "Loading data..."
+    "message": "Lade Daten..."
   },
   "insightsTransactions.loading.loaded": {
-    "message": "Loaded {count} epochs. Adjust the slider to filter the range."
+    "message": "{count} Epochen geladen. Passe den Regler an, um den Bereich zu filtern."
   },
   "insightsTransactions.loading.currentEpoch": {
-    "message": "Loading current epoch..."
+    "message": "Lade aktuelle Epoche..."
   },
   "insightsTransactions.notice.inProgressTitle": {
-    "message": "Current Epoch In Progress"
+    "message": "Aktuelle Epoche läuft"
   },
   "insightsTransactions.notice.inProgressDescription": {
-    "message": "Epoch {epoch} is currently in progress. Data for this epoch is incomplete and will appear lower than completed epochs. The final values will be available once the epoch ends. In-progress data points are marked with an orange indicator on the charts."
+    "message": "Epoche {epoch} läuft gerade. Die Daten sind noch unvollständig und fallen niedriger aus als bei abgeschlossenen Epochen. Die endgültigen Werte stehen nach Epochenende zur Verfügung. Laufende Datenpunkte sind in den Charts orange markiert."
   },
   "insightsTransactions.toc.title": {
-    "message": "Contents"
+    "message": "Inhalt"
   },
   "insightsTransactions.toc.transactions": {
-    "message": "Transaction Volume"
+    "message": "Transaktionsvolumen"
   },
   "insightsTransactions.toc.fees": {
-    "message": "Transaction Fees"
+    "message": "Transaktionsgebühren"
   },
   "insightsTransactions.toc.avgFee": {
-    "message": "Average Fee per Transaction"
+    "message": "Durchschnittliche Gebühr pro Transaktion"
   },
   "insightsTransactions.toc.blocks": {
-    "message": "Block Production"
+    "message": "Blockproduktion"
   },
   "insightsTransactions.toc.combined": {
-    "message": "Transactions & Fees Combined"
+    "message": "Transaktionen & Gebühren kombiniert"
   },
   "insightsTransactions.transactions.divider": {
-    "message": "Transaction Volume"
+    "message": "Transaktionsvolumen"
   },
   "insightsTransactions.fees.divider": {
-    "message": "Transaction Fees"
+    "message": "Transaktionsgebühren"
   },
   "insightsTransactions.avgFee.divider": {
-    "message": "Average Fee per Transaction"
+    "message": "Durchschnittliche Gebühr pro Transaktion"
   },
   "insightsTransactions.blocks.divider": {
-    "message": "Block Production"
+    "message": "Blockproduktion"
   },
   "insightsTransactions.combined.divider": {
-    "message": "Transactions & Fees Combined"
+    "message": "Transaktionen & Gebühren kombiniert"
   },
   "insights.footer.text": {
-    "message": "Last updated: {lastUpdated}. Charts are using real time data."
+    "message": "Letzte Aktualisierung: {lastUpdated}. Charts verwenden Echtzeitdaten."
   },
   "apps.card.getStarted": {
-    "message": "Get Started"
+    "message": "Loslegen"
   },
   "apps.card.source": {
-    "message": "Source"
+    "message": "Quellcode"
   }
 }

--- a/i18n/de/docusaurus-plugin-content-docs/current.json
+++ b/i18n/de/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "Weiter",
     "description": "The label for version current"
   },
   "sidebar.getInvolvedSidebar.category.Site Components": {

--- a/i18n/de/docusaurus-plugin-content-docs/current/communities.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/communities.md
@@ -27,7 +27,7 @@ Lerne die Cardano-Community bei Veranstaltungen vor Ort oder online kennen.
 Echtzeit-Chat und schnelle Diskussionen.
 
 - Cardano Main: https://t.me/Cardano
-- Cardano Developers: https://t.me/CardanoDevelopersOfficial
+- Cardano Entwickler: https://t.me/CardanoDevelopersOfficial
 - Cardano Report to Admin: https://t.me/cardanoreporttoadmin – für Fragen oder Probleme mit Regeln, Nutzern, Admins, Moderatoren oder anderen Themen in unseren Telegram-Kanälen.
 
 ## Cardano auf Discord

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/agriculture.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/agriculture.md
@@ -1,11 +1,11 @@
 ---
 title: Landwirtschaft
-description: Rückverfolgbarkeit mit Cardano Blockchain für die Transparenz der Lebensmittelkette
+description: Rückverfolgbarkeit vom Erzeuger bis auf den Tisch mithilfe der Cardano-Blockchain für mehr Transparenz in der Lebensmittelversorgungskette
 sidebar_label: Landwirtschaft
 sidebar_position: 8
 ---
 
-# Agrarwirtschaft
+# Landwirtschaft
 
 ## Das Problem
 
@@ -33,8 +33,8 @@ Intelligente Verträge (Smart contracts) können Zahlungen an Landwirte automati
 - **Global accessibility** supports smallholder farmers in developing regions
 - **Proven deployments** demonstrate real-world agricultural traceability
 
-## Get Started
+## Erste Schritte
 
-- [Explore supply chain solutions](/solutions)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Erkunden Sie Lieferketten-Lösungen](/solutions)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/data-storage.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/data-storage.md
@@ -1,19 +1,19 @@
 ---
-title: Data Storage
+title: Datenspeicher
 description: Decentralized, secure data storage solutions on Cardano blockchain
-sidebar_label: Data Storage
+sidebar_label: Datenspeicher
 sidebar_position: 12
 ---
 
-# Data Storage
+# Datenspeicher
 
-## The Challenge
+## Die Herausforderung
 
 Centralized data storage creates single points of failure and concentrates control over sensitive information. Cloud providers can experience outages, change terms of service, or be compelled to provide access to stored data. For sensitive applications, this dependency on third parties creates unacceptable risks.
 
 Data integrity is another concern. How can users verify that stored data hasn't been tampered with, especially over long time periods? Traditional backup systems provide redundancy but not proof of integrity.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Blockchain-based storage solutions combine decentralization with cryptographic integrity guarantees:
 
@@ -25,7 +25,7 @@ Blockchain-based storage solutions combine decentralization with cryptographic i
 
 While large files are typically stored off-chain, their cryptographic hashes recorded on Cardano provide proof of existence and integrity that is as permanent as the blockchain itself.
 
-## Why Cardano
+## Warum Cardano
 
 - **Proven security** through rigorous cryptographic protocols
 - **Long-term sustainability** through proof of stake and community governance
@@ -33,8 +33,8 @@ While large files are typically stored off-chain, their cryptographic hashes rec
 - **Low costs** for storing hashes and access control logic
 - **Developer tools** for building storage applications
 
-## Get Started
+## Erste Schritte
 
 - [Explore decentralized storage solutions](/solutions)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/digital-identity.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/digital-identity.md
@@ -1,21 +1,21 @@
 ---
-title: Digital Identity
-description: Self-sovereign identity solutions on Cardano give users control over their personal data
-sidebar_label: Digital Identity
+title: Digitale Identität
+description: Selbstsouveräne Identitätslösungen für Cardano geben den Nutzern die Kontrolle über ihre persönlichen Daten
+sidebar_label: Digitale Identität
 sidebar_position: 3
 ---
 
-# Digital Identity
+# Digitale Identität
 
-## The Challenge
+## Die Herausforderung
 
-In today's digital world, our identities are fragmented across countless platforms, each holding pieces of our personal information. Users have little control over how their data is used, shared, or monetized. Data breaches expose millions of records, identity theft is rampant, and proving who you are online remains cumbersome and privacy-invasive.
+In der heutigen digitalen Welt ist unsere Identität auf unzählige Plattformen verteilt, von denen jede Teile unserer persönlichen Daten speichert. Die Nutzer haben kaum Einfluss darauf, wie ihre Daten genutzt, weitergegeben oder verkauft werden. Durch Datenlecks werden Millionen von Datensätzen offengelegt. Identitätsdiebstahl ist weit verbreitet, und der Nachweis der eigenen Identität im Internet ist nach wie vor umständlich und stellt einen Eingriff in die Privatsphäre dar.
 
-Centralized identity systems create single points of failure and give disproportionate power to identity providers. Users must repeatedly share sensitive information, creating unnecessary exposure and friction in digital interactions.
+Zentralisierte Identitätssysteme schaffen zentralisierte Fehlerquellen und verleihen Identitätsanbietern unverhältnismäßig große Macht. Nutzer müssen immer wieder sensible Daten preisgeben, was zu unnötigen Risiken und Hindernissen bei digitalen Interaktionen führt.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
-Self-sovereign identity (SSI) on Cardano puts users in control of their digital identity. Key features include:
+Selbstsouveräne Identität (SSI) auf Cardano verleiht den Nutzern die Kontrolle über ihre digitale Identität. Die wichtigsten Merkmale sind:
 
 - **User ownership**: Individuals control their identity data and decide what to share
 - **Selective disclosure**: Share only the information needed for a specific transaction
@@ -25,16 +25,16 @@ Self-sovereign identity (SSI) on Cardano puts users in control of their digital 
 
 With blockchain-based identity, users can prove they're over 18 without revealing their birthdate, or prove they live in a certain country without revealing their address.
 
-## Why Cardano
+## Warum Cardano
 
-- **Formal verification methods** ensure identity smart contracts behave as intended
-- **Extended UTXO model** provides predictable transaction costs for identity operations
-- **Interoperability focus** enables identity credentials to work across different systems
+- **Formale Verifizierungsmethoden** stellen sicher, dass sich Identitäts-Smart-Contracts wie vorgesehen verhalten
+- **Erweitertes UTXO-Modell** bietet vorhersehbare Transaktionskosten für Identitätsvorgänge
+- **Interoperabilitätsfokus** ermöglicht Identitätsnachweise über verschiedene Systeme hinweg
 - **Strong governance** ensures the platform evolves with community input
-- **Scalability roadmap** supports identity solutions at global scale
+- **Skalierbarkeits-Roadmap** unterstützt Identitätslösungen im globalen Maßstab
 
-## Get Started
+## Erste Schritte
 
-- [Explore identity applications on Cardano](/apps/?tags=identity)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Entdecke Identitätsanwendungen auf Cardano](/apps/?tags=identity)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/education.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/education.md
@@ -1,19 +1,19 @@
 ---
 title: Education Credentials
 description: Blockchain-verified academic credentials on Cardano provide tamper-proof, instantly verifiable certifications
-sidebar_label: Education
+sidebar_label: Bildung
 sidebar_position: 2
 ---
 
 # Education Credentials
 
-## The Challenge
+## Die Herausforderung
 
 The issuance of academic certifications is heavily centralized and often opaque. Traditional paper-based credentials are easily forged, difficult to verify, and can be lost or damaged. Educational institutions face challenges in maintaining the integrity of their certifications, while employers struggle to verify the authenticity of candidates' qualifications.
 
 The verification process is slow and costly, often requiring direct contact with issuing institutions. This creates friction in hiring processes and can disadvantage qualified candidates who obtained credentials from institutions that are difficult to reach or no longer exist.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Cardano's blockchain-based identity and credentials solutions enable educational institutions to issue digital credentials that are:
 
@@ -24,7 +24,7 @@ Cardano's blockchain-based identity and credentials solutions enable educational
 
 Smart contracts can automate the issuance process, ensuring credentials are only issued when specific requirements are met. This creates an auditable trail of academic achievements that benefits students, institutions, and employers alike.
 
-## Why Cardano
+## Warum Cardano
 
 - **Low transaction fees** make credential issuance economically viable at scale
 - **Energy-efficient proof of stake** aligns with educational institutions' sustainability goals
@@ -32,8 +32,8 @@ Smart contracts can automate the issuance process, ensuring credentials are only
 - **Aiken smart contracts** provide programmable verification logic
 - **Global accessibility** ensures credentials can be verified anywhere in the world
 
-## Get Started
+## Erste Schritte
 
-- [Explore identity applications on Cardano](/apps/?tags=identity)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Entdecke Identitätsanwendungen auf Cardano](/apps/?tags=identity)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/finance-kyc.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/finance-kyc.md
@@ -1,19 +1,19 @@
 ---
-title: Finance KYC
+title: Finanz-KYC
 description: Streamlined Know Your Customer verification using blockchain technology on Cardano
-sidebar_label: Finance KYC
+sidebar_label: Finanz-KYC
 sidebar_position: 4
 ---
 
-# Finance KYC
+# Finanz-KYC
 
-## The Challenge
+## Die Herausforderung
 
 Know Your Customer (KYC) processes are essential for financial compliance but create significant friction for both institutions and customers. Users must repeatedly submit the same documents to different institutions, leading to duplicated effort and increased exposure of sensitive data. Financial institutions spend billions annually on KYC compliance, with much of that cost passed on to customers.
 
 The current system is also exclusionary. The estimated 1.4 billion adults worldwide without formal identity documents are effectively locked out of the financial system, unable to access basic services like bank accounts or loans.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Blockchain-based KYC solutions create a more efficient and inclusive verification system:
 
@@ -25,7 +25,7 @@ Blockchain-based KYC solutions create a more efficient and inclusive verificatio
 
 Smart contracts can automate compliance checks, ensuring only verified users can access specific financial services while maintaining privacy and reducing manual review requirements.
 
-## Why Cardano
+## Warum Cardano
 
 - **Regulatory awareness** built into platform development from the start
 - **Privacy features** enable compliant verification without unnecessary data exposure
@@ -33,8 +33,8 @@ Smart contracts can automate compliance checks, ensuring only verified users can
 - **Low fees** make micro-transactions and small account verification economically viable
 - **Enterprise partnerships** demonstrate real-world financial sector adoption
 
-## Get Started
+## Erste Schritte
 
-- [Explore identity applications on Cardano](/apps/?tags=identity)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Entdecke Identitätsanwendungen auf Cardano](/apps/?tags=identity)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/government.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/government.md
@@ -1,19 +1,19 @@
 ---
 title: Government Documents
 description: Tamper-proof official documents and records using Cardano blockchain technology
-sidebar_label: Government
+sidebar_label: Verwaltung
 sidebar_position: 5
 ---
 
 # Government Documents
 
-## The Challenge
+## Die Herausforderung
 
 Government-issued documents form the foundation of civic identity, yet they remain vulnerable to forgery, loss, and bureaucratic inefficiency. Birth certificates, property deeds, business licenses, and other official records are often paper-based, creating challenges for verification and portability.
 
 Citizens frequently face lengthy processes to obtain copies of their own documents, while government agencies struggle with record-keeping across jurisdictions. Document fraud undermines trust in institutions and creates real harm for individuals whose identities are misused.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Blockchain technology enables governments to issue and manage official documents with unprecedented security and efficiency:
 
@@ -25,7 +25,7 @@ Blockchain technology enables governments to issue and manage official documents
 
 Smart contracts can automate document issuance when conditions are met, reducing processing times and human error while maintaining security and compliance.
 
-## Why Cardano
+## Warum Cardano
 
 - **Proven security** through peer-reviewed cryptographic protocols
 - **Sustainability** aligns with government environmental commitments
@@ -33,8 +33,8 @@ Smart contracts can automate document issuance when conditions are met, reducing
 - **Scalability** handles document verification at national scale
 - **Interoperability** enables integration with existing government systems
 
-## Get Started
+## Erste Schritte
 
-- [Explore identity applications on Cardano](/apps/?tags=identity)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Entdecke Identitätsanwendungen auf Cardano](/apps/?tags=identity)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/healthcare.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/healthcare.md
@@ -1,19 +1,19 @@
 ---
-title: Healthcare
+title: Gesundheitswesen
 description: Portable, secure health records using Cardano blockchain technology
-sidebar_label: Healthcare
+sidebar_label: Gesundheitswesen
 sidebar_position: 15
 ---
 
-# Healthcare
+# Gesundheitswesen
 
-## The Challenge
+## Die Herausforderung
 
 Healthcare data is fragmented across providers, making it difficult for patients and doctors to access complete medical histories. This fragmentation leads to repeated tests, dangerous drug interactions, and delayed diagnoses. In emergencies, critical information may be unavailable.
 
 Current systems also create privacy and security risks. Centralized databases are attractive targets for hackers, and patients have limited control over who accesses their sensitive health information.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Blockchain-based health records give patients control over their complete medical history:
 
@@ -25,7 +25,7 @@ Blockchain-based health records give patients control over their complete medica
 
 Smart contracts can automate consent management, ensuring providers only access data they're authorized to see while maintaining compliance with healthcare regulations.
 
-## Why Cardano
+## Warum Cardano
 
 - **Privacy features** protect sensitive health information
 - **Security** through proven cryptographic protocols
@@ -33,8 +33,8 @@ Smart contracts can automate consent management, ensuring providers only access 
 - **Global accessibility** supports healthcare across borders
 - **Regulatory compliance** capabilities for HIPAA and similar requirements
 
-## Get Started
+## Erste Schritte
 
 - [Explore Cardano applications](/apps)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/index.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/index.md
@@ -1,31 +1,31 @@
 ---
-title: Use Cases Overview
-description: Explore how Cardano blockchain technology solves real-world problems across industries
-sidebar_label: Overview
+title: Anwendungsfälle
+description: Entdecken Sie, wie die Technologie der Cardano Blockchain Probleme in der realen Welt in allen Branchen lösen kann
+sidebar_label: Anwendungsfälle
 sidebar_position: 1
 ---
 
-# Cardano Use Cases
+# Cardano Anwendungsfälle
 
-Cardano is a public, permissionless Layer 1 blockchain, perfect for enterprises and individuals seeking secure, scalable, and transparent solutions. Whether it's streamlining supply chains, enabling global payments, or tokenizing assets, Cardano offers decentralized innovation with robust security and low energy usage.
+Cardano ist eine öffentliche, frei zugängliche Layer-1-Blockchain, die sich ideal für Unternehmen und Privatpersonen eignet, die nach sicheren, skalierbaren und transparenten Lösungen suchen. Ob es um die Optimierung von Lieferketten, die Abwicklung globaler Zahlungen oder die Tokenisierung von Vermögenswerten geht – Cardano bietet dezentrale Innovationen mit hoher Sicherheit und geringem Energieverbrauch.
 
-## Identity
+## Identität
 
-Blockchain-based identity solutions provide secure, verifiable credentials that users control.
+Blockchain-basierte Identitätslösungen bieten sichere, überprüfbare Identitätsnachweise, über die die Nutzer selbst die Kontrolle haben.
 
-- **[Education Credentials](./education)** - Blockchain-verified academic credentials
-- **[Digital Identity](./digital-identity)** - Self-sovereign identity solutions
-- **[Finance KYC](./finance-kyc)** - Streamlined identity verification for financial services
-- **[Government Documents](./government)** - Tamper-proof official documents
+- **[Bildungsnachweise](./education)** – Blockchain-verifizierte akademische Zeugnisse
+- **[Digitale Identität](./digital-identity)** – Lösungen für selbstbestimmte Identität
+- **[Finance KYC](./finance-kyc)** – Optimierte Identitätsprüfung für Finanzdienstleistungen
+- **[Behördendokumente](./government)** – Fälschungssichere amtliche Dokumente
 
-## Finance
+## Finanzwirtschaft
 
 Decentralized financial applications that provide transparency and accessibility.
 
 - **[DeFi](./defi)** - Decentralized lending, borrowing, and exchanges
 - **[Payments](./payments)** - Fast, low-cost cross-border transfers
 
-## Supply Chain
+## Lieferketten
 
 End-to-end traceability and verification for products and goods.
 
@@ -33,20 +33,20 @@ End-to-end traceability and verification for products and goods.
 - **[Retail](./retail)** - Combat counterfeiting with provenance tracking
 - **[Logistics](./logistics)** - Real-time tracking and verification
 
-## Social Impact
+## Soziale Wirkung
 
 Blockchain solutions for transparency and accountability in social programs.
 
 - **[Social Programs](./social-programs)** - Transparent fund distribution
 
-## Data & Technology
+## Daten & Technologie
 
 Decentralized approaches to data management and asset ownership.
 
 - **[Data Storage](./data-storage)** - Decentralized, secure storage solutions
 - **[Tokenized Assets](./tokenized-assets)** - Fractional ownership of real-world assets
 
-## Emerging Applications
+## Neue Anwendungsbereiche
 
 New and developing use cases for blockchain technology.
 
@@ -56,6 +56,6 @@ New and developing use cases for blockchain technology.
 
 ---
 
-## Enterprise Solutions
+## Unternehmenslösungen
 
 Looking for proven enterprise deployments and case studies? Visit our [Enterprise Solutions](/solutions) page to explore real-world implementations by the Cardano Foundation and partners.

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/logistics.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/logistics.md
@@ -1,19 +1,19 @@
 ---
-title: Logistics
+title: Logistik
 description: Real-time tracking and verification for supply chain logistics on Cardano
-sidebar_label: Logistics
+sidebar_label: Logistik
 sidebar_position: 10
 ---
 
-# Logistics
+# Logistik
 
-## The Challenge
+## Die Herausforderung
 
 Global logistics involves countless handoffs between carriers, warehouses, and customs authorities. Each handoff creates opportunities for errors, delays, disputes, and fraud. Paper-based documentation leads to inefficiencies and disputes that cost the industry billions annually.
 
 Lack of real-time visibility makes it difficult to optimize routes, predict delays, or respond quickly to disruptions. When problems occur, determining responsibility across multiple parties becomes contentious and time-consuming.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Blockchain technology creates a shared, immutable record of logistics operations:
 
@@ -25,7 +25,7 @@ Blockchain technology creates a shared, immutable record of logistics operations
 
 IoT devices can automatically record location, temperature, humidity, and other conditions, creating an unbroken chain of custody documentation.
 
-## Why Cardano
+## Warum Cardano
 
 - **Scalability** supports high-volume logistics operations
 - **Interoperability** enables connection with existing logistics management systems
@@ -33,8 +33,8 @@ IoT devices can automatically record location, temperature, humidity, and other 
 - **Low latency** provides timely updates for operational decisions
 - **Enterprise-ready** security and reliability
 
-## Get Started
+## Erste Schritte
 
 - [Explore traceability solutions](/solutions)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/music-ip.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/music-ip.md
@@ -1,19 +1,19 @@
 ---
-title: Music & IP
+title: Musik & geistiges Eigentum
 description: Direct royalty payments to artists through blockchain technology on Cardano
-sidebar_label: Music & IP
+sidebar_label: Musik & geistiges Eigentum
 sidebar_position: 16
 ---
 
 # Music & Intellectual Property
 
-## The Challenge
+## Die Herausforderung
 
 Artists and creators often receive a small fraction of the revenue their work generates. Complex licensing arrangements, opaque royalty calculations, and numerous intermediaries mean that payments are delayed and reduced at every step. Many creators struggle to make a living despite their work being widely consumed.
 
 Intellectual property rights are difficult to track and enforce in the digital age. Piracy is rampant, and even legitimate uses often fail to compensate creators fairly.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Blockchain technology enables direct relationships between creators and consumers:
 
@@ -25,7 +25,7 @@ Blockchain technology enables direct relationships between creators and consumer
 
 NFTs and native tokens on Cardano enable new models for music distribution, from limited edition releases to ongoing royalty streams that fairly compensate all contributors.
 
-## Why Cardano
+## Warum Cardano
 
 - **Low transaction fees** make micropayments to artists economically viable
 - **Native tokens** enable efficient representation of rights and royalties
@@ -33,8 +33,8 @@ NFTs and native tokens on Cardano enable new models for music distribution, from
 - **Community focus** aligns with artists seeking alternatives to corporate control
 - **Sustainability** through proof of stake appeals to environmentally conscious creators
 
-## Get Started
+## Erste Schritte
 
 - [Explore NFT marketplaces on Cardano](/apps/?tags=nft)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/payments.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/payments.md
@@ -1,19 +1,19 @@
 ---
-title: Payments
+title: Zahlungen
 description: Fast, low-cost cross-border transfers using Cardano blockchain technology
-sidebar_label: Payments
+sidebar_label: Zahlungen
 sidebar_position: 7
 ---
 
-# Payments
+# Zahlungen
 
-## The Challenge
+## Die Herausforderung
 
 Cross-border payments remain slow, expensive, and opaque. Traditional remittance services charge fees averaging 6-7% globally, with some corridors exceeding 10%. Transactions can take days to settle, and recipients often have limited options for accessing funds.
 
 For the millions of migrant workers sending money home to support their families, these fees represent a significant burden. The World Bank estimates that reducing remittance fees to 3% could save senders over $20 billion annually.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Cardano enables fast, low-cost payments that settle in minutes rather than days:
 
@@ -25,7 +25,7 @@ Cardano enables fast, low-cost payments that settle in minutes rather than days:
 
 Native tokens on Cardano enable stablecoins pegged to local currencies, reducing volatility concerns for everyday transactions while maintaining the benefits of blockchain settlement.
 
-## Why Cardano
+## Warum Cardano
 
 - **Scalability** through Hydra and other Layer 2 solutions enables high transaction throughput
 - **Interoperability** allows connection with traditional payment systems
@@ -33,9 +33,9 @@ Native tokens on Cardano enable stablecoins pegged to local currencies, reducing
 - **Low environmental impact** through proof of stake consensus
 - **Growing merchant adoption** expands real-world payment utility
 
-## Get Started
+## Erste Schritte
 
-- [Get a Cardano wallet](/apps/?tags=wallet)
+- [Cardano wallet erstellen](/apps/?tags=wallet)
 - [Where to get ada](/where-to-get-ada)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/retail.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/retail.md
@@ -1,19 +1,19 @@
 ---
-title: Retail
+title: Einzelhandel
 description: Combat counterfeiting with blockchain-verified product provenance on Cardano
-sidebar_label: Retail
+sidebar_label: Einzelhandel
 sidebar_position: 9
 ---
 
-# Retail
+# Einzelhandel
 
-## The Challenge
+## Die Herausforderung
 
 Counterfeiting costs legitimate businesses hundreds of billions of dollars annually and poses real risks to consumers. From luxury goods to electronics to pharmaceuticals, fake products flood markets worldwide. Traditional anti-counterfeiting measures like holograms and serial numbers are easily replicated.
 
 Consumers struggle to verify product authenticity, especially when purchasing through secondary markets or online platforms. Legitimate brands face reputational damage when counterfeits bearing their name cause harm or disappointment.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Blockchain-based product authentication provides unforgeable proof of origin and ownership:
 
@@ -25,7 +25,7 @@ Blockchain-based product authentication provides unforgeable proof of origin and
 
 Smart contracts can link physical products to digital twins, enabling automated warranty claims, loyalty rewards, and product registration.
 
-## Why Cardano
+## Warum Cardano
 
 - **Native tokens** enable efficient product tokenization without complex smart contracts
 - **Low fees** make tracking individual items economically viable
@@ -33,8 +33,8 @@ Smart contracts can link physical products to digital twins, enabling automated 
 - **Consumer-friendly verification** through mobile applications
 - **Enterprise solutions** proven in real-world retail deployments
 
-## Get Started
+## Erste Schritte
 
 - [Explore authenticity solutions](/solutions)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/social-programs.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/social-programs.md
@@ -1,19 +1,19 @@
 ---
-title: Social Programs
+title: Sozialprogramme
 description: Transparent fund distribution for social programs using Cardano blockchain
-sidebar_label: Social Programs
+sidebar_label: Sozialprogramme
 sidebar_position: 11
 ---
 
-# Social Programs
+# Sozialprogramme
 
-## The Challenge
+## Die Herausforderung
 
 Social programs aimed at poverty reduction, disaster relief, and development face persistent challenges with fund distribution. Corruption siphons resources away from intended beneficiaries, while administrative inefficiencies add costs and delays. Donors and taxpayers often lack visibility into how funds are actually used.
 
 For beneficiaries, accessing aid can involve bureaucratic hurdles, intermediaries who extract fees, and delays that undermine the program's effectiveness. Proving eligibility and preventing duplicate claims adds further complexity.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Blockchain technology enables transparent, efficient distribution of social program funds:
 
@@ -25,7 +25,7 @@ Blockchain technology enables transparent, efficient distribution of social prog
 
 Stablecoins and digital wallets enable beneficiaries to receive and use funds even without traditional bank accounts, increasing financial inclusion.
 
-## Why Cardano
+## Warum Cardano
 
 - **Low transaction fees** maximize the percentage of funds reaching beneficiaries
 - **Sustainability** through proof of stake aligns with development goals
@@ -33,8 +33,8 @@ Stablecoins and digital wallets enable beneficiaries to receive and use funds ev
 - **Accessibility** works in areas with limited banking infrastructure
 - **Governance** enables community participation in program design
 
-## Get Started
+## Erste Schritte
 
 - [Explore Cardano applications](/apps)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/tokenized-assets.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/tokenized-assets.md
@@ -1,19 +1,19 @@
 ---
-title: Tokenized Assets
+title: Tokenisierte Assets
 description: Fractional ownership of real-world assets through tokenization on Cardano
-sidebar_label: Tokenized Assets
+sidebar_label: Tokenisierte Assets
 sidebar_position: 13
 ---
 
-# Tokenized Assets
+# Tokenisierte Assets
 
-## The Challenge
+## Die Herausforderung
 
 Traditional investment in real-world assets like real estate, art, or commodities requires significant capital and involves complex legal and administrative processes. This excludes most people from wealth-building opportunities that have historically been reserved for the wealthy.
 
 Even for those who can invest, assets are often illiquid, making it difficult to access funds when needed. The overhead of buying, selling, and managing these assets further reduces returns.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Asset tokenization divides ownership of real-world assets into digital tokens that can be easily traded:
 
@@ -25,7 +25,7 @@ Asset tokenization divides ownership of real-world assets into digital tokens th
 
 Tokenization can apply to virtually any asset class: real estate, infrastructure, commodities, collectibles, intellectual property, and more.
 
-## Why Cardano
+## Warum Cardano
 
 - **Native tokens** provide efficient, secure asset representation
 - **Low transaction fees** make small trades economically viable
@@ -33,8 +33,8 @@ Tokenization can apply to virtually any asset class: real estate, infrastructure
 - **Smart contract security** through formal verification methods
 - **Global accessibility** enables worldwide participation
 
-## Get Started
+## Erste Schritte
 
 - [Explore Cardano applications](/apps)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-plugin-content-docs/current/use-cases/voting-systems.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/use-cases/voting-systems.md
@@ -1,19 +1,19 @@
 ---
-title: Voting Systems
+title: Wahlsysteme
 description: Secure, transparent election systems using Cardano blockchain technology
-sidebar_label: Voting Systems
+sidebar_label: Wahlsysteme
 sidebar_position: 14
 ---
 
-# Voting Systems
+# Wahlsysteme
 
-## The Challenge
+## Die Herausforderung
 
 Election integrity is fundamental to democracy, yet voting systems face persistent challenges. Paper-based systems are slow and error-prone, while electronic systems raise concerns about security, auditability, and trust. Voters often cannot verify that their vote was counted correctly.
 
 Beyond governmental elections, organizations of all types need secure voting mechanisms for governance decisions. Current solutions often lack transparency or are vulnerable to manipulation.
 
-## How Blockchain Solves This
+## Wie Blockchain dies löst
 
 Blockchain voting systems provide security, transparency, and verifiability:
 
@@ -25,7 +25,7 @@ Blockchain voting systems provide security, transparency, and verifiability:
 
 Cardano's own governance uses blockchain-based voting, demonstrating the technology's viability for high-stakes decisions affecting billions of dollars in value.
 
-## Why Cardano
+## Warum Cardano
 
 - **Proven governance voting** through Catalyst and on-chain governance
 - **Privacy-preserving options** protect voter anonymity while ensuring integrity
@@ -33,9 +33,9 @@ Cardano's own governance uses blockchain-based voting, demonstrating the technol
 - **Community governance experience** provides real-world insights
 - **Research-driven approach** addresses complex voting system requirements
 
-## Get Started
+## Erste Schritte
 
 - [Learn about Cardano governance](/governance)
 - [Explore governance tools](/apps?tags=governance)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Ressourcen für Entwickler zur Programmierung auf Cardano](https://developers.cardano.org)
+- [Enterprise Lösungen anzeigen](/solutions)

--- a/i18n/de/docusaurus-theme-classic/footer.json
+++ b/i18n/de/docusaurus-theme-classic/footer.json
@@ -1,6 +1,6 @@
 {
   "link.title.Entities": {
-    "message": "Entities",
+    "message": "Organisationen",
     "description": "The title of the footer links column with title=Entities in the footer"
   },
   "link.title.Support": {
@@ -16,7 +16,7 @@
     "description": "The title of the footer links column with title=More in the footer"
   },
   "link.item.label.Cardano Foundation": {
-    "message": "Cardano Foundation",
+    "message": "Cardano Stiftung",
     "description": "The label of footer link with label=Cardano Foundation linking to /entities?tab=cardanofoundation"
   },
   "link.item.label.EMURGO": {
@@ -40,7 +40,7 @@
     "description": "The label of footer link with label=More entities linking to /entities/#companies"
   },
   "link.item.label.Brand Assets": {
-    "message": "Brand Assets",
+    "message": "Asset-Sammlung",
     "description": "The label of footer link with label=Brand Assets linking to /brand-assets"
   },
   "link.item.label.Glossary": {

--- a/i18n/de/docusaurus-theme-classic/navbar.json
+++ b/i18n/de/docusaurus-theme-classic/navbar.json
@@ -76,7 +76,7 @@
     "description": "Navbar item with label Cardano Ambassadors"
   },
   "item.label.Cardano Events": {
-    "message": "Cardano Events",
+    "message": "Cardano-Events",
     "description": "Navbar item with label Cardano Events"
   },
   "item.label.Cardano Forum": {

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -1,201 +1,201 @@
 {
   "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
-    "message": "Expand the dropdown",
+    "message": "Desplegar el menú",
     "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
   },
   "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
-    "message": "Collapse the dropdown",
+    "message": "Ocultar menú",
     "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
   },
   "theme.docs.sidebar.expandButtonTitle": {
-    "message": "Expand sidebar",
+    "message": "Desplegar barra lateral",
     "description": "The ARIA label and title attribute for expand button of doc sidebar"
   },
   "theme.docs.sidebar.expandButtonAriaLabel": {
-    "message": "Expand sidebar",
+    "message": "Desplegar barra lateral",
     "description": "The ARIA label and title attribute for expand button of doc sidebar"
   },
   "theme.ErrorPageContent.title": {
-    "message": "This page crashed.",
+    "message": "La página ha fallado.",
     "description": "The title of the fallback page when the page crashed"
   },
   "theme.blog.archive.title": {
-    "message": "Archive",
+    "message": "Archivo",
     "description": "The page & hero title of the blog archive page"
   },
   "theme.blog.archive.description": {
-    "message": "Archive",
+    "message": "Archivo",
     "description": "The page & hero description of the blog archive page"
   },
   "theme.BackToTopButton.buttonAriaLabel": {
-    "message": "Scroll back to top",
+    "message": "Volver arriba",
     "description": "The ARIA label for the back to top button"
   },
   "theme.blog.paginator.navAriaLabel": {
-    "message": "Blog list page navigation",
+    "message": "Navegación por el listado del blog",
     "description": "The ARIA label for the blog pagination"
   },
   "theme.blog.paginator.newerEntries": {
-    "message": "Newer entries",
+    "message": "Entradas recientes",
     "description": "The label used to navigate to the newer blog posts page (previous page)"
   },
   "theme.blog.paginator.olderEntries": {
-    "message": "Older entries",
+    "message": "Entradas anteriores",
     "description": "The label used to navigate to the older blog posts page (next page)"
   },
   "theme.blog.post.paginator.navAriaLabel": {
-    "message": "Blog post page navigation",
+    "message": "Navegación de publicaciones",
     "description": "The ARIA label for the blog posts pagination"
   },
   "theme.blog.post.paginator.newerPost": {
-    "message": "Newer post",
+    "message": "Publicación más reciente",
     "description": "The blog post button label to navigate to the newer/previous post"
   },
   "theme.blog.post.paginator.olderPost": {
-    "message": "Older post",
+    "message": "Publicación anterior",
     "description": "The blog post button label to navigate to the older/next post"
   },
   "theme.tags.tagsPageLink": {
-    "message": "View all tags",
+    "message": "Ver todas las etiquetas",
     "description": "The label of the link targeting the tag list page"
   },
   "theme.colorToggle.ariaLabel.mode.system": {
-    "message": "system mode",
+    "message": "modo del sistema",
     "description": "The name for the system color mode"
   },
   "theme.colorToggle.ariaLabel.mode.light": {
-    "message": "light mode",
+    "message": "modo claro",
     "description": "The name for the light color mode"
   },
   "theme.colorToggle.ariaLabel.mode.dark": {
-    "message": "dark mode",
+    "message": "modo oscuro",
     "description": "The name for the dark color mode"
   },
   "theme.colorToggle.ariaLabel": {
-    "message": "Switch between dark and light mode (currently {mode})",
+    "message": "Cambiar entre modo claro y oscuro (actualmente {mode})",
     "description": "The ARIA label for the color mode toggle"
   },
   "theme.docs.breadcrumbs.navAriaLabel": {
-    "message": "Breadcrumbs",
+    "message": "Ruta de navegación",
     "description": "The ARIA label for the breadcrumbs"
   },
   "theme.docs.DocCard.categoryDescription.plurals": {
-    "message": "1 item|{count} items",
+    "message": "1 elemento | {count} elementos",
     "description": "The default description for a category card in the generated index about how many items this category includes"
   },
   "theme.docs.paginator.navAriaLabel": {
-    "message": "Docs pages",
+    "message": "Documentación",
     "description": "The ARIA label for the docs pagination"
   },
   "theme.docs.paginator.previous": {
-    "message": "Previous",
+    "message": "Anterior",
     "description": "The label used to navigate to the previous doc"
   },
   "theme.docs.paginator.next": {
-    "message": "Next",
+    "message": "Siguiente",
     "description": "The label used to navigate to the next doc"
   },
   "theme.docs.tagDocListPageTitle.nDocsTagged": {
-    "message": "One doc tagged|{count} docs tagged",
+    "message": "Un documento etiquetado|{count} documentos etiquetados",
     "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.docs.tagDocListPageTitle": {
-    "message": "{nDocsTagged} with \"{tagName}\"",
+    "message": "{nDocsTagged} con \"{tagName}\"",
     "description": "The title of the page for a docs tag"
   },
   "theme.docs.versionBadge.label": {
-    "message": "Version: {versionLabel}"
+    "message": "Versión: {versionLabel}"
   },
   "theme.docs.versions.unreleasedVersionLabel": {
-    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "message": "Esta es documentación no publicada para la versión {versionLabel} de {siteTitle}.",
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "message": "Esta es documentación para {siteTitle} {versionLabel}, ya no cuenta con mantenimiento activo.",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
   },
   "theme.docs.versions.latestVersionSuggestionLabel": {
-    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "message": "Para consultar la documentación actualizada, visita {latestVersionLink} ({versionLabel}).",
     "description": "The label used to tell the user to check the latest version"
   },
   "theme.docs.versions.latestVersionLinkLabel": {
-    "message": "latest version",
+    "message": "última versión",
     "description": "The label used for the latest version suggestion link label"
   },
   "theme.common.editThisPage": {
-    "message": "Edit this page",
+    "message": "Editar esta página",
     "description": "The link label to edit the current page"
   },
   "theme.common.headingLinkTitle": {
-    "message": "Direct link to {heading}",
+    "message": "Enlace directo a {heading}",
     "description": "Title for link to heading"
   },
   "theme.lastUpdated.atDate": {
-    "message": " on {date}",
+    "message": " el {date}",
     "description": "The words used to describe on which date a page has been last updated"
   },
   "theme.lastUpdated.byUser": {
-    "message": " by {user}",
+    "message": " por {user}",
     "description": "The words used to describe by who the page has been last updated"
   },
   "theme.lastUpdated.lastUpdatedAtBy": {
-    "message": "Last updated{atDate}{byUser}",
+    "message": "Última actualización: {atDate} {byUser}",
     "description": "The sentence used to display when a page has been last updated, and by who"
   },
   "theme.NotFound.title": {
-    "message": "Page Not Found",
+    "message": "Página no encontrada",
     "description": "The title of the 404 page"
   },
   "theme.navbar.mobileVersionsDropdown.label": {
-    "message": "Versions",
+    "message": "Versiones",
     "description": "The label for the navbar versions dropdown on mobile view"
   },
   "theme.tags.tagsListLabel": {
-    "message": "Tags:",
+    "message": "Etiquetas:",
     "description": "The label alongside a tag list"
   },
   "theme.admonition.caution": {
-    "message": "caution",
+    "message": "precaución",
     "description": "The default label used for the Caution admonition (:::caution)"
   },
   "theme.admonition.danger": {
-    "message": "danger",
+    "message": "peligro",
     "description": "The default label used for the Danger admonition (:::danger)"
   },
   "theme.admonition.info": {
-    "message": "info",
+    "message": "información",
     "description": "The default label used for the Info admonition (:::info)"
   },
   "theme.admonition.note": {
-    "message": "note",
+    "message": "nota",
     "description": "The default label used for the Note admonition (:::note)"
   },
   "theme.admonition.tip": {
-    "message": "tip",
+    "message": "sugerencia",
     "description": "The default label used for the Tip admonition (:::tip)"
   },
   "theme.admonition.warning": {
-    "message": "warning",
+    "message": "advertencia",
     "description": "The default label used for the Warning admonition (:::warning)"
   },
   "theme.AnnouncementBar.closeButtonAriaLabel": {
-    "message": "Close",
+    "message": "Cerrar",
     "description": "The ARIA label for close button of announcement bar"
   },
   "theme.blog.sidebar.navAriaLabel": {
-    "message": "Blog recent posts navigation",
+    "message": "Navegación de artículos recientes",
     "description": "The ARIA label for recent posts in the blog sidebar"
   },
   "theme.DocSidebarItem.expandCategoryAriaLabel": {
-    "message": "Expand sidebar category '{label}'",
+    "message": "Desplegar categoría '{label}'",
     "description": "The ARIA label to expand the sidebar category"
   },
   "theme.DocSidebarItem.collapseCategoryAriaLabel": {
-    "message": "Collapse sidebar category '{label}'",
+    "message": "Ocultar categoría '{label}'",
     "description": "The ARIA label to collapse the sidebar category"
   },
   "theme.IconExternalLink.ariaLabel": {
-    "message": "(opens in new tab)",
+    "message": "(abre en una pestaña nueva)",
     "description": "The ARIA label for the external link icon"
   },
   "theme.NavBar.navAriaLabel": {
@@ -227,74 +227,74 @@
     "description": "The ARIA label for the link to full blog posts from excerpts"
   },
   "theme.blog.post.readingTime.plurals": {
-    "message": "One min read|{readingTime} min read",
+    "message": "Un minuto de lectura|{readingTime} min. de lectura",
     "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.CodeBlock.copy": {
-    "message": "Copy",
+    "message": "Copiar",
     "description": "The copy button label on code blocks"
   },
   "theme.CodeBlock.copied": {
-    "message": "Copied",
+    "message": "Copiado",
     "description": "The copied button label on code blocks"
   },
   "theme.CodeBlock.copyButtonAriaLabel": {
-    "message": "Copy code to clipboard",
+    "message": "Copiar código al portapapeles",
     "description": "The ARIA label for copy code blocks button"
   },
   "theme.CodeBlock.wordWrapToggle": {
-    "message": "Toggle word wrap",
+    "message": "Ajuste de línea automático",
     "description": "The title attribute for toggle word wrapping button of code block lines"
   },
   "theme.docs.breadcrumbs.home": {
-    "message": "Home page",
+    "message": "Página de inicio",
     "description": "The ARIA label for the home page in the breadcrumbs"
   },
   "theme.docs.sidebar.collapseButtonTitle": {
-    "message": "Collapse sidebar",
+    "message": "Contraer barra lateral",
     "description": "The title attribute for collapse button of doc sidebar"
   },
   "theme.docs.sidebar.collapseButtonAriaLabel": {
-    "message": "Collapse sidebar",
+    "message": "Contraer barra lateral",
     "description": "The title attribute for collapse button of doc sidebar"
   },
   "theme.docs.sidebar.navAriaLabel": {
-    "message": "Docs sidebar",
+    "message": "Barra lateral de documentación",
     "description": "The ARIA label for the sidebar navigation"
   },
   "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
-    "message": "Close navigation bar",
+    "message": "Cerrar barra de navegación",
     "description": "The ARIA label for close button of mobile sidebar"
   },
   "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
-    "message": "Back to main menu",
+    "message": "Volver al menú principal",
     "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
   },
   "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
-    "message": "Toggle navigation bar",
+    "message": "Activar barra de navegación",
     "description": "The ARIA label for hamburger menu button of mobile navigation"
   },
   "theme.SearchBar.seeAll": {
-    "message": "See all {count} results"
+    "message": "Ver los {count} resultados"
   },
   "theme.SearchPage.documentsFound.plurals": {
-    "message": "One document found|{count} documents found",
+    "message": "Se encontró un documento|Se encontraron {count} documentos",
     "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.SearchPage.existingResultsTitle": {
-    "message": "Search results for \"{query}\"",
+    "message": "Resultados de búsqueda para \"{query}\"",
     "description": "The search page title for non-empty query"
   },
   "theme.SearchPage.emptyResultsTitle": {
-    "message": "Search the documentation",
+    "message": "Buscar en la documentación",
     "description": "The search page title for empty query"
   },
   "theme.SearchPage.inputPlaceholder": {
-    "message": "Type your search here",
+    "message": "Escribe tu búsqueda aquí",
     "description": "The placeholder for search page input"
   },
   "theme.SearchPage.inputLabel": {
-    "message": "Search",
+    "message": "Buscar",
     "description": "The ARIA label for search page input"
   },
   "theme.SearchPage.algoliaLabel": {
@@ -302,2065 +302,2065 @@
     "description": "The description label for Algolia mention"
   },
   "theme.SearchPage.noResultsText": {
-    "message": "No results were found",
+    "message": "No se encontraron resultados",
     "description": "The paragraph for empty search result"
   },
   "theme.SearchPage.fetchingNewResults": {
-    "message": "Fetching new results...",
+    "message": "Obteniendo nuevos resultados...",
     "description": "The paragraph for fetching new search results"
   },
   "theme.SearchBar.label": {
-    "message": "Search",
+    "message": "Buscar",
     "description": "The ARIA label and placeholder for search button"
   },
   "theme.SearchModal.searchBox.resetButtonTitle": {
-    "message": "Clear the query",
+    "message": "Borrar la búsqueda",
     "description": "The label and ARIA label for search box reset button"
   },
   "theme.SearchModal.searchBox.cancelButtonText": {
-    "message": "Cancel",
+    "message": "Cancelar",
     "description": "The label and ARIA label for search box cancel button"
   },
   "theme.SearchModal.searchBox.placeholderText": {
-    "message": "Search docs",
+    "message": "Buscar en documentos",
     "description": "The placeholder text for the main search input field"
   },
   "theme.SearchModal.searchBox.placeholderTextAskAi": {
-    "message": "Ask another question...",
+    "message": "Haz otra pregunta...",
     "description": "The placeholder text when in AI question mode"
   },
   "theme.SearchModal.searchBox.placeholderTextAskAiStreaming": {
-    "message": "Answering...",
+    "message": "Respondiendo...",
     "description": "The placeholder text for search box when AI is streaming an answer"
   },
   "theme.SearchModal.searchBox.enterKeyHint": {
-    "message": "search",
+    "message": "buscar",
     "description": "The hint for the search box enter key text"
   },
   "theme.SearchModal.searchBox.enterKeyHintAskAi": {
-    "message": "enter",
+    "message": "entrar",
     "description": "The hint for the Ask AI search box enter key text"
   },
   "theme.SearchModal.searchBox.searchInputLabel": {
-    "message": "Search",
+    "message": "Buscar",
     "description": "The ARIA label for search input"
   },
   "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
-    "message": "Back to keyword search",
+    "message": "Volver a la búsqueda por palabra clave",
     "description": "The text for back to keyword search button"
   },
   "theme.SearchModal.searchBox.backToKeywordSearchButtonAriaLabel": {
-    "message": "Back to keyword search",
+    "message": "Volver a la búsqueda por palabra clave",
     "description": "The ARIA label for back to keyword search button"
   },
   "theme.SearchModal.startScreen.recentSearchesTitle": {
-    "message": "Recent",
+    "message": "Reciente",
     "description": "The title for recent searches"
   },
   "theme.SearchModal.startScreen.noRecentSearchesText": {
-    "message": "No recent searches",
+    "message": "No hay búsquedas recientes",
     "description": "The text when there are no recent searches"
   },
   "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
-    "message": "Save this search",
+    "message": "Guardar esta búsqueda",
     "description": "The title for save recent search button"
   },
   "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
-    "message": "Remove this search from history",
+    "message": "Eliminar esta búsqueda del historial",
     "description": "The title for remove recent search button"
   },
   "theme.SearchModal.startScreen.favoriteSearchesTitle": {
-    "message": "Favorite",
+    "message": "Favorito",
     "description": "The title for favorite searches"
   },
   "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
-    "message": "Remove this search from favorites",
+    "message": "Eliminar esta búsqueda de favoritos",
     "description": "The title for remove favorite search button"
   },
   "theme.SearchModal.startScreen.recentConversationsTitle": {
-    "message": "Recent conversations",
+    "message": "Conversaciones recientes",
     "description": "The title for recent conversations"
   },
   "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
-    "message": "Remove this conversation from history",
+    "message": "Eliminar esta conversación del historial",
     "description": "The title for remove recent conversation button"
   },
   "theme.SearchModal.errorScreen.titleText": {
-    "message": "Unable to fetch results",
+    "message": "No se pudieron obtener los resultados",
     "description": "The title for error screen"
   },
   "theme.SearchModal.errorScreen.helpText": {
-    "message": "You might want to check your network connection.",
+    "message": "Es posible que desees comprobar tu conexión de red.",
     "description": "The help text for error screen"
   },
   "theme.SearchModal.resultsScreen.askAiPlaceholder": {
-    "message": "Ask AI: ",
+    "message": "Pregúntale a la IA: ",
     "description": "The placeholder text for Ask AI input"
   },
   "theme.SearchModal.askAiScreen.disclaimerText": {
-    "message": "Answers are generated with AI which can make mistakes. Verify responses.",
+    "message": "Las respuestas se generan mediante inteligencia artificial, la cual puede cometer errores. Verifique las respuestas.",
     "description": "The disclaimer text for AI answers"
   },
   "theme.SearchModal.askAiScreen.relatedSourcesText": {
-    "message": "Related sources",
+    "message": "Fuentes relacionadas",
     "description": "The text for related sources"
   },
   "theme.SearchModal.askAiScreen.thinkingText": {
-    "message": "Thinking...",
+    "message": "Pensando...",
     "description": "The text when AI is thinking"
   },
   "theme.SearchModal.askAiScreen.copyButtonText": {
-    "message": "Copy",
+    "message": "Copiar",
     "description": "The text for copy button"
   },
   "theme.SearchModal.askAiScreen.copyButtonCopiedText": {
-    "message": "Copied!",
+    "message": "¡Copiado!",
     "description": "The text for copy button when copied"
   },
   "theme.SearchModal.askAiScreen.copyButtonTitle": {
-    "message": "Copy",
+    "message": "Copiar",
     "description": "The title for copy button"
   },
   "theme.SearchModal.askAiScreen.likeButtonTitle": {
-    "message": "Like",
+    "message": "Me Gusta",
     "description": "The title for like button"
   },
   "theme.SearchModal.askAiScreen.dislikeButtonTitle": {
-    "message": "Dislike",
+    "message": "No me gusta",
     "description": "The title for dislike button"
   },
   "theme.SearchModal.askAiScreen.thanksForFeedbackText": {
-    "message": "Thanks for your feedback!",
+    "message": "¡Gracias por su opinión!",
     "description": "The text for thanks for feedback"
   },
   "theme.SearchModal.askAiScreen.preToolCallText": {
-    "message": "Searching...",
+    "message": "Búsqueda en curso...",
     "description": "The text before tool call"
   },
   "theme.SearchModal.askAiScreen.duringToolCallText": {
-    "message": "Searching for ",
+    "message": "Buscando ",
     "description": "The text during tool call"
   },
   "theme.SearchModal.askAiScreen.afterToolCallText": {
-    "message": "Searched for",
+    "message": "Búsqueda de",
     "description": "The text after tool call"
   },
   "theme.SearchModal.footer.selectText": {
-    "message": "Select",
+    "message": "Seleccionar",
     "description": "The select text for footer"
   },
   "theme.SearchModal.footer.submitQuestionText": {
-    "message": "Submit question",
+    "message": "Enviar consulta",
     "description": "The submit question text for footer"
   },
   "theme.SearchModal.footer.selectKeyAriaLabel": {
-    "message": "Enter key",
+    "message": "Tecla Enter",
     "description": "The ARIA label for select key in footer"
   },
   "theme.SearchModal.footer.navigateText": {
-    "message": "Navigate",
+    "message": "Navegar",
     "description": "The navigate text for footer"
   },
   "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
-    "message": "Arrow up",
+    "message": "Flecha arriba",
     "description": "The ARIA label for navigate up key in footer"
   },
   "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
-    "message": "Arrow down",
+    "message": "Flecha abajo",
     "description": "The ARIA label for navigate down key in footer"
   },
   "theme.SearchModal.footer.closeText": {
-    "message": "Close",
+    "message": "Cerrar",
     "description": "The close text for footer"
   },
   "theme.SearchModal.footer.closeKeyAriaLabel": {
-    "message": "Escape key",
+    "message": "Tecla Escape",
     "description": "The ARIA label for close key in footer"
   },
   "theme.SearchModal.footer.searchByText": {
-    "message": "Powered by",
+    "message": "Desarrollado por",
     "description": "The 'Powered by' text for footer"
   },
   "theme.SearchModal.footer.backToSearchText": {
-    "message": "Back to search",
+    "message": "Regresar a la búsqueda",
     "description": "The back to search text for footer"
   },
   "theme.SearchModal.noResultsScreen.noResultsText": {
-    "message": "No results found for",
+    "message": "No se han encontrado resultados para",
     "description": "The text when there are no results"
   },
   "theme.SearchModal.noResultsScreen.suggestedQueryText": {
-    "message": "Try searching for",
+    "message": "Intenta buscando para",
     "description": "The text for suggested query"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
-    "message": "Believe this query should return results?",
+    "message": "¿Crees que esta consulta debería tener resultados?",
     "description": "The text for reporting missing results"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
-    "message": "Let us know.",
+    "message": "Háganos saber.",
     "description": "The link text for reporting missing results"
   },
   "theme.SearchModal.placeholder": {
-    "message": "Search docs",
+    "message": "Buscar en los documentos",
     "description": "The placeholder of the input of the DocSearch pop-up modal"
   },
   "theme.IdealImageMessage.loading": {
-    "message": "Loading...",
+    "message": "Cargando...",
     "description": "When the full-scale image is loading"
   },
   "theme.IdealImageMessage.load": {
-    "message": "Click to load{sizeMessage}",
+    "message": "Haz clic para cargar{sizeMessage}",
     "description": "To prompt users to load the full image. sizeMessage is a parenthesized size figure."
   },
   "theme.IdealImageMessage.offline": {
-    "message": "Your browser is offline. Image not loaded",
+    "message": "Su navegador está desconectado. Imagen no cargada",
     "description": "When the user is viewing an offline document"
   },
   "theme.IdealImageMessage.404error": {
-    "message": "404. Image not found",
+    "message": "404. Página no encontrada",
     "description": "When the image is not found"
   },
   "theme.IdealImageMessage.error": {
-    "message": "Error. Click to reload",
+    "message": "Error. Haga clic para recargar",
     "description": "When the image fails to load for unknown error"
   },
   "theme.blog.post.plurals": {
-    "message": "One post|{count} posts",
+    "message": "Una publicación|{count} publicaciones",
     "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.blog.tagTitle": {
-    "message": "{nPosts} tagged with \"{tagName}\"",
+    "message": "{nPosts} etiquetado(s) con \"{tagName}\"",
     "description": "The title of the page for a blog tag"
   },
   "theme.blog.author.pageTitle": {
-    "message": "{authorName} - {nPosts}",
+    "message": "{authorName} ‒ {nPosts}",
     "description": "The title of the page for a blog author"
   },
   "theme.blog.authorsList.pageTitle": {
-    "message": "Authors",
+    "message": "Autores",
     "description": "The title of the authors page"
   },
   "theme.blog.authorsList.viewAll": {
-    "message": "View all authors",
+    "message": "Ver todos los autores",
     "description": "The label of the link targeting the blog authors page"
   },
   "theme.blog.author.noPosts": {
-    "message": "This author has not written any posts yet.",
+    "message": "Este autor aún no ha escrito ninguna publicación.",
     "description": "The text for authors with 0 blog post"
   },
   "theme.contentVisibility.unlistedBanner.title": {
-    "message": "Unlisted page",
+    "message": "Página sin clasificar",
     "description": "The unlisted content banner title"
   },
   "theme.contentVisibility.unlistedBanner.message": {
-    "message": "This page is unlisted. Search engines will not index it, and only users having a direct link can access it.",
+    "message": "Esta página no está listada. Los motores de búsqueda no lo indexarán y solo los usuarios que tengan un enlace directo pueden acceder a ella.",
     "description": "The unlisted content banner message"
   },
   "theme.contentVisibility.draftBanner.title": {
-    "message": "Draft page",
+    "message": "Página Borrador",
     "description": "The draft content banner title"
   },
   "theme.contentVisibility.draftBanner.message": {
-    "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
+    "message": "Esta página es un borrador. Solo será visible en desarrollo y se excluirá de la versión de producción.",
     "description": "The draft content banner message"
   },
   "theme.ErrorPageContent.tryAgain": {
-    "message": "Try again",
+    "message": "Inténtelo de nuevo",
     "description": "The label of the button to try again rendering when the React error boundary captures an error"
   },
   "theme.common.skipToMainContent": {
-    "message": "Skip to main content",
+    "message": "Saltar al contenido principal",
     "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
   },
   "theme.tags.tagsPageTitle": {
-    "message": "Tags",
+    "message": "Etiquetas",
     "description": "The title of the tag list page"
   },
   "whatIsAda.hero.title": {
-    "message": "What is ada?"
+    "message": "¿Qué es Ada?"
   },
   "whatIsAda.hero.description1": {
-    "message": "A new type of currency. A new means of transaction."
+    "message": "Un nuevo tipo de moneda. Un nuevo medio de transacción."
   },
   "whatIsAda.hero.description2": {
-    "message": "Direct. Secure. From Anywhere. For Everyone."
+    "message": "Directo. Seguro. Desde cualquier lugar. Para todos."
   },
   "whatIsAda.meta.title": {
-    "message": "What Is ada, the Native Token of Cardano"
+    "message": "Qué es ada, el Token Nativo de Cardano"
   },
   "whatIsAda.meta.description": {
-    "message": "ada is the native cryptocurrency of the Cardano blockchain. Use it for transactions, staking, governance voting, and interacting with decentralized applications."
+    "message": "ada es la criptomoneda nativa de la blockchain de Cardano. Úsala para transacciones, staking, voto de gobierno e interacción con aplicaciones descentralizadas."
   },
   "whatIsAda.section.headline": {
-    "message": "What is ada?"
+    "message": "¿Qué es ada?"
   },
   "whatIsAda.section.title": {
-    "message": "Ada Is The Native Token Of Cardano"
+    "message": "Ada es el Token Nativo de Cardano"
   },
   "whatIsAda.section.description1": {
-    "message": "It is named after Ada Lovelace: a 19th-century mathematician who is recognized as the first computer programmer, and is the daughter of the poet Lord Byron."
+    "message": "Su nombre viene de Ada Lovelace: una matemática del siglo XIX que es reconocida como la primera programadora de computación, y es hija del poeta Lord Byron."
   },
   "whatIsAda.section.description2": {
-    "message": "Ada is a digital currency. Any user, located anywhere in the world, can use ada as a secure exchange of value – without requiring a third party to mediate the exchange. Every transaction is permanently, securely, and transparently recorded on the Cardano blockchain."
+    "message": "Ada es una moneda digital. Cualquier usuario, ubicado en cualquier lugar del mundo, puede usar ada como un intercambio seguro de valor, sin necesidad de que un tercero medie en el intercambio. Cada transacción se registra de forma permanente, segura y transparente en el blockchain de Cardano."
   },
   "whatIsAda.section.description3": {
-    "message": "Every ada holder also holds a stake in the Cardano network. Ada stored in a wallet can be delegated to a stake pool to earn rewards – to participate in the successful running of the network – or found and run your own stake pool to increase the pool's likelihood of receiving rewards. In time, ada will also be usable for a variety of applications and services on the Cardano platform."
+    "message": "Cada titular de ada también tiene una participación en la red de Cardano. El ada almacenado en una cartera puede ser delegado a un \"stake pool\" para ganar recompensas y participar en el seguro funcionamiento de la red o crear y operar su propio \"stake pool\". Con el tiempo, ada también será utilizable para una variedad de aplicaciones y servicios en la plataforma Cardano."
   },
   "whatIsAda.section.quote": {
-    "message": "What can I do with ada?"
+    "message": "¿Qué puedo hacer con ada?"
   },
   "howToBuyAda.title": {
-    "message": "How Do I Buy/Sell Ada?"
+    "message": "¿Cómo Compro/Vendo Ada?"
   },
   "howToBuyAda.description1": {
-    "message": "There are many ways to obtain ada to use the Cardano blockchain. Find out on {whereToGetAdaLink}"
+    "message": "Hay muchas maneras de obtener ada para usar la blockchain de Cardano. Descubre en {whereToGetAdaLink}"
   },
   "howToBuyAda.whereToGetAdaLink": {
-    "message": "where to get ada?"
+    "message": "¿dónde obtener ada?"
   },
   "howToBuyAda.description2": {
-    "message": "As an ada holder, it is important to keep your funds secure, and that means you need to keep your private keys private. It is highly recommended to avoid keeping your cryptocurrency in an exchange longer than necessary, and instead to use a cryptocurrency wallet."
+    "message": "Como titular de ada, es importante mantener sus fondos seguros, y eso significa que necesitas mantener sus claves privadas seguras. Es altamente recomendable evitar mantener la criptomoneda en un intercambio más tiempo de lo necesario, y en su lugar utilizar una cartera de criptomonedas."
   },
   "walletSection.typhon.title": {
     "message": "Typhon Wallet"
   },
   "walletSection.typhon.text": {
-    "message": "Blazing fast, feature-rich, secure, beautiful web and extension Cardano wallet. Delegate to multiple pools of your choice with multi-accounts."
+    "message": "Super rápida, múltiples opciones, segura y bien diseñada cartera, disponible para web y extensiones para el navegador. Delega a múltiples pools de tu elección con cuentas múltiples."
   },
   "walletSection.typhon.subtext": {
-    "message": "Browser extension for Chrome, Brave and Edge"
+    "message": "Extensión del navegador para Chrome, Brave y Edge"
   },
   "walletSection.typhon.label": {
-    "message": "Get Typhon"
+    "message": "Obtén Typhon"
   },
   "walletSection.vespr.title": {
     "message": "VESPR Wallet"
   },
   "walletSection.vespr.text": {
-    "message": "VESPR is a non-custodial mobile light wallet for the Cardano network, prioritizing the security and safety of your digital assets while ensuring exceptional ease-of-use."
+    "message": "VESPR es una cartera móvil no custodia para la red de Cardano, que prioriza la seguridad y custodia de sus activos digitales, garantizando al mismo tiempo una facilidad de uso excepcional."
   },
   "walletSection.vespr.subtext": {
-    "message": "App for iOS and Android"
+    "message": "Aplicación para iOS y Android"
   },
   "walletSection.vespr.label": {
-    "message": "Get VESPR"
+    "message": "Obtener VESPR"
   },
   "walletSection.yoroi.title": {
     "message": "Yoroi Wallet"
   },
   "walletSection.yoroi.text": {
-    "message": "A user-friendly, [open-source](https://github.com/Emurgo/yoroi-frontend) Cardano wallet with a browser-based interface, providing a convenient way to manage ada holdings securely. Yoroi is also available as mobile app."
+    "message": "Una billetera de Cardano, fácil de usar, [open-source](https://github.com/Emurgo/yoroi-frontend) con una interfaz basada en el navegador, proporcionando una manera conveniente de gestionar las tenencias de ada de forma segura. También está disponible como aplicación móvil."
   },
   "walletSection.yoroi.subtext": {
-    "message": "Browser extension and app for iOS and Android"
+    "message": "Extensión del navegador y aplicación para iOS y Android"
   },
   "walletSection.yoroi.label": {
-    "message": "Get Yoroi"
+    "message": "Obtén Yoroi"
   },
   "walletSection.eternl.title": {
     "message": "Eternl Wallet"
   },
   "walletSection.eternl.text": {
-    "message": "The alternative Cardano light wallet in the browser. Aims to add features most requested by the Cardano community. Eternl is also available as mobile app."
+    "message": "El monedero liviano alternativo de Cardano en el navegador. Tiene por objeto añadir características más solicitadas por la comunidad de Cardano. Eternl también está disponible como aplicación móvil."
   },
   "walletSection.eternl.subtext": {
-    "message": "Browser extension and app for iOS and Android"
+    "message": "Extensión del navegador y aplicación para iOS y Android"
   },
   "walletSection.eternl.label": {
-    "message": "Get Eternl"
+    "message": "Obtén Eternl"
   },
   "walletSection.lace.title": {
     "message": "Lace Wallet"
   },
   "walletSection.lace.text": {
-    "message": "An [open-source](https://github.com/input-output-hk/lace) light wallet platform from IOG, one of the creators of Cardano. Manually verified by an independent auditor, Lace lets you quickly, easily, and securely manage your digital assets and enjoy Web3."
+    "message": "Una plataforma ligera [open-source](https://github.com/input-output-hk/lace) de IOG, uno de los creadores de Cardano. Verificado manualmente por un auditor independiente, Lace le permite administrar de forma rápida, fácil y segura sus activos digitales y disfrutar de Web3."
   },
   "walletSection.lace.subtext": {
-    "message": "Browser extension for Chrome, Brave"
+    "message": "Extensión del navegador para Chrome, Brave y Edge"
   },
   "walletSection.lace.label": {
-    "message": "Get Lace"
+    "message": "Obtén Lace"
   },
   "walletSection.daedalus.title": {
     "message": "Daedalus Wallet"
   },
   "walletSection.daedalus.text": {
-    "message": "The [open-source](https://github.com/input-output-hk/daedalus) full node wallet for Cardano. It offers enhanced control and security by maintaining a complete copy of the blockchain, but this comes at the cost of a more complex user experience. As a result, they are typically geared towards professional users who require these advanced features."
+    "message": "La [open-source](https://github.com/input-output-hk/daedalus) cartera de nodo completa para Cardano. Ofrece mayor control y seguridad manteniendo una copia completa de la cadena de bloques, pero esto se hace a costa de una experiencia de usuario más compleja. Como resultado, normalmente se orientan hacia usuarios profesionales que requieren estas características avanzadas."
   },
   "walletSection.daedalus.subtext": {
-    "message": "Only for powerful desktop PCs"
+    "message": "Sólo para potentes PCs de escritorio"
   },
   "walletSection.daedalus.label": {
-    "message": "Get Daedalus"
+    "message": "Obtén Daedalus"
   },
   "walletSection.explore.title": {
-    "message": "Explore Apps"
+    "message": "Explorar aplicaciones"
   },
   "walletSection.explore.text": {
-    "message": "Discover a wide variety of wallets designed to facilitate your interaction."
+    "message": "Descubra una amplia variedad de carteras diseñadas para facilitar su interacción."
   },
   "walletSection.explore.label": {
-    "message": "More Wallets"
+    "message": "Más billeteras"
   },
   "walletSection.divider": {
     "message": "Cardano Wallets"
   },
   "walletSection.disclaimer": {
-    "message": "The example applications are provided for informational purposes only and not endorsed or approved. Their use is strictly at your own risk. The descriptions have been provided by the respective project teams."
+    "message": "Las aplicaciones de ejemplo se proporcionan solo con fines informativos y no están respaldadas o aprobadas. Su uso es estrictamente bajo su propio riesgo. Las descripciones han sido proporcionadas por los respectivos equipos de proyecto."
   },
   "walletSection.storageTitle": {
-    "message": "How Do I Store My Ada And Keep It Safe?"
+    "message": "¿Cómo almaceno mi Ada y lo mantengo seguro?"
   },
   "walletSection.storageDescription1": {
-    "message": "A cryptocurrency wallet is a software program designed to store your public and private keys, send and receive digital currencies, monitor your balance, and interact with supported blockchains."
+    "message": "Una cartera de criptomonedas es un programa de software diseñado para almacenar sus claves públicas y privadas, envía y recibe monedas digitales, monitorea tu saldo e interactúa con blockchains soportadas."
   },
   "walletSection.storageDescription2": {
-    "message": "In addition to the variation of wallets available, there are also two types of wallets: a hot wallet and a cold wallet."
+    "message": "Además de la variedad de carteras disponibles, también hay dos tipos de carteras: una cartera caliente y una cartera fría."
   },
   "walletSection.hotWalletText": {
-    "message": "A hot wallet is connected to the internet and can be accessed at any time with the requisite keys. Examples of hot wallets include mobile and software wallets, and funds stored on exchanges."
+    "message": "Una cartera caliente está conectada a internet y se puede acceder en cualquier momento con las claves solicitadas. Ejemplos de carteras calientes son las carteras móviles y de software, y los fondos almacenados en los intercambios."
   },
   "walletSection.coldWalletText": {
-    "message": "A cold wallet is an offline wallet. It is not connected to the internet and is used for securing storing funds that do not have to be frequently accessed. Examples include hardware wallets - which is a secure hardware device that stores the wallet's private keys - and paper wallets. Cardano is supported by both Trezor and Ledger hardware wallets."
+    "message": "Una cartera fría es una cartera sin conexión. No está conectada a internet y se utiliza para garantizar el almacenamiento de fondos que no tienen que ser accedidos con frecuencia. Algunos ejemplos son las carteras de hardware, que son un dispositivo de hardware seguro que almacena las claves privadas de la cartera, y las carteras de papel. Cardano es soportado por las carteras de hardware Keystone, Trezor y Ledger entre otras."
   },
   "whatIsAda.button.getStarted": {
-    "message": "Get started with Cardano"
+    "message": "Empieza en Cardano"
   },
   "whatIsAda.button.whereToGetAda": {
-    "message": "Where to get ada?"
+    "message": "¿Dónde obtener ada?"
   },
   "getStarted.hero.title": {
-    "message": "Get started with Cardano"
+    "message": "Empieza en Cardano"
   },
   "getStarted.hero.description": {
-    "message": "Step into the new world yourself and learn all the basics in just few steps."
+    "message": "Entra en el nuevo mundo tú mismo y aprende todo lo básico en pocos pasos."
   },
   "getStarted.meta.title": {
-    "message": "Get Started with Cardano, Your First Steps"
+    "message": "Comience con Cardano, primeros pasos"
   },
   "getStarted.meta.description": {
-    "message": "Set up a Cardano wallet, get ada, and start exploring DApps and staking in a few simple steps. Your beginner's guide to the Cardano ecosystem."
+    "message": "Configura una cartera de Cardano, obtén ada, y comience a explorar dApps siguiendo en unos simples pasos. Tu guía inicial para el ecosistema de Cardano."
   },
   "getStarted.step1.title": {
-    "message": "Download a wallet"
+    "message": "Descargar billetera"
   },
   "getStarted.step1.description": {
-    "message": "A wallet is an app that allows you to receive, send cryptocurrencies and manage your Cardano account."
+    "message": "Una cartera es una aplicación que te permite recibir, enviar criptomonedas y administrar tu cuenta de Cardano."
   },
   "getStarted.step1.heading": {
-    "message": "Download a wallet"
+    "message": "Descargar billetera"
   },
   "getStarted.step1.text1": {
-    "message": "A Cardano wallet is your personal interface to the blockchain, much like a web browser is your interface to the internet. It lets you securely manage your ada, use dApps, and interact with the network."
+    "message": "Una cartera de Cardano es su interfaz personal al blockchain, al igual que un navegador web es su interfaz a Internet. Te permite administrar de forma segura tu ada, usar dApps, e interactuar con la red."
   },
   "getStarted.step1.text2": {
-    "message": "You will create your wallet in the next steps. Downloading alone does not create one."
+    "message": "Creará su billetera en los siguientes pasos. La descarga por sí sola no crea una billetera."
   },
   "getStarted.step1.securityNote": {
-    "message": "Your recovery phrase is required to regain access to your wallet. Cardano wallets are non-custodial, which means there is no central service, help desk, or recovery mechanism."
+    "message": "Su frase de recuperación es necesaria para recuperar el acceso a su billetera. En Cardano, las billeteras no tienen custodia, lo que significa que no hay servicio centralizado, asistencia técnica o mecanismo de recuperación."
   },
   "getStarted.step1.checkbox": {
-    "message": "I downloaded a wallet."
+    "message": "Descargar billetera."
   },
   "getStarted.common.scamLink": {
-    "message": "Be aware of the most common scams."
+    "message": "Tenga en cuenta las estafas más comunes."
   },
   "getStarted.step2.title": {
-    "message": "Backup your recovery phrase"
+    "message": "Respalde su Frase de Recuperación"
   },
   "getStarted.step2.description": {
-    "message": "When you create a new wallet, you'll receive a set of 12, 15, or 24 words. This is your recovery phrase, also called a seed phrase. It is the master key to your wallet. Keep it safe!"
+    "message": "Cuando cree una nueva billetera, recibirá un conjunto de 12, 15 o 24 palabras. Esta es su frase de recuperación, también llamada una frase de semilla. Es la clave maestra de su billetera. ¡Manténgala segura!"
   },
   "getStarted.step2.heading": {
-    "message": "Save your recovery phrase"
+    "message": "Respalde su Frase de Recuperación"
   },
   "getStarted.step2.whatToDo": {
-    "message": "What to do:"
+    "message": "Lo que necesita hacer:"
   },
   "getStarted.step2.tip1": {
-    "message": "Write it down on paper and store it securely offline"
+    "message": "Escríbalo en papel y guárdelo sin conexión"
   },
   "getStarted.step2.tip2": {
-    "message": "Never share it with anyone or store it digitally"
+    "message": "Nunca lo comparta con nadie o lo almacene digitalmente"
   },
   "getStarted.step2.tip3": {
-    "message": "Anyone with your recovery phrase can access your funds"
+    "message": "Cualquiera con su frase de recuperación puede acceder a sus fondos"
   },
   "getStarted.step2.tip4": {
-    "message": "Keep multiple copies in different secure locations"
+    "message": "Mantener varias copias en diferentes lugares seguros"
   },
   "getStarted.step2.checkbox": {
-    "message": "I've backed up my recovery phrase."
+    "message": "Respalde su Frase de Recuperación."
   },
   "getStarted.step3.title": {
-    "message": "Complete wallet setup"
+    "message": "Configuración completa de la billetera"
   },
   "getStarted.step3.description": {
-    "message": "Finish setting up your wallet with a password and verification."
+    "message": "Termine de configurar su billetera con una contraseña y verificación."
   },
   "getStarted.step3.heading": {
-    "message": "Final setup steps"
+    "message": "Pasos finales de configuración"
   },
   "getStarted.step3.intro": {
-    "message": "After backing up your recovery phrase, complete these two important steps:"
+    "message": "Después de hacer una copia de seguridad de su frase de recuperación, complete estos dos pasos importantes:"
   },
   "getStarted.step3.passwordLabel": {
-    "message": "Spending password:"
+    "message": "Contraseña de gasto:"
   },
   "getStarted.step3.passwordText": {
-    "message": "Create a strong password to protect everyday transactions. This password is different from your recovery phrase and secures your wallet on this device."
+    "message": "Crea una contraseña segura para proteger las transacciones diarias. Esta contraseña es diferente de tu frase de recuperación y asegura tu cartera en este dispositivo."
   },
   "getStarted.step3.verifyLabel": {
-    "message": "Verify your backup:"
+    "message": "Verifique su copia de seguridad:"
   },
   "getStarted.step3.verifyText": {
-    "message": "Most wallets will ask you to confirm your recovery phrase by selecting words in order. This ensures you've correctly saved it."
+    "message": "La mayoría de las billeteras le pedirán que confirme su frase de recuperación seleccionando palabras en orden. Esto asegura que la ha guardado correctamente."
   },
   "getStarted.step3.ready": {
-    "message": "Once these steps are complete, your wallet is ready to use!"
+    "message": "Una vez completados estos pasos, ¡tu billetera está lista para usar!"
   },
   "getStarted.step3.securityNote": {
-    "message": "If you forget your spending password, you can restore your wallet using your recovery phrase."
+    "message": "Si olvida su contraseña para gastos, puede restaurar su billetera usando su frase de recuperación."
   },
   "getStarted.step3.securityWarning": {
-    "message": "However, anyone who obtains your recovery phrase can fully access and empty your wallet without needing the spending password."
+    "message": "Sin embargo, cualquiera que obtenga su frase de recuperación puede acceder completamente y vaciar su billetera sin necesidad de utilizar la contraseña de ingreso."
   },
   "getStarted.step3.checkbox": {
-    "message": "I've completed the wallet setup."
+    "message": "Configuración completa de la billetera."
   },
   "getStarted.step4.title": {
-    "message": "Connect your wallet"
+    "message": "Conecte su billetera"
   },
   "getStarted.step4.description": {
-    "message": "Use your wallet as a single account for apps and projects on Cardano. A wallet connector, like the one shown below, lets websites securely connect to your wallet so you can interact without creating separate accounts or passwords."
+    "message": "Utilice su billetera como una única cuenta para aplicaciones y proyectos en Cardano. Un conector de billetera, como el que se muestra a continuación, permite a los sitios web conectarse de forma segura a su cartera para que pueda interactuar sin crear cuentas separadas o contraseñas."
   },
   "getStarted.step4.securityNote": {
-    "message": "When you approve a connection or transaction, you are granting that site specific permissions. Always check the website address and review what you are asked to approve before continuing."
+    "message": "Cuando aprueba una conexión o transacción, está otorgando a ese sitio permisos específicos. Compruebe siempre la dirección del sitio web y revise lo que se le pide que apruebe antes de continuar."
   },
   "getStarted.step4.checkbox": {
-    "message": "I've connected my wallet."
+    "message": "He conectado mi billetera."
   },
   "getStarted.step5.title": {
-    "message": "Get ada"
+    "message": "Obtener ada"
   },
   "getStarted.step5.description": {
-    "message": "Obtain ada, Cardano's native cryptocurrency, to start using the blockchain."
+    "message": "Obtén ada, criptomoneda nativa de Cardano, para empezar a usar la blockchain."
   },
   "getStarted.step5.heading": {
-    "message": "Where to get ada"
+    "message": "Dónde conseguir ada"
   },
   "getStarted.step5.text": {
-    "message": "There are several ways to obtain ada, but the most common method is buying it on cryptocurrency exchanges using fiat currency or other cryptocurrencies."
+    "message": "Hay varias maneras de obtener ada, pero el método más común es comprarlo en intercambios de criptomoneda usando monedas fiat u otras criptomonedas."
   },
   "getStarted.step5.button": {
-    "message": "View all options"
+    "message": "Ver todas las opciones"
   },
   "getStarted.step5.securityNote": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers."
+    "message": "El espacio de criptomonedas está lleno de oportunidades, pero también es un parque de diversiones para estafadores."
   },
   "getStarted.step5.checkbox": {
-    "message": "I have ada in my wallet."
+    "message": "Tengo ada en mi billetera."
   },
   "getStarted.step6.title": {
-    "message": "Explore the ecosystem"
+    "message": "Explora el ecosistema"
   },
   "getStarted.step6.description": {
-    "message": "Now that you have a wallet and ada, you are ready to explore everything Cardano has to offer. A good place to start is by exploring popular apps."
+    "message": "Ahora que usted tiene una billetera y ada, usted está listo para explorar todo lo que Cardano tiene para ofrecer. Un buen lugar para comenzar es explorar aplicaciones más populares."
   },
   "whereToGetAda.hero.title": {
-    "message": "Where to get ada?"
+    "message": "¿Dónde conseguir ada?"
   },
   "whereToGetAda.hero.description": {
-    "message": "There are many ways to obtain ada to use the Cardano blockchain."
+    "message": "Hay muchas maneras de obtener ada para usar la blockchain de Cardano."
   },
   "whereToGetAda.meta.title": {
-    "message": "Buy ada, Where to Get Cardano's Native Token"
+    "message": "Compra ada, Donde Obtener el Token Nativo de Cardano"
   },
   "whereToGetAda.meta.description": {
-    "message": "Buy ada on centralized or decentralized exchanges, earn staking rewards, or receive it directly. Find the best way to get Cardano's native token."
+    "message": "Compra ada en los intercambios centralizados o descentralizados, gana recompensas de staking, o recíbelas directamente. Encuentra la mejor forma de obtener el token nativo de Cardano."
   },
   "whereToGetAda.divider.exchanges": {
-    "message": "Buy ada using Exchanges"
+    "message": "Comprar ada usando Intercambios"
   },
   "whereToGetAda.cex.title": {
-    "message": "Centralized Exchanges"
+    "message": "Intercambios centralizados"
   },
   "whereToGetAda.cex.description": {
-    "message": "Centralized exchanges (CEXs) are platforms where cryptocurrencies and other digital assets are traded. They act as intermediaries between buyers and sellers, facilitating transactions and often providing additional services such as custodial storage, order matching, and regulatory compliance. Note that CEXs have custody over [ada](/what-is-ada/) and other native tokens until you send them to a [wallet](/what-is-ada/#wallets) that you control."
+    "message": "Los intercambios centralizados (CEXs) son plataformas donde operar criptomonedas y otros activos digitales. Actúan como intermediarios entre compradores y vendedores, facilitando las transacciones y a menudo proporcionando servicios adicionales como el almacenamiento custodial, el emparejamiento de órdenes y el cumplimiento de la normativa. Ten en cuenta que los CEXs tienen la custodia sobre [ada](/what-is-ada/) y otros tokens nativos hasta que los envíes a un [wallet](/what-is-ada/#wallets) que tu controles."
   },
   "whereToGetAda.cex.disclaimer": {
-    "message": "Listing here does not imply endorsement. This data is crowd-sourced by the community. Visit [CoinMarketCap](https://coinmarketcap.com/currencies/cardano/#Markets) to see a full list of exchanges that support [ada](/what-is-ada/)."
+    "message": "La lista aquí no implica aprobación. Estos datos son recopilados por la comunidad. Visita [CoinMarketCap](https://coinmarketcap.com/currencies/cardano/#Markets) para ver una lista completa de intercambios que soportan [ada](/what-is-ada/)."
   },
   "whereToGetAda.dex.title": {
-    "message": "Decentralized Exchanges"
+    "message": "Intercambios Descentralizados"
   },
   "whereToGetAda.dex.description": {
-    "message": "Decentralized exchanges (DEXs) are platforms for trading cryptocurrencies that operate without a central authority. They allow users to trade directly with each other (peer-to-peer) through automated processes facilitated by smart contracts. This approach enhances security and privacy, reducing the risk of hacking and custodial failures associated with centralized exchanges."
+    "message": "Los intercambios descentralizados (DEXs) son plataformas para operar criptomonedas que operan sin una autoridad central. Permiten a los usuarios operar directamente entre sí (peer-to-peer) a través de procesos automatizados facilitados por contratos inteligentes. Este enfoque mejora la seguridad y la privacidad, reduciendo el riesgo de ataques informáticos y problemas de custodia asociados con los intercambios centralizados."
   },
   "whereToGetAda.dex.disclaimer": {
-    "message": "DEXs are not suitable for beginners, as you must already have [ada](/what-is-ada/) to use them. Listing here does not imply endorsement. Transaction data is based on the last 30 days."
+    "message": "Los DEXs no son adecuados para principiantes, ya que debes tener [ada](/what-is-ada/) para usarlos. La lista aquí no implica aprobación. Los datos de transacciones se basan en los últimos 30 días."
   },
   "whereToGetAda.divider.receive": {
-    "message": "Receive ada from people around the world"
+    "message": "Recibe ada de personas de todo el mundo"
   },
   "whereToGetAda.receive.title": {
-    "message": "Receive ada"
+    "message": "Recibir ada"
   },
   "whereToGetAda.receive.description1": {
-    "message": "Before receiving or buying [ada](/what-is-ada/), you need to set up a [Cardano wallet](/what-is-ada/#wallets)."
+    "message": "Antes de recibir o comprar [ada](/what-is-ada/), necesitas configurar una [cartera de Cardano](/what-is-ada/#wallets)."
   },
   "whereToGetAda.receive.description2": {
-    "message": "Once you have a [Cardano wallet](/what-is-ada/#wallets), all you need to do is share your address to start sending and receiving [ada](/what-is-ada/) (and other native tokens) peer-to-peer."
+    "message": "Una vez que tengas una [cartera de Cardano](/what-is-ada/#wallets), todo lo que necesitas hacer es compartir tu dirección para empezar a enviar y recibir [ada](/what-is-ada/) (y otros tokens nativos) peer-to-peer."
   },
   "whereToGetAda.receive.description3": {
-    "message": "Some [wallets](/what-is-ada/#wallets) let you purchase crypto with a debit/credit card, bank transfer, or Apple Pay. Availability depends on your location."
+    "message": "Algunas [carteras](/what-is-ada/#wallets) te permiten comprar criptomonedas con una tarjeta de débito/crédito, transferencia bancaria o Apple Pay. La disponibilidad depende de tu ubicación."
   },
   "whereToGetAda.divider.funding": {
-    "message": "Get funded in ada"
+    "message": "Obtén fondos en ada"
   },
   "whereToGetAda.funding.title": {
-    "message": "Project Catalyst"
+    "message": "Proyecto Catalyst"
   },
   "whereToGetAda.funding.description": {
-    "message": "Discover Cardano's innovation fund designed to support groundbreaking projects and ideas. By participating, you can receive [ada](/what-is-ada/) funding to bring your vision to life. Visit [Project Catalyst](https://projectcatalyst.io) and learn how to create a proposal."
+    "message": "Descubra el fondo de innovación de Cardano diseñado para apoyar proyectos e ideas innovadoras. Al participar, puedes recibir fondos en [ada](/what-is-ada/) para dar vida a tu visión. Visita [Projecto Catalyst](https://projectcatalyst.io) y aprende a crear una propuesta."
   },
   "whereToGetAda.divider.rewards": {
-    "message": "Staking rewards"
+    "message": "Recompensas de staking"
   },
   "whereToGetAda.staking.title": {
-    "message": "Staking rewards"
+    "message": "Recompensas de staking"
   },
   "whereToGetAda.staking.description1": {
-    "message": "If you already have some [ada](/what-is-ada/), you can earn more by [delegating your ada to a stake pool](/stake-pool-delegation/). This allows you to participate in the network's proof-of-stake system and earn rewards. Alternatively, you can [run your own stake pool](/stake-pool-operation/), which requires more effort and technical knowledge but can be more rewarding."
+    "message": "Si ya tienes [ada](/what-is-ada/), puedes ganar más al [delegar tu ada a un pool de stake](/stake-pool-delegation/). Esto le permite participar en el sistema de prueba de participación de la red y ganar recompensas. Alternativamente, puedes [correr tu propio servidor](/stake-pool-operation/), lo que requiere más esfuerzo y conocimientos técnicos pero puede ser más gratificante."
   },
   "whereToGetAda.staking.description2": {
-    "message": "Cardano offers several advantages for staking: there is no minimum amount of [ada](/what-is-ada/) required to stake, no risk of slashing (losing your staked [ada](/what-is-ada/)), and no locking period. You always maintain custody over your delegated [ada](/what-is-ada/), ensuring that your funds remain secure and accessible at all times. Additionally, rewards are distributed by the protocol itself, not by the pools, ensuring a fair and transparent distribution process."
+    "message": "Cardano ofrece varias ventajas sl hacer staking: no se requiere una cantidad mínima de [ada](/what-is-ada/) para delegar, sin riesgo de slashing (perdiendo el [ada] en stake (/what-is-ada/)), y sin período de bloqueo. Siempre mantienes la custodia sobre el [ada] delegado (/what-is-ada/), asegurándote de que tus fondos permanezcan seguros y accesibles en todo momento. Además, las recompensas se distribuyen por el propio protocolo, no por los pools, garantizando un proceso de distribución justo y transparente."
   },
   "commonScams.hero.title": {
-    "message": "Common Cardano scams"
+    "message": "Estafas comunes en Cardano"
   },
   "commonScams.hero.description": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers."
+    "message": "El espacio de criptomonedas está lleno de oportunidades, pero también es un parque de diversiones para estafadores."
   },
   "commonScams.meta.title": {
-    "message": "Common Cardano Scams, How to Stay Safe"
+    "message": "Estafas Comunes en Cardano: Cómo Mantenerse Seguro"
   },
   "commonScams.meta.description": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers."
+    "message": "El espacio de criptomonedas está lleno de oportunidades, pero también es un parque de diversiones para estafadores."
   },
   "commonScams.quiz.title": {
-    "message": "Test Your Knowledge"
+    "message": "Prueba tu Conocimiento"
   },
   "commonScams.quiz.description": {
-    "message": "Take the 5-question quiz to see how well you can identify and avoid common blockchain scams."
+    "message": "Responde el cuestionario de 5 preguntas para ver si puedes identificar y evitar estafas comunes en blockchain."
   },
   "commonScams.quiz.buttonText": {
-    "message": "Start Quiz"
+    "message": "Iniciar Cuestionario"
   },
   "commonScams.intro.title": {
-    "message": "Protecting your ada from scammers"
+    "message": "Protegiendo tu ada de estafadores"
   },
   "commonScams.intro.description1": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers. Cardano (ada), one of the most popular blockchains, isn't immune to these threats. From fake giveaways to phishing attacks, scammers are constantly innovating new ways to exploit users. As artificial intelligence continues to improve, these scams are also becoming more sophisticated. This page outlines the most common scams in the Cardano ecosystem and how you can protect yourself."
+    "message": "El espacio de criptomonedas está lleno de oportunidades, pero también es un parque de diversiones para estafadores. Cardano (ada), una de las blockchains más populares, no es inmune a estas amenazas. Desde falsas entregas hasta ataques de phishing, los estafadores están constantemente innovando nuevas formas de explotar a los usuarios. A medida que la inteligencia artificial sigue mejorando, estas estafas también se están haciendo más frecuentes. Esta página describe las estafas más comunes en el ecosistema de Cardano y cómo puedes protegerte a ti mismo."
   },
   "commonScams.intro.description2": {
-    "message": "**Remember:** If someone gains access to your seed words (recovery phrase), they can take full control of your wallet—no spending password can protect you. Once your ada is stolen, it's gone forever, with no way to recover it."
+    "message": "**Recuerda:** Si alguien obtiene acceso a tus palabras semillas (frase de recuperación), puede tomar el control total de tu cartera: ninguna contraseña de gasto puede protegerte. Una vez robada tu ada, ha desaparecido para siempre, sin ninguna forma de recuperarla."
   },
   "commonScams.divider.giveaway": {
     "message": "Giveaway"
   },
   "commonScams.giveaway.title": {
-    "message": "Ada Giveaway Scam"
+    "message": "Estafa Ada Giveaway"
   },
   "commonScams.giveaway.description1": {
-    "message": "One of the most well-known scams targeting the Cardano community is the **Ada Giveaway Scam.** Scammers promise to double your ada if you send them a certain amount first. These scams often feature fake live streams of Charles Hoskinson, or other well-known personalities, to appear legitimate. The streams may mimic genuine events and include a wallet address for you to send your ada."
+    "message": "Una de las estafas más conocidas que apuntan a la comunidad de Cardano es la **estafa Ada Giveaway. ** Los estafadores prometen duplicar tu ada si los mandas una cierta cantidad primero. Estas estafas a menudo presentan videos en vivo falsos de Charles Hoskinson, u otras personalidades conocidas, para parecer legítimas. Los streams pueden imitar eventos genuinos e incluir una dirección de cartera para que usted envíe su ada."
   },
   "commonScams.giveaway.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "Cómo protegerse:"
   },
   "commonScams.giveaway.tip1": {
-    "message": "Legitimate giveaways **never** ask for money upfront."
+    "message": "Los sorteos legítimos **nunca** piden dinero por adelantado."
   },
   "commonScams.giveaway.tip2": {
-    "message": "Avoid clicking on links in unsolicited messages or live streams."
+    "message": "Evite hacer clic en enlaces de mensajes no solicitados o transmisiones en vivo."
   },
   "commonScams.giveaway.tip3": {
-    "message": "Remember: Once sent, your ada is gone forever."
+    "message": "Recuerde: Una vez enviado, tu ada se ha ido para siempre."
   },
   "commonScams.giveaway.tip4": {
-    "message": "Read reports and scam sightings from users in [the Cardano forum](https://forum.cardano.org/c/english/report-a-scam/184)."
+    "message": "Lee informes y avistamientos de estafas de usuarios en [el foro de Cardano](https://forum.cardano.org/c/english/report-a-scam/184)."
   },
   "commonScams.divider.phishing": {
     "message": "Phishing"
   },
   "commonScams.phishing.title": {
-    "message": "Phishing Attacks"
+    "message": "Ataques de Suplantación de Identidad"
   },
   "commonScams.phishing.description": {
-    "message": "Phishing scams involve fake websites, apps or emails designed to steal sensitive information, such as your wallet credentials or recovery phrase (seed words). These fraudulent sites often mimic popular wallets like [Typhon, VESPR or Eternl](/what-is-ada/#wallets)."
+    "message": "Las estafas de suplantación de identidad implican sitios web, aplicaciones o correos electrónicos falsos, diseñados para robar información confidencial, como las credenciales de su billetera o la frase de recuperación (palabras semilla). Estos sitios fraudulentos a menudo imitan billeteras populares como [Typhon, VESPR o Eternl](/what-is-ada/#wallets)."
   },
   "commonScams.phishing.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "Cómo protegerse:"
   },
   "commonScams.phishing.tip1": {
-    "message": "Double-check URLs to ensure they match actual wallet websites."
+    "message": "Verifique las URL para asegurarse de que coincidan con los sitios web reales de las billeteras."
   },
   "commonScams.phishing.tip2": {
-    "message": "**Never** share your recovery phrase, **even** with \"support\" staff or \"moderators\"."
+    "message": "**nunca** comparta su frase de recuperación, **incluso** con el personal de \"soporte\" o \"moderadores\"."
   },
   "commonScams.phishing.tip3": {
-    "message": "Consider using hardware wallets."
+    "message": "Considere el uso de carteras de hardware."
   },
   "commonScams.phishing.tip4": {
-    "message": "Use two-factor authentication where possible."
+    "message": "Usar autenticación de doble factor cuando sea posible."
   },
   "commonScams.divider.investment": {
-    "message": "Fake Investment"
+    "message": "Inversión falsa"
   },
   "commonScams.investment.title": {
-    "message": "Fake Investment Opportunities"
+    "message": "Oportunidades de inversión falsas"
   },
   "commonScams.investment.description": {
-    "message": "Fraudulent investment schemes are another popular scam. Scammers promote fake projects, claiming they are \"Cardano-backed\" or \"ada-specific\" opportunities with guaranteed high returns. Victims are urged to send ada or other funds to a provided wallet address, with promises of earning exponential profits."
+    "message": "Las estafas de inversión fraudulentas son otro tipo de fraude común. Los estafadores promocionan proyectos falsos, afirmando que son oportunidades respaldadas por Cardano o específicas de ada con altos rendimientos garantizados. Se insta a las víctimas a enviar ada u otros fondos a una dirección de billetera proporcionada, con la promesa de obtener ganancias exponenciales."
   },
   "commonScams.investment.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "Cómo protegerte a ti mismo:"
   },
   "commonScams.investment.tip1": {
-    "message": "Legitimate projects **never** promise guaranteed returns."
+    "message": "Proyectos legítimos **nunca** promenten retornos garantizados."
   },
   "commonScams.investment.tip2": {
-    "message": "Be skeptical of unsolicited investment offers."
+    "message": "Sean escépticos con respecto a las ofertas de inversión no solicitadas."
   },
   "commonScams.investment.tip3": {
-    "message": "Research projects thoroughly, checking for transparency and a credible team."
+    "message": "Investigue a fondo los proyectos, comprobando la transparencia y un equipo creíble."
   },
   "commonScams.divider.support": {
-    "message": "Fake Support"
+    "message": "Soporte falso"
   },
   "commonScams.support.title": {
-    "message": "Fake Tech Support"
+    "message": "Soporte técnico falso"
   },
   "commonScams.support.description1": {
-    "message": "In this scam, fraudsters pose as \"official\" Cardano support representatives. They often reach out via social media, forums, or email, claiming they can fix your wallet or troubleshoot an issue. They also often copy the profiles of real moderators and to \"help,\" they'll ask for your recovery phrase (seed words) or private keys."
+    "message": "En esta estafa, los defraudadores se presentan como representantes \"oficiales\" que apoyan a los representantes. A menudo llegan a través de redes sociales, foros o correo electrónico, afirmando que pueden arreglar su billetera o solucionar un problema. También a menudo copian los perfiles de los moderadores reales y para \"ayudar\", pedirán su frase de recuperación (palabras de semilla) o claves privadas."
   },
   "commonScams.support.description2": {
-    "message": "This scam is often seen when a [new user enters a channel](/docs/communities) and asks a question about a wallet. Scammers quickly respond, pretending to be official support."
+    "message": "Esta estafa se ve a menudo cuando un [nuevo usuario entra en un canal] (/docs/communities) y hace una pregunta sobre una billetera. Los estafadores responden rápidamente, fingiendo ser un apoyo oficial."
   },
   "commonScams.support.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "Cómo protegerte a ti mismo:"
   },
   "commonScams.support.tip1": {
-    "message": "Legitimate people on [forums and channels](/docs/communities) will **never** ask for your passwords, recovery phrases or private keys."
+    "message": "Personas legítimas en [foros y canales](/docs/communities) **nunca** pedirán tus contraseñas, frases de recuperación o claves privadas."
   },
   "commonScams.support.tip2": {
-    "message": "Never engage with unsolicited messages claiming to be from support."
+    "message": "Nunca te comprometas con mensajes no solicitados que afirman ser de soporte."
   },
   "commonScams.support.tip3": {
-    "message": "Legitimate people on forums and channels will **never** contact you first in a private message."
+    "message": "Personas legítimas en los foros y canales **nunca** se pondrán en contacto contigo primero en un mensaje privado."
   },
   "commonScams.divider.rug": {
     "message": "Rug Pulls"
   },
   "commonScams.rug.title": {
-    "message": "Rug Pulls in Cardano Ecosystem"
+    "message": "Rug Pulls en el ecosistema de Cardano"
   },
   "commonScams.rug.description": {
-    "message": "Cardano is a public, permissionless Layer 1 blockchain and everyone can use it. Some fraudulent projects launch on Cardano, gaining attention with big promises and flashy marketing. After collecting a significant amount of ada from investors, these projects disappear—this is known as a \"rug pull.\""
+    "message": "Cardano es una blockchain de Capa 1, pública, abierta y todo el mundo puede usarla. Algunos proyectos fraudulentos se lanzan en Cardano, ganando atención con grandes promesas y mercadeo escandaloso. Después de recoger una cantidad significativa de ada de los inversores, estos proyectos desaparecen, lo que se conoce como una \"estafa de salida\"."
   },
   "commonScams.rug.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "Cómo protegerte a ti mismo:"
   },
   "commonScams.rug.tip1": {
-    "message": "Research the project team's credentials and reputation."
+    "message": "Investiga las credenciales y la reputación del equipo del proyecto."
   },
   "commonScams.rug.tip2": {
-    "message": "Check for audits or transparent documentation."
+    "message": "Comprobar auditorías o documentación transparente."
   },
   "commonScams.rug.tip3": {
-    "message": "Avoid projects with anonymous teams or unrealistic promises."
+    "message": "Evite proyectos con equipos anónimos o promesas poco realistas."
   },
   "commonScams.rug.tip4": {
-    "message": "Only get utility tokens when you need to use the utility."
+    "message": "Solo adquiere tokens de utilidad cuando necesites usarla."
   },
   "commonScams.rug.tip5": {
-    "message": "Find out what other people think about projects in [the Cardano forum](https://forum.cardano.org/c/english/report-a-scam/184)."
+    "message": "Averigua lo que otras personas piensan sobre proyectos en [el foro de Cardano](https://forum.cardano.org/c/english/report-a-scam/184)."
   },
   "home.meta.title": {
-    "message": "Cardano, Secure Decentralized Blockchain Platform"
+    "message": "Cardano, Plataforma Descentralizada de Cadena de Bloques Segura"
   },
   "home.meta.description": {
-    "message": "Cardano is a decentralized blockchain platform built through peer-reviewed research. Explore ada, staking, governance, DApps, and a global open-source community."
+    "message": "Cardano es una plataforma descentralizada de cadena de bloques construida a través de investigaciones revisadas por pares. Explora ada, staking, gobernanza, Aplicaciones descentralizadas y una comunidad global de código abierto."
   },
   "home.hero.title": {
-    "message": "Making the World Work Better for All"
+    "message": "Haciendo que el mundo funcione mejor para todos"
   },
   "home.hero.description": {
-    "message": "Cardano is the most secure, reliable and censorship-resistant blockchain for mission critical applications to power economies and societies of the future."
+    "message": "Cardano es la cadena de bloques más segura, confiable y resistente a la censura para aplicaciones de misión críticas al impulsar las economías y sociedades del futuro."
   },
   "home.hero.ctaWhatIsAda": {
-    "message": "What is ada?"
+    "message": "¿Qué es ada?"
   },
   "home.hero.ctaGetStarted": {
-    "message": "Get Started"
+    "message": "Comenzar"
   },
   "home.featured.title": {
-    "message": "Our World Is Changing. Together, We Can Change It For The Better."
+    "message": "Nuestro mundo está cambiando. Juntos podemos cambiarlo para mejor."
   },
   "home.featured.description1": {
-    "message": "Cardano is a proof-of-stake blockchain platform: the first to be founded on [peer-reviewed research](/research) and developed through evidence-based methods. It combines pioneering technologies to provide unparalleled security and sustainability to decentralized applications, systems, and societies."
+    "message": "Cardano es una plataforma de cadena de bloques de prueba de participación: la primera en ser fundada en [investigación revisada por pares](/research) y desarrollada a través de métodos basados en evidencia. Combina tecnologías pioneras para proporcionar seguridad y sostenibilídad sin precedentes a aplicaciones, sistemas y sociedades descentralizadas."
   },
   "home.featured.description2": {
-    "message": "With a leading team of engineers, Cardano exists to redistribute power from unaccountable structures to the margins – to individuals – and be an enabling force for positive change and progress."
+    "message": "Con un equipo líder de ingenieros, Cardano existe para redistribuir el poder de estructuras no confiables a los bordes, a los individuos y ser una fuerza que permita un cambio y un progreso positivo."
   },
   "home.featured.quote1": {
-    "message": "A History Of Impossible,"
+    "message": "Una Historia de lo Imposible"
   },
   "home.featured.quote2": {
-    "message": "Made Possible"
+    "message": "Hecho posible"
   },
   "home.featured.buttonLabel": {
-    "message": "Use Cardano Apps"
+    "message": "Usar aplicaciones de Cardano"
   },
   "home.divider.benefits": {
-    "message": "Benefits"
+    "message": "Beneficios"
   },
   "home.quoteBox.description": {
-    "message": "Cardano restores trust to global systems – creating, through science, a more secure, transparent, and sustainable foundation for individuals to transact and exchange, systems to govern, and enterprises to grow."
+    "message": "Cardano restaura la confianza en los sistemas globales, creando, a través de la ciencia, una más segura, transparente, y una base sostenible para que las personas transaccionen e intercambien, sistemas para gobernar y empresas para crecer."
   },
   "home.quoteBox.quote": {
-    "message": "Cardano brings a new standard in technology – open and inclusive – to challenge the old and activate a new age of sustainable, globally-distributed innovation."
+    "message": "Cardano aporta un nuevo estándar en tecnología, abierta e inclusiva, para desafiar a los viejos patrones y activar una nueva era de innovación sostenible y distribuida a nivel global."
   },
   "home.benefits.ouroboros.label": {
-    "message": "Proof-of-stake and Ouroboros"
+    "message": "Prueba de participación y Ouroboros"
   },
   "home.benefits.ouroboros.category": {
-    "message": "Protocol"
+    "message": "Protocolo"
   },
   "home.benefits.ouroboros.title": {
-    "message": "Proof-Of-Stake And Ouroboros: The Most Environmentally Sustainable Blockchain Protocol"
+    "message": "Prueba de participación y Ouroboros: el Protocolo Blockchain Ambientalmente más Sostenible"
   },
   "home.benefits.ouroboros.body": {
-    "message": "Ouroboros is the first peer-reviewed, verifiably-secure blockchain protocol, and Cardano is the first blockchain to implement it. Ouroboros enables decentralization in the Cardano network on a sustainable scale for global requirements and most crucially, without compromising security.<br /><br />The protocol is the result of tireless efforts, based on foundational research, propelled by a vision for more secure and transparent global payment systems, and provides the means to equitably redistribute power and control."
+    "message": "Ouroboros es el primer protocolo de blockchain revisado por pares, verificablemente seguro, y Cardano es el primer blockchain en implementarlo. Ouroboros permite la descentralización en la red Cardano a una escala sostenible para los requerimientos globales y lo más crucial, sin comprometer la seguridad.<br /><br />El protocolo es el resultado de esfuerzos incansables, basados en investigaciones fundacionales. impulsada por una visión de sistemas de pago globales más seguros y transparentes, y proporciona los medios para redistribuir equitativamente el poder y el control."
   },
   "home.benefits.ouroboros.cta": {
-    "message": "Learn about Ouroboros"
+    "message": "Aprende sobre Ouroboros"
   },
   "home.benefits.research.label": {
-    "message": "Evidence-based development"
+    "message": "Desarrollo basado en evidencia"
   },
   "home.benefits.research.category": {
-    "message": "Research"
+    "message": "Investigación"
   },
   "home.benefits.research.title": {
-    "message": "The Highest Standards In Development, Rooted In Science"
+    "message": "Los más altos estándares en desarrollo, arraigados en la ciencia"
   },
   "home.benefits.research.body": {
-    "message": "Cardano is developed using evidence-based methods; a novel combination of formal methods, normally found in critical high-stakes applications, and an agile approach, which helps the project remain adaptable and responsive to emerging requirements and new innovations. To support global applications, systems, and solutions, we believe security assurance is not a choice: it is a requirement. Our protocol implementations and platform integrations are first researched, challenged, and mathematically modeled and tested before they are specified. These specifications then inform development which, in turn, is independently audited. The result is a codebase offering an unrivaled level of assurance."
+    "message": "Cardano se desarrolla utilizando métodos basados en la evidencia; una nueva combinación de métodos formales, normalmente encontrados en aplicaciones críticas de alto riesgo y un enfoque ágil, lo que ayuda a que el proyecto se mantenga adaptable y responda a las necesidades emergentes y a las nuevas innovaciones. Para apoyar las aplicaciones, sistemas y soluciones globales, creemos que la garantía de seguridad no es una opción: es un requisito. Nuestras implementaciones de protocolos e integraciones de plataformas son investigadas, desafiadas y matemáticamente modeladas y probadas antes de ser especificadas. A continuación. Estas especificaciones informan sobre un desarrollo que, a su vez, se somete a auditorías independientes, y el resultado es un código base que ofrece un nivel de seguridad sin igual."
   },
   "home.benefits.research.cta": {
-    "message": "Discover the research"
+    "message": "Descubre la investigación"
   },
   "home.benefits.secure.label": {
-    "message": "Secure"
+    "message": "Segura"
   },
   "home.benefits.secure.category": {
-    "message": "Transact"
+    "message": "Transaccionar"
   },
   "home.benefits.secure.title": {
-    "message": "Unparalleled Security - And The Makings Of A Trustless World"
+    "message": "Seguridad sin parangón y mecanismos de un mundo que no depende de la confianza"
   },
   "home.benefits.secure.body": {
-    "message": "Cardano makes it possible for any actors who do not know each other - and have no reason to trust one another - to interact and transact, securely. It is a platform for building trust where none might naturally exist, opening up whole new markets and opportunities. Through Ouroboros, Cardano is provably secure against bad actors and Sybil attacks. Every transaction, interaction, and exchange is immutably and transparently recovered, and securely validated using multi-signature and a pioneering extended UTXO model."
+    "message": "Cardano hace posible que cualquier actor que no se conozca y no tenga motivos para confiar unos en otros interactúe y transaccione con seguridad. Se trata de una plataforma para generar confianza en la que naturalmente no existe ninguna, abriendo mercados y oportunidades totalmente nuevos. A través de Ouroboros, Cardano está demostrablemente seguro contra malos actores y ataques de Sybil. Cada transacción, interacción e intercambio se recupera de forma inmutable y transparente, y se valida de forma segura utilizando una firma múltiple y un modelo pionero de UTXO extendido."
   },
   "home.benefits.secure.cta": {
-    "message": "Visit the roadmap"
+    "message": "Visita la hoja de ruta"
   },
   "home.benefits.participation.label": {
-    "message": "Incentivized participation"
+    "message": "Participación incentivada"
   },
   "home.benefits.participation.category": {
-    "message": "Open"
+    "message": "Abrir"
   },
   "home.benefits.participation.title": {
-    "message": "Open And Incentivized Participation"
+    "message": "Participación Abierta e Incentivada"
   },
   "home.benefits.participation.body": {
-    "message": "With a committed community at its core, Cardano is an open-source project developed through open participation. To ensure the longevity and health of the network, Cardano features an incentive mechanism that rewards users - either as stake pool operators or stake delegators - for their participation. The platform is built and expanded through enhancement and improvement proposals. Cardano's governance system gives everyone a democratic voice; ada holders can submit or vote on proposals to upgrade the platform or help determine the direction of development. The governance model uniquely positions Cardano for future growth and development, and provides the means to introduce new capabilities tailored to user needs. It ensures Cardano and its community can continuously fund and decide upon platform and ecosystem improvements."
+    "message": "Con una comunidad comprometida en su centro, Cardano es un proyecto de código abierto desarrollado a través de la participación abierta. Para garantizar la longevidad y la salud de la red, Cardano cuenta con un mecanismo de incentivos que premia a los usuarios ya sea como operadores de stake pool o como delengantes de stake por su participación. La plataforma se construye y amplía a través de propuestas de mejora. El sistema de gobernanza de Cardano da a todo el mundo una voz democrática. Los poseedores de ada pueden presentar o votar propuestas para actualizar la plataforma o ayudar a determinar la dirección del desarrollo. El modelo de gobernanza posiciona a Cardano para el crecimiento y el desarrollo futuros, y proporciona los medios para introducir nuevas capacidades adaptadas a las necesidades del usuario. Asegura que Cardano y su comunidad puedan financiar y decidir continuamente las mejoras de plataforma y ecosistemas."
   },
   "home.benefits.participation.cta": {
-    "message": "Learn about governance"
+    "message": "Aprende sobre gobernanza"
   },
   "home.benefits.scalable.label": {
-    "message": "Scalable and sustainable"
+    "message": "Escalable y sostenible"
   },
   "home.benefits.scalable.category": {
-    "message": "Ecosystem"
+    "message": "Ecosistema"
   },
   "home.benefits.scalable.title": {
-    "message": "Extremely Scalable And Environmentally Sustainable"
+    "message": "Extremadamente escalable y ambientalmente sostenible"
   },
   "home.benefits.scalable.body": {
-    "message": "Ouroboros allows Cardano to scale to global requirements with minimal energy consumption. Unlike other blockchains, Cardano does not require exponentially increasing energy to enhance performance and add blocks. The balance between performance and sustainability is achieved through a combination of novel approaches, including multi-ledger, side chains, and parallel transaction processing through multi-party state channels.<br /><br />The network proliferates as the number of stake pools increases, while parameters are set and adjusted to measure the attractiveness of specific stake pools. This is a network that rewards participation directly. Cardano is designed to ensure that those who act in the best interests of the network are also acting in their own best interests. This ensures the development of a healthy ecosystem with a durable, healthy, and robust network, now and into the future. The combination of sustainability and scalability allows Cardano to achieve the throughput required to meet the evolving demands of global systems— financial, logistical, identity-related, societal."
+    "message": "Ouroboros permite a Cardano escalar a los requerimientos globales con un consumo de energía mínimo. A diferencia de otras blockchains, Cardano no requiere energía exponencialmente creciente para mejorar el rendimiento y añadir bloques. El equilibrio entre rendimiento y sostenibilidad se logra mediante una combinación de nuevos enfoques, incluyendo multi-ledger, cadenas laterales, y procesamiento de transacciones paralelas a través de canales de estado multipartitas.<br /><br />La red prolifera a medida que aumenta el número de stake pools, mientras que los parámetros son configurados y ajustados para medir el atractivo de los stake pools específicos. Esta es una red que recompensa directamente la participación. Cardano está diseñado para garantizar que quienes actúan en el mejor interés de la red también actúen en su propio interés. Esto asegura el desarrollo de un ecosistema saludable con una red duradera, saludable y robusta, ahora y hacia el futuro. La combinación de sostenibilidad y escalabilidad permite a Cardano lograr el avance necesario para satisfacer las crecientes demandas de los sistemas globales: financieros, logísticos, relacionados con la identidad, la sociedad."
   },
   "home.benefits.scalable.cta": {
-    "message": "Learn about Hydra"
+    "message": "Aprende sobre Hydra"
   },
   "home.vision.title1": {
-    "message": "Define Your Possible."
+    "message": "Define tu posibilidad."
   },
   "home.vision.title2": {
-    "message": "Change Your World."
+    "message": "Cambia tu mundo."
   },
   "home.divider.makeTheChange": {
-    "message": "Make the Change"
+    "message": "Haz el cambio"
   },
   "home.discover.title": {
-    "message": "Discover Cardano"
+    "message": "Descubre Cardano"
   },
   "home.discover.description": {
-    "message": "Cardano is the first blockchain platform to be built through [peer-reviewed research](/research), to be secure enough to protect the data of billions, scalable enough to accommodate global systems, and robust enough to support foundational change."
+    "message": "Cardano es la primera plataforma de blockchain que se construye a través de [investigación revisada por pares](/research), para estar lo suficientemente seguros como para proteger los datos de miles de millones, lo suficientemente escalables como para acomodar los sistemas globales y lo suficientemente sólidos como para apoyar el cambio fundacional."
   },
   "home.discover.people": {
-    "message": "People"
+    "message": "Personas"
   },
   "home.discover.purpose": {
-    "message": "Purpose"
+    "message": "Propósito"
   },
   "home.discover.research": {
-    "message": "Research"
+    "message": "Investigación"
   },
   "home.discover.technology": {
-    "message": "Technology"
+    "message": "Tecnología"
   },
   "home.discover.opportunity": {
-    "message": "Opportunity"
+    "message": "Oportunidad"
   },
   "home.discover.quote1": {
-    "message": "We have changed science. We have changed what it means to build global systems and sustainable models of exchange and governance."
+    "message": "Hemos cambiado la ciencia, hemos cambiado lo que significa construir sistemas globales y modelos sostenibles de intercambio y gobernanza."
   },
   "home.discover.quote2": {
-    "message": "Alongside the community, entities, and companies building on Cardano, a new future is being defined: a decentralized future without intermediaries, where power is returned to the individual"
+    "message": "Junto a la comunidad, entidades y empresas que construyen en Cardano, un nuevo futuro está siendo definido: un futuro descentralizado sin intermediarios, donde el poder es devuelto al individuo"
   },
   "home.divider.entities": {
-    "message": "Entities"
+    "message": "Entidades"
   },
   "home.entities.description": {
-    "message": "Multiple independent entities collaborate within a decentralized team framework to drive Cardano forward, ensuring that it remains aligned with its core mission as it progresses and develops. These are a few of them:"
+    "message": "Múltiples entidades independientes colaboran dentro de un marco descentralizado para hacer avanzar a Cardano asegurando que permanezca alineado con su misión central a medida que avanza y se desarrolla. Estos son algunos de ellos:"
   },
   "home.follow.divider": {
     "message": "Social"
   },
   "home.follow.title": {
-    "message": "Get Involved"
+    "message": "Involúcrate"
   },
   "navbar.mega.column.Get to know": {
-    "message": "Get to know",
+    "message": "Conozca",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Take part": {
-    "message": "Take part",
+    "message": "Participa",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Research": {
-    "message": "Research",
+    "message": "Investigación",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Connect": {
-    "message": "Connect",
+    "message": "Conectar",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Engage": {
-    "message": "Engage",
+    "message": "Participar",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Governance": {
-    "message": "Governance",
+    "message": "Gobernanza",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Get started": {
-    "message": "Get started",
+    "message": "Comenzar",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Tools": {
-    "message": "Tools",
+    "message": "Herramientas",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.For Enterprise": {
-    "message": "For Enterprise",
+    "message": "Para la empresa",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Use Cases": {
-    "message": "Use Cases",
+    "message": "Casos de Uso",
     "description": "Mega menu column title"
   },
   "navbar.mega.label.What is ada?": {
-    "message": "What is ada?",
+    "message": "¿Qué es ada?",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Get started with Cardano": {
-    "message": "Get started with Cardano",
+    "message": "Empieza con Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Where to get ada?": {
-    "message": "Where to get ada?",
+    "message": "¿Dónde conseguir ada?",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Protect your ada": {
-    "message": "Protect your ada",
+    "message": "Protege tú ada",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Delegate your ada": {
-    "message": "Delegate your ada",
+    "message": "Delega tú ada",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Delegate your vote": {
-    "message": "Delegate your vote",
+    "message": "Delegar tu voto",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Use Cardano Apps": {
-    "message": "Use Cardano Apps",
+    "message": "Usar aplicaciones de Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Code of Conduct": {
-    "message": "Code of Conduct",
+    "message": "Código de conducta",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Research": {
-    "message": "Cardano Research",
+    "message": "Investigación de Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Insights": {
-    "message": "Cardano Insights",
+    "message": "Perspectivas de Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Hard Forks": {
-    "message": "Hard Forks",
+    "message": "Bifurcaciones duras",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.News": {
-    "message": "News",
+    "message": "Noticias",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Newsletter": {
-    "message": "Newsletter",
+    "message": "Boletín de noticias",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Online Communities": {
-    "message": "Online Communities",
+    "message": "Comunidades Online",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Ambassador Program": {
-    "message": "Ambassador Program",
+    "message": "Programa de Embajadores",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Events": {
-    "message": "Cardano Events",
+    "message": "Eventos de Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Forum": {
-    "message": "Cardano Forum",
+    "message": "Foro Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Get involved in cardano.org": {
-    "message": "Get involved in cardano.org",
+    "message": "Participa en cardano.org",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Participate in governance": {
-    "message": "Participate in governance",
+    "message": "Participa en la gobernanza",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Governance Tools": {
-    "message": "Governance Tools",
+    "message": "Herramientas de Gobernanza",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Constitution": {
-    "message": "Cardano Constitution",
+    "message": "Constitución de Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Start building on Cardano": {
-    "message": "Start building on Cardano",
+    "message": "Empieza a construir en Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Integrate Cardano": {
-    "message": "Integrate Cardano",
+    "message": "Integrar Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Developer Portal": {
-    "message": "Developer Portal",
+    "message": "Portal para Desarrolladores",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Builder Tools": {
-    "message": "Builder Tools",
+    "message": "Herramientas para Desarrolladores",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Companies building on Cardano": {
-    "message": "Companies building on Cardano",
+    "message": "Empresas construyendo en Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Enterprise Solutions": {
-    "message": "Enterprise Solutions",
+    "message": "Soluciones para empresas",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Contact the Foundation": {
-    "message": "Contact the Foundation",
+    "message": "Contactar a la Fundación Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.All Use Cases": {
-    "message": "All Use Cases",
+    "message": "Todos los casos de uso",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Identity": {
-    "message": "Identity",
+    "message": "Identidad",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Supply Chain": {
-    "message": "Supply Chain",
+    "message": "Cadena de Suministro",
     "description": "Mega menu item label"
   },
   "navbar.mega.description.What is ada?": {
-    "message": "Cardano's native token",
+    "message": "Token nativo de Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Get started with Cardano": {
-    "message": "Learn the basics and start using Cardano",
+    "message": "Aprende lo básico y empieza a usar Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Where to get ada?": {
-    "message": "Obtain ada to use Cardano",
+    "message": "Obtén ada para usar Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Protect your ada": {
-    "message": "Don't fall for scams",
+    "message": "No caigas en estafas",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Delegate your ada": {
-    "message": "Be a part of it and earn rewards",
+    "message": "Sé parte y gana recompensas",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Delegate your vote": {
-    "message": "Lend your voting power to a DRep",
+    "message": "Presta tu poder de voto a un DRep",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Use Cardano Apps": {
-    "message": "Explore curated applications",
+    "message": "Explorar aplicaciones curadas",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Code of Conduct": {
-    "message": "Community standards and values",
+    "message": "Estándares comunitarios y valores",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Research": {
-    "message": "Peer-reviewed research and papers",
+    "message": "Investigaciones y documentos revisados por pares",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Insights": {
-    "message": "On-chain or regularly refreshed data",
+    "message": "Datos en cadena o actualizados regularmente",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Hard Forks": {
-    "message": "Implemented Upgrades",
+    "message": "Mejoras implementadas",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.News": {
-    "message": "Latest Cardano news and updates",
+    "message": "Últimas noticias y actualizaciones de Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Newsletter": {
-    "message": "Stay updated with Cardano news",
+    "message": "Mantente actualizado con noticias de Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Online Communities": {
-    "message": "Recommended Channels",
+    "message": "Canales Recomendados",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Ambassador Program": {
-    "message": "Meet Cardano Ambassadors",
+    "message": "Conoce a los embajadores de Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Events": {
-    "message": "Join Cardano community events",
+    "message": "Únete a eventos de la comunidad de Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Forum": {
-    "message": "Structured long-format discussions",
+    "message": "Discusiones de formato largo estructuradas",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Get involved in cardano.org": {
-    "message": "If you'd like to participate, this will get you started",
+    "message": "Si quieres participar, puedes iniciar con esto",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Participate in governance": {
-    "message": "Shape Cardano's future",
+    "message": "Dar forma al futuro de Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Governance Tools": {
-    "message": "Tools for transparent, community-driven decisions",
+    "message": "Herramientas para decisiones transparentes impulsadas por la comunidad",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Constitution": {
-    "message": "Learn about governance",
+    "message": "Aprende sobre gobernanza",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Start building on Cardano": {
-    "message": "Developer resources and tooling",
+    "message": "Recursos de desarrollador y herramientas",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Integrate Cardano": {
-    "message": "Exchange and integration guides",
+    "message": "Guías de intercambio e integración",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Developer Portal": {
-    "message": "Cardano developer portal and docs",
+    "message": "Portal de desarrolladores de Cardano y documentos",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Builder Tools": {
-    "message": "Tools to build on Cardano",
+    "message": "Herramientas para construir en Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Companies building on Cardano": {
-    "message": "Companies, associations, and collaborations",
+    "message": "Empresas, asociaciones y colaboraciones",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Enterprise Solutions": {
-    "message": "Case studies and proven deployments",
+    "message": "Casos de estudio e implementaciones probadas",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Contact the Foundation": {
-    "message": "Partner with the Cardano Foundation",
+    "message": "Asociarse con la Fundación Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.All Use Cases": {
-    "message": "Explore blockchain applications",
+    "message": "Explorar aplicaciones blockchain",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Identity": {
-    "message": "Credentials & verification",
+    "message": "Credenciales y verificación",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Supply Chain": {
-    "message": "Traceability & provenance",
+    "message": "Trazabilidad y procedencia",
     "description": "Mega menu item description"
   },
   "solutions.data.dpp.title": {
-    "message": "Digital Product Passport"
+    "message": "Pasaporte de producto digital"
   },
   "solutions.data.dpp.description": {
-    "message": "EU-compliant digital product passports for transparency and sustainability."
+    "message": "Pasaportes de productos digitales compatibles con la UE para la transparencia y la sostenibilidad."
   },
   "solutions.data.category.supplyChain": {
-    "message": "Supply Chain"
+    "message": "Cadena de suministro"
   },
   "solutions.data.traceability.title": {
-    "message": "Traceability"
+    "message": "Trazabilidad"
   },
   "solutions.data.traceability.description": {
-    "message": "End-to-end supply chain traceability powered by blockchain."
+    "message": "Trazabilidad de la cadena de suministro de extremo a extremo impulsada por blockchain."
   },
   "solutions.data.authenticity.title": {
-    "message": "Authenticity"
+    "message": "Autenticidad"
   },
   "solutions.data.authenticity.description": {
-    "message": "Combat counterfeiting with blockchain-verified product authenticity."
+    "message": "Combate la falsificación con la trazabilidad de los productos verificada mediante blockchain en Cardano."
   },
   "solutions.data.sustainability.title": {
-    "message": "Sustainability"
+    "message": "Sustentabilidad"
   },
   "solutions.data.sustainability.description": {
-    "message": "Track and verify sustainability claims with immutable records."
+    "message": "Seguimiento y verificación de reclamos de sostenibilidad con registros inmutables."
   },
   "solutions.data.storage.title": {
-    "message": "Decentralized Storage"
+    "message": "Almacenamiento descentralizado"
   },
   "solutions.data.storage.description": {
-    "message": "Secure, distributed data storage solutions for enterprises."
+    "message": "Soluciones de almacenamiento de datos seguras y distribuidas para empresas."
   },
   "solutions.data.category.dataTech": {
-    "message": "Data & Technology"
+    "message": "Data y tecnología"
   },
   "solutions.data.navio.description": {
-    "message": "Blockchain-based solution for supply chain management."
+    "message": "Solución basada en Blockchain para la gestión de cadenas de suministro."
   },
   "solutions.data.caseStudies.title": {
-    "message": "Case Studies"
+    "message": "Casos de estudio"
   },
   "solutions.data.caseStudies.description": {
-    "message": "Explore real-world implementations of Cardano blockchain solutions."
+    "message": "Explora implementaciones reales de soluciones en la blockchain de Cardano."
   },
   "useCases.category.identity": {
-    "message": "Identity"
+    "message": "Identidad"
   },
   "useCases.card.education.title": {
-    "message": "Education"
+    "message": "Educación"
   },
   "useCases.card.education.summary": {
-    "message": "Blockchain-verified academic credentials"
+    "message": "Credenciales académicas verificadas por Blockchain"
   },
   "useCases.card.digitalIdentity.title": {
-    "message": "Digital Identity"
+    "message": "Identidad Digital"
   },
   "useCases.card.digitalIdentity.summary": {
-    "message": "Own and control your digital identity"
+    "message": "Controla tu propia identidad digital"
   },
   "useCases.card.financeKyc.title": {
-    "message": "Finance KYC"
+    "message": "KYC financiero"
   },
   "useCases.card.financeKyc.summary": {
-    "message": "Streamlined identity verification"
+    "message": "Verificación de identidad simplificada"
   },
   "useCases.card.government.title": {
-    "message": "Government"
+    "message": "Gobierno"
   },
   "useCases.card.government.summary": {
-    "message": "Tamper-proof official documents"
+    "message": "Documentos oficiales a prueba de manipulación"
   },
   "useCases.category.finance": {
-    "message": "Finance"
+    "message": "Finanzas"
   },
   "useCases.card.defi.summary": {
-    "message": "Decentralized lending and exchanges"
+    "message": "Préstamos e intercambios descentralizados"
   },
   "useCases.card.payments.title": {
-    "message": "Payments"
+    "message": "Pagos"
   },
   "useCases.card.payments.summary": {
-    "message": "Fast, low-cost cross-border transfers"
+    "message": "Transferencias transfronterizas rápidas y de bajo costo"
   },
   "useCases.category.supplyChain": {
-    "message": "Supply Chain"
+    "message": "Cadena de Suministro"
   },
   "useCases.card.agriculture.title": {
-    "message": "Agriculture"
+    "message": "Agricultura"
   },
   "useCases.card.agriculture.summary": {
-    "message": "Farm-to-table traceability"
+    "message": "Trazabilidad del productor a la mesa"
   },
   "useCases.card.retail.title": {
-    "message": "Retail"
+    "message": "Comercio minorista"
   },
   "useCases.card.retail.summary": {
-    "message": "Combat counterfeiting with provenance"
+    "message": "Combate falsificación con procedencia"
   },
   "useCases.card.logistics.title": {
-    "message": "Logistics"
+    "message": "Logística"
   },
   "useCases.card.logistics.summary": {
-    "message": "Real-time tracking and verification"
+    "message": "Seguimiento y verificación en tiempo real"
   },
   "useCases.category.socialImpact": {
-    "message": "Social Impact"
+    "message": "Impacto Social"
   },
   "useCases.card.socialPrograms.title": {
-    "message": "Social Programs"
+    "message": "Programas sociales"
   },
   "useCases.card.socialPrograms.summary": {
-    "message": "Transparent fund distribution"
+    "message": "Distribución transparente de fondos"
   },
   "useCases.category.dataTech": {
-    "message": "Data & Technology"
+    "message": "Data y tecnología"
   },
   "useCases.card.dataStorage.title": {
-    "message": "Data Storage"
+    "message": "Almacenamiento de Datos"
   },
   "useCases.card.dataStorage.summary": {
-    "message": "Decentralized, secure storage"
+    "message": "Almacenamiento descentralizado y seguro"
   },
   "useCases.card.tokenizedAssets.title": {
-    "message": "Tokenized Assets"
+    "message": "Activos tokenizados"
   },
   "useCases.card.tokenizedAssets.summary": {
-    "message": "Fractional ownership of real-world assets"
+    "message": "Propiedad fraccional de activos del mundo real"
   },
   "useCases.category.emerging": {
-    "message": "Emerging Applications"
+    "message": "Aplicaciones emergentes"
   },
   "useCases.card.votingSystems.title": {
-    "message": "Voting Systems"
+    "message": "Sistema de Votación"
   },
   "useCases.card.votingSystems.summary": {
-    "message": "Secure, transparent elections"
+    "message": "Elecciones seguras y transparentes"
   },
   "useCases.card.healthcare.title": {
-    "message": "Healthcare"
+    "message": "Sistemas de Salud"
   },
   "useCases.card.healthcare.summary": {
-    "message": "Portable, secure health records"
+    "message": "Historial de salud portable y seguro"
   },
   "useCases.card.musicIp.title": {
-    "message": "Music & IP"
+    "message": "Música y Propiedad Intelectual"
   },
   "useCases.card.musicIp.summary": {
-    "message": "Direct royalty payments to artists"
+    "message": "Pagos directos a los artistas"
   },
   "ambassadors.hero.title": {
-    "message": "Ambassadors"
+    "message": "Embajadores"
   },
   "ambassadors.hero.description": {
-    "message": "The Cardano Ambassador Program celebrates community leaders driving the expansion of the Cardano ecosystem. Established in 2018 and continuously refined by the Cardano Foundation, it empowers dedicated contributors to make a global impact."
+    "message": "El Programa de Embajadores de Cardano celebra a los líderes comunitarios que impulsan la expansión del ecosistema de Cardano. Establecido en 2018 y administrado por la Fundación Cardano, otorga reconocimiento a los colaboradores dedicados en lograr un impacto global."
   },
   "ambassadors.layout.title": {
-    "message": "Cardano Ambassador Program, Join the Community"
+    "message": "Programa de Embajadores de Cardano, Únete a la Comunidad"
   },
   "ambassadors.layout.description": {
-    "message": "The Cardano Ambassador Program recognizes community leaders who educate, engage, and raise awareness to drive Cardano's adoption."
+    "message": "El Programa de Embajadores de Cardano reconoce a los líderes comunitarios que educan, participan y aumentan el conocimiento para impulsar la adopción global de Cardano."
   },
   "ambassadors.cta.leftTitle": {
-    "message": "Become a Cardano Ambassador"
+    "message": "Conviértete en un Embajador de Cardano"
   },
   "ambassadors.cta.leftText1": {
-    "message": "The journey to becoming an Ambassador is built on dedication, collaboration, and meaningful contributions. Ambassadors emerge from the community by actively participating and making a lasting impact."
+    "message": "El viaje para convertirse en Embajador se basa en la dedicación, la colaboración y las contribuciones significativas. Los embajadores emergen de la comunidad participando activamente y haciendo un impacto duradero."
   },
   "ambassadors.cta.leftText2": {
-    "message": "Your first step begins in the Cardano Forum, a dynamic space for collaboration, discussion, and knowledge sharing. By contributing valuable insights, engaging in conversations, and supporting fellow community members, you build a strong foundation of trust and influence. As you progress through different levels, new opportunities for deeper involvement and leadership open up."
+    "message": "El primer paso comienza en el Foro de Cardano, un espacio dinámico para la colaboración, discusión y intercambio de conocimientos. Al contribuir con información valiosa, entablar conversaciones y apoyar a otros miembros de la comunidad, usted construye una base sólida de confianza e influencia. A medida que avanzan a través de diferentes niveles, se abren nuevas oportunidades para una mayor participación y liderazgo."
   },
   "ambassadors.cta.leftText3": {
-    "message": "Ambassadorship is a reflection of commitment and contribution. Those who actively support the community and help Cardano grow naturally step into this role."
+    "message": "Ser Embajador es un reflejo del compromiso y de la contribución al ecosistema. Quienes apoyan activamente a la comunidad y ayudan a Cardano a crecer naturalmente en este rol."
   },
   "ambassadors.cta.rightButtonLabel": {
-    "message": "Get Started"
+    "message": "Comenzar"
   },
   "brandAssets.hero.title": {
-    "message": "Brand Assets"
+    "message": "Recursos de marca"
   },
   "brandAssets.hero.description": {
-    "message": "Our brand is a reflection of everything that we create. Here are some of the things that make up our brand and how you can use them."
+    "message": "Nuestra marca es un reflejo de todo lo que creamos. Aquí están algunas de las cosas que conforman nuestra marca y cómo puedes utilizarlas."
   },
   "brandAssets.layout.title": {
-    "message": "Cardano Brand Assets, Logos and Guidelines"
+    "message": "Activos de marca Cardano, Logos y Directrices"
   },
   "brandAssets.layout.description": {
-    "message": "Our brand is a reflection of everything that we create. Here are some of the things that make up our brand and how you can use them."
+    "message": "Nuestra marca es un reflejo de todo lo que creamos. Aquí están algunas de las cosas que conforman nuestra marca y cómo puedes utilizarlas."
   },
   "codeOfConduct.hero.title": {
-    "message": "Community Code Of Conduct"
+    "message": "Código de Conducta de la Comunidad"
   },
   "codeOfConduct.hero.description": {
-    "message": "The Cardano community consists of people from all over the world, who have come together to grow and safeguard the spirit and the future of Cardano."
+    "message": "La comunidad de Cardano está formada por personas de todo el mundo, que se han unido para crecer y salvaguardar el espíritu y el futuro de Cardano."
   },
   "codeOfConduct.layout.title": {
-    "message": "Cardano Community Code of Conduct"
+    "message": "Código de Conducta de la Comunidad Cardano"
   },
   "codeOfConduct.layout.description": {
-    "message": "The Cardano community consists of people from all over the world, who have come together to grow and safeguard the spirit and the future of Cardano."
+    "message": "La comunidad de Cardano está formada por personas de todo el mundo, que se han unido para crecer y salvaguardar el espíritu y el futuro de Cardano."
   },
   "codeOfConduct.intro.description": {
-    "message": "The Cardano community consists of people from all over the world, who have come together to grow and safeguard the spirit and the future of Cardano. All participants in the community are expected to act lawfully, honestly, ethically and in the best interest of the project. This Code of Conduct offers rules and guidelines designed to aid judgment within our community and keep it a clean and well-lighted place for civilised public discourse about the project. By joining and participating in any of the official Cardano community channels, you confirm that you agree to be bound by the Code of Conduct."
+    "message": "La comunidad de Cardano está formada por personas de todo el mundo, que se han unido para crecer y salvaguardar el espíritu y el futuro de Cardano. Se espera que todos los participantes de la comunidad actúen de forma legal, honesta, ética y en el mejor interés del proyecto. Este Código de Conducta ofrece normas y directrices diseñadas para ayudar a juzgar dentro de nuestra comunidad y mantenerlo como un lugar limpio y bien iluminado para el discurso público civilizado sobre el proyecto. Al unirte y participar en cualquiera de los canales oficiales de la comunidad Cardano, confirmas que estás de acuerdo con el Código de conducta."
   },
   "codeOfConduct.improveDiscussion.title": {
-    "message": "Improve the discussion"
+    "message": "Mejora la discusión"
   },
   "codeOfConduct.improveDiscussion.description1": {
-    "message": "Help us make the community a great place for discussion by always working to improve the discussion in some way, however small. If you are not sure your post adds to the conversation, think over what you want to say and try again later. The topics discussed in the community matter to us, and we want you to act as if they matter to you, too. Be respectful of the topics and the people discussing them, even if you disagree with some of what is being said."
+    "message": "Ayúdanos a hacer de la comunidad un gran lugar para el debate trabajando siempre para mejorar la discusión de alguna manera, hasta la más pequeña. Si no estás seguro de que tu publicación añade valor a la conversación, piensa en lo que quieres decir e inténtalo de nuevo más tarde. Los temas discutidos en la comunidad nos importan y queremos que actúes como si también te importan. Sean respetuosos con los temas y con las personas que los discuten, aunque no estén de acuerdo con algunos de los que se están diciendo."
   },
   "codeOfConduct.improveDiscussion.description2": {
-    "message": "One way to improve the discussion is by discovering ones that are already happening. Spend some time to search the community platform before replying and you'll have a better chance of meeting others who share your interests. Always look to add value. Discussion should be healthy and informative and members should provide meaningful contribution towards the development of Cardano. This means any content shared or uploaded online should be relevant to the community. Please also refrain from posting or spread misinformation or fake news that attempt to create fear or doubt."
+    "message": "Una forma de mejorar el debate es descubriendo aquellos que ya están ocurriendo. Dedique algo de tiempo a buscar en la plataforma de la comunidad antes de responder y tendrá una mejor oportunidad de conocer a otros que comparten sus intereses. Busque siempre para añadir valor. El debate debe ser saludable e informativo y los miembros deben aportar una contribución significativa al desarrollo de Cardano. Esto significa que cualquier contenido compartido o subido en línea debe ser relevante para la comunidad. Por favor, no dude en publicar o difundir información errónea o falsas noticias que intentan crear miedo o dudas."
   },
   "codeOfConduct.improveDiscussion.description3": {
-    "message": "We also do not allow trading or shilling of ada or any other tokens, goods or services."
+    "message": "Tampoco permitimos el comercio o publicidad falsa de ada o cualquier otro tokens, bienes o servicios."
   },
   "codeOfConduct.beAgreeable.title": {
-    "message": "Be agreeable, even when you disagree"
+    "message": "Estar de acuerdo, incluso cuando no esté de acuerdo"
   },
   "codeOfConduct.beAgreeable.description1": {
-    "message": "You may wish to respond to something by disagreeing with it. That's fine. But remember to criticise ideas, not people. Please avoid:"
+    "message": "Puede que quieras responder a algo discrepando con ello. Eso está bien. Pero recuerda criticar ideas, no personas. Por favor, evita que:"
   },
   "codeOfConduct.beAgreeable.list1": {
-    "message": "Name-calling"
+    "message": "Insultar"
   },
   "codeOfConduct.beAgreeable.list2": {
-    "message": "Ad hominem attacks"
+    "message": "Ataques personales"
   },
   "codeOfConduct.beAgreeable.list3": {
-    "message": "Responding to a post's tone instead of its actual content"
+    "message": "Respuesta al tono de una publicación en lugar de su contenido real"
   },
   "codeOfConduct.beAgreeable.list4": {
-    "message": "Knee-jerk reaction"
+    "message": "Reacción impulsiva"
   },
   "codeOfConduct.beAgreeable.list5": {
-    "message": "Caps Lock. We consider this as electronic shouting"
+    "message": "Bloqueo de mayúsculas. Consideramos esto como gritos electrónicos"
   },
   "codeOfConduct.beAgreeable.description2": {
-    "message": "Instead, provide reasoned counter-arguments that improve the conversation. Please also remember the rule above to add value and meaningful discussion. The Cardano community channels should not be used for personal disputes between community members."
+    "message": "En su lugar, proporcione contra-argumentos razonados que mejoran la conversación. Por favor, recuerde también la regla anterior para agregar valor y discusión significativa. Los canales comunitarios de Cardano no deben ser utilizados para disputas personales entre miembros de la comunidad."
   },
   "codeOfConduct.participation.title": {
-    "message": "Your participation counts"
+    "message": "Tu participación cuenta"
   },
   "codeOfConduct.participation.description": {
-    "message": "The conversations we have in the community sets the tone for every new arrival. Help us influence the future of this community by choosing to engage in discussions that make this forum an interesting place to be --- and avoiding those that do not."
+    "message": "Las conversaciones que tenemos en la comunidad marcan el tono para cada nueva llegada. Ayúdanos a influir en el futuro de esta comunidad eligiendo participar en discusiones que hacen de este foro un lugar interesante para ser --- y evitar los que no."
   },
   "codeOfConduct.reportProblem.title": {
-    "message": "If you see a problem, report it"
+    "message": "Si ves un problema, repórtalo"
   },
   "codeOfConduct.reportProblem.description1": {
-    "message": "Moderators have special authority within the community; they are responsible for ensuring members adhere to this conduct. But so are you. With your help, moderators can be community facilitators. When you see bad behaviour, don't reply. It encourages the bad behaviour by acknowledging it, consumes your energy, and wastes everyone's time. Just report it! Below are specific instructions on how to report violations in each channel."
+    "message": "Los moderadores tienen autoridad especial dentro de la comunidad; son responsables de asegurar que los miembros se adhieran a esta conducta. Pero tú también. Con tu ayuda, los moderadores pueden ser facilitadores de la comunidad. Cuando veas mal comportamiento, no respondas. Fomenta el mal comportamiento al reconocerlo, consume energía y pierde el tiempo de todos. ¡Simplemente reportalo! Debajo hay instrucciones específicas sobre cómo reportar violaciones en cada canal."
   },
   "codeOfConduct.reportProblem.list1": {
-    "message": "[Cardano Forum](https://forum.cardano.org): if you see a post that you think violates the Cardano Community Code of Conduct, click the options button and flag it as inappropriate or leave a more detailed message for the moderators."
+    "message": "[Foro de Cardano](https://forum.cardano.org): si ves una publicación que crees que viola el Código de Conducta de la Comunidad de Cardano, haga clic en el botón de opciones y marcarlo como inapropiado o deje un mensaje más detallado para los moderadores."
   },
   "codeOfConduct.reportProblem.list2": {
-    "message": "[Reddit](https://www.reddit.com/r/cardano): you can report any post in Reddit by clicking on the 'Report' button underneath all posts. You are required to provide further information as to which rules or laws the post infringes. Reddit moderators will then review your request."
+    "message": "[Reddit](https://www.reddit.com/r/cardano): puedes denunciar cualquier publicación en Reddit haciendo clic en el botón «Denunciar» que aparece debajo de todas las publicaciones. Se te pedirá que facilites más información sobre qué normas o leyes incumple la publicación. A continuación, los moderadores de Reddit revisarán tu solicitud."
   },
   "codeOfConduct.reportProblem.list3": {
-    "message": "[Telegram](https://t.me/CardanoAnnouncements): any message can be reported by right clicking on it. This will go to the platform. There is also a [Report to Admin](https://t.me/CardanoReportToAdmin) channel, specifically for reporting offensive content or abusive users. You can also forward any messages in violation of the code in a DM to any of our admins."
+    "message": "[Telegram](https://t.me/CardanoAnnouncements): puedes denunciar cualquier mensaje haciendo clic con el botón derecho del ratón sobre él. La denuncia se enviará a la plataforma. También hay un canal llamado [Denunciar al administrador](https://t.me/CardanoReportToAdmin), destinado específicamente a denunciar contenidos ofensivos o usuarios abusivos. Asimismo, puedes reenviar cualquier mensaje que incumpla el código de conducta mediante un mensaje privado a cualquiera de nuestros administradores."
   },
   "codeOfConduct.reportProblem.list4": {
-    "message": "[Facebook](https://www.facebook.com/groups/CardanoCommunity): you can report any post in our Facebook group by clicking the arrow in the top right corner of the post and selecting Report. This alerts the moderators and admins to review."
+    "message": "[Facebook](https://www.facebook.com/groups/CardanoCommunity): puedes denunciar cualquier publicación de nuestro grupo de Facebook haciendo clic en la flecha situada en la esquina superior derecha de la publicación y seleccionando «Denunciar». De este modo, se avisará a los moderadores y administradores para que la revisen."
   },
   "codeOfConduct.reportProblem.list5": {
-    "message": "[Twitter](https://twitter.com/cardano): you can report any tweet directly to Twitter by clicking on the drop down menu on the tweet itself. Please note that reports on tweets will go directly to Twitter and not the Cardano moderating team."
+    "message": "[Twitter](https://twitter.com/cardano): puedes denunciar cualquier tuit directamente a Twitter haciendo clic en el menú desplegable que aparece en el propio tuit. Ten en cuenta que las denuncias sobre los tuits se enviarán directamente a Twitter y no al equipo de moderación de Cardano."
   },
   "codeOfConduct.reportProblem.description2": {
-    "message": "In order to maintain our community, moderators reserve the right to remove any content and any user account for any reason at any time. Moderators do not preview new posts; the moderators and site operators take no responsibility for any content posted by the community."
+    "message": "Con el fin de mantener nuestra comunidad, los moderadores se reservan el derecho de eliminar cualquier contenido y cualquier cuenta de usuario por cualquier motivo y en cualquier momento. Los moderadores no revisan previamente las nuevas publicaciones; ni los moderadores ni los administradores del sitio se hacen responsables del contenido publicado por la comunidad."
   },
   "codeOfConduct.reportProblem.description3": {
-    "message": "And on the other hand, if you feel your content has been inaccurately removed, the Community team can perform a secondary review. Please provide details of your post to community *at* cardano *dot* org. Please be aware that escalating to secondary review should only be for serious concerns and it may take some time for the community team to respond."
+    "message": "Por otro lado, si consideras que tu contenido ha sido eliminado de forma injustificada, el equipo de la comunidad puede llevar a cabo una revisión secundaria. Envía los detalles de tu publicación a community *arroba* cardano *punto* org. Ten en cuenta que solo se debe solicitar una revisión secundaria en casos graves y que el equipo de la comunidad puede tardar algún tiempo en responder."
   },
   "codeOfConduct.beCivil.title": {
-    "message": "Always be civil"
+    "message": "Siempre ser civilizado"
   },
   "codeOfConduct.beCivil.description1": {
-    "message": "Nothing sabotages a healthy conversation like rudeness:"
+    "message": "Nada sabotea una conversación saludable como la rudeza:"
   },
   "codeOfConduct.beCivil.list1": {
-    "message": "Be civil. Don't post anything that a reasonable person would consider offensive, abusive, or hate speech."
+    "message": "Ser civilizado. No publique nada que una persona razonable considere ofensivo, abuso o discurso de odio."
   },
   "codeOfConduct.beCivil.list2": {
-    "message": "Keep it clean. Don't post anything obscene or sexually explicit."
+    "message": "Manténgalo limpio. No publique nada obsceno o sexualmente explícito."
   },
   "codeOfConduct.beCivil.list3": {
-    "message": "Respect each other. Don't harass or grief anyone, impersonate people, or expose their private information."
+    "message": "Respeto de unos a otros. No acoses o molestes a nadie, suplanten a la gente o expongan su información privada."
   },
   "codeOfConduct.beCivil.list4": {
-    "message": "Respect our community. Don't post spam or otherwise vandalise the forum."
+    "message": "Respete nuestra comunidad. No publique spam o vandalice el foro."
   },
   "codeOfConduct.beCivil.list5": {
-    "message": "We take harassment seriously. Harassment includes offensive verbal comments related to gender, age, sexual orientation, disability, physical appearance, body size, race, religion, but also includes deliberate intimidation, stalking, following, sustained disruption of conversation. Harassment of members, admins or moderators will not be tolerated."
+    "message": "Nos tomamos muy en serio el acoso. El acoso incluye comentarios verbales ofensivos relacionados con el género, la edad, la orientación sexual, la discapacidad, el aspecto físico, el peso, la raza o la religión, pero también abarca la intimidación deliberada, el acoso, el seguimiento y la interrupción continuada de una conversación. No se tolerará el acoso a miembros, administradores o moderadores."
   },
   "codeOfConduct.beCivil.list6": {
-    "message": "Do not post another community member's personal information including but not limited to name, address, phone number, social-media accounts."
+    "message": "No publiques información personal de otros miembros de la comunidad, como, por ejemplo, el nombre, la dirección, el número de teléfono o las cuentas en redes sociales."
   },
   "codeOfConduct.beCivil.list7": {
-    "message": "Do not repost removed or deleted information."
+    "message": "No vuelvas a publicar información que haya sido retirada o eliminada."
   },
   "codeOfConduct.beCivil.description2": {
-    "message": "These are not concrete terms with precise definitions --- avoid even the appearance of any of these things. If you're unsure, ask yourself how you would feel if your post was featured on the front page of a global news website. This is a public community, and search engines index these discussions. Keep the language, links, and images safe for family and friends."
+    "message": "No se trata de conceptos concretos con definiciones precisas; evita incluso dar la impresión de que se trata de algo así. Si tienes dudas, pregúntate cómo te sentirías si tu publicación apareciera en la portada de un sitio web de noticias internacional. Esta es una comunidad pública, y los motores de búsqueda indexan estos debates. Utiliza un lenguaje, enlaces e imágenes que sean aptos para toda la familia y los amigos."
   },
   "codeOfConduct.keepTidy.title": {
-    "message": "Keep it tidy"
+    "message": "Mantenlo ordenado"
   },
   "codeOfConduct.keepTidy.description": {
-    "message": "Make the effort to put things in the right place, so that we can spend more time discussing and less cleaning up. A healthy community requires conversations to be structured and categorized. So:"
+    "message": "Haga el esfuerzo de situar las cosas en el lugar adecuado, para que podamos dedicar más tiempo a debatir y a limpiar menos. Una comunidad saludable requiere que las conversaciones sean estructuradas y categorizadas. Sí:"
   },
   "codeOfConduct.keepTidy.list1": {
-    "message": "Don't start a conversation in the wrong category or channel."
+    "message": "No iniciar una conversación en una categoría o canal incorrectos."
   },
   "codeOfConduct.keepTidy.list2": {
-    "message": "Don't cross-post the same thing in multiple channels."
+    "message": "No publicar lo mismo en múltiples canales."
   },
   "codeOfConduct.postOwnStuff.title": {
-    "message": "Post only your own stuff"
+    "message": "Publicar solo tus propias cosas"
   },
   "codeOfConduct.postOwnStuff.description": {
-    "message": "You may not post anything digital that belongs to someone else without permission. You may not post descriptions of, links to, or methods for stealing someone's intellectual property (software, video, audio, images), or for breaking any other law. Credit should always be attributed back to the original content producer."
+    "message": "No puedes publicar nada digital que pertenezca a otra persona sin permiso. Usted no puede publicar descripciones de, enlaces o métodos para robar la propiedad intelectual de alguien (software, vídeo, audio, imágenes) o para infringir cualquier otra ley. Siempre se debe atribuir crédito al productor de contenido original."
   },
   "codeOfConduct.multipleAccounts.title": {
-    "message": "Multiple Accounts"
+    "message": "Múltiples cuentas"
   },
   "codeOfConduct.multipleAccounts.description": {
-    "message": "Multiple accounts by the same user will not be allowed. This helps foster a more human experience in the online world and restricts spamming. Note that duplicate accounts may be investigated and removed."
+    "message": "No se permitirán múltiples cuentas por el mismo usuario. Esto ayuda a fomentar una experiencia más humana en el mundo en línea y restringe el spamming. Tenga en cuenta que las cuentas duplicadas pueden ser investigadas y eliminadas."
   },
   "codeOfConduct.violation.title": {
-    "message": "Violation of rules"
+    "message": "Incumplimiento de las reglas"
   },
   "codeOfConduct.violation.description1": {
-    "message": "If any of the rules are broken, moderators will perform the following sanctions:"
+    "message": "Si alguna de las reglas es incumplida, los moderadores realizarán las siguientes sanciones:"
   },
   "codeOfConduct.violation.list1": {
-    "message": "First offence: warning is given and the user will be suspended from their account for 24 hours."
+    "message": "Primera infracción: se advierte y el usuario será suspendido de su cuenta durante 24 horas."
   },
   "codeOfConduct.violation.list2": {
-    "message": "Second offence: warning is given and the user will be suspended for a period of up to 1 month depending on the severity of the violation."
+    "message": "Segunda infracción: se advierte y el usuario será suspendido durante un período de hasta 1 mes dependiendo de la gravedad de la violación."
   },
   "codeOfConduct.violation.list3": {
-    "message": "Third and final offence: if the user continues to repeatedly break community rules, their account will be banned from the community platform. This penalty may be applied across all community channels if necessary."
+    "message": "Tercera y última infracción: si el usuario continúa violando repetidamente las reglas de la comunidad, su cuenta será baneada de la plataforma comunitaria. Esta penalización puede aplicarse en todos los canales comunitarios si es necesario."
   },
   "codeOfConduct.violation.description2": {
-    "message": "The community team reserves the right to deny access to the official Community channels to anyone who has violated the Cardano Community Code of Conduct."
+    "message": "El equipo de la comunidad se reserva el derecho de denegar el acceso a los canales oficiales de la Comunidad a cualquiera que haya violado el Código de Conducta de la Comunidad Cardano."
   },
   "codeOfConduct.poweredByYou.title": {
-    "message": "Powered by you"
+    "message": "Desarrollado por ti"
   },
   "codeOfConduct.poweredByYou.description": {
-    "message": "This community is operated by the community staff and you, the community. If you have any further questions about how things should work here, open a new topic in the [community feedback category](https://forum.cardano.org/c/english/community-feedback/16) of the forum and let's discuss! If there is ever a critical or urgent issue please contact us directly at community *at* cardano *dot* org."
+    "message": "Esta comunidad es administrada por miembros de la comunidad. Si tienes más preguntas sobre cómo deberían funcionar las cosas aquí, abrir un nuevo tema en la [categoría de comentarios de la comunidad](https://forum.cardano.org/c/english/community-feedback/16) del foro y vamos a discutir! Si alguna vez hay un problema crítico o urgente, por favor contáctenos directamente en la community *at* cardano *dot* org."
   },
   "constitution.error.title": {
-    "message": "Current Enacted Constitution"
+    "message": "Constitución actualmente promulgada"
   },
   "constitution.error.localCopy": {
-    "message": "(Local Copy)"
+    "message": "(Copia local)"
   },
   "constitution.error.fetchError": {
-    "message": "Could not fetch from data.cardano.org:"
+    "message": "No se pudo obtener desde data.cardano.org:"
   },
   "constitution.error.showingLocal": {
-    "message": "Showing local copy below."
+    "message": "Mostrando copia local abajo."
   },
   "constitution.link.download": {
-    "message": "Download Constitution"
+    "message": "Descargar Constitución"
   },
   "constitution.link.viewRawMarkdown": {
-    "message": "View Raw Markdown"
+    "message": "Ver Recorte Crudo"
   },
   "constitution.loading.versions": {
-    "message": "Loading constitution versions..."
+    "message": "Cargando versiones de la constitución..."
   },
   "constitution.enacted.title": {
-    "message": "Current Enacted Cardano Constitution"
+    "message": "Constitución Cardano actualmente aprobada"
   },
   "constitution.enacted.description": {
-    "message": "Discover the Cardano Constitution: the governance framework of the Cardano blockchain. Read the current enacted charter, explore its ratification history, and download the full text via IPFS."
+    "message": "Descubra la Constitución de Cardano: el marco de gobernanza de la blockchain de Cardano. Lea la carta aprobada actualmente, explore su historial de ratificación y descargue el texto completo a través de IPFS."
   },
   "constitution.link.viewOnIPFS": {
-    "message": "View on IPFS"
+    "message": "Ver en IPFS"
   },
   "constitution.error.loadDocument": {
-    "message": "Could not load constitution document:"
+    "message": "No se pudo cargar el documento de constitución:"
   },
   "constitution.loading.document": {
-    "message": "Loading document..."
+    "message": "Cargando documento..."
   },
   "constitution.history.title": {
-    "message": "Constitution Ratification History"
+    "message": "Historia de la ratificación de la Constitución"
   },
   "constitution.history.description": {
-    "message": "Below you can find the Cardano Constitution and its ratification history. Click any version to view the full text on IPFS."
+    "message": "A continuación encontrará la Constitución de Cardano y su historia de ratificación. Haga clic en cualquier versión para ver el texto completo sobre IPFS."
   },
   "constitution.history.versionRatified": {
-    "message": "Version ratified at epoch"
+    "message": "Versión ratificada en epoch"
   },
   "constitution.history.enactedAtEpoch": {
-    "message": "Enacted at epoch"
+    "message": "Promulgada en epoch"
   },
   "constitution.history.hash": {
     "message": "Hash:"
   },
   "constitution.link.viewOnIPFSHistory": {
-    "message": "View this constitution on IPFS"
+    "message": "Ver esta constitución en IPFS"
   },
   "constitution.hero.title": {
-    "message": "The Cardano Constitution"
+    "message": "La Constitución de Cardano"
   },
   "constitution.hero.description": {
-    "message": "Discover the Cardano Constitution: the governance framework of the Cardano blockchain."
+    "message": "Descubra la Constitución de Cardano: el marco de gobernanza de la blockchain de Cardano."
   },
   "constitution.layout.title": {
-    "message": "The Cardano Constitution, On-Chain Governance Framework"
+    "message": "La Constitución de Cardano, Marco de Gobernanza en Cadena"
   },
   "constitution.layout.description": {
-    "message": "Discover the Cardano Constitution: the governance framework of the Cardano blockchain. Read the current enacted charter, explore its ratification history, and download the full text via IPFS."
+    "message": "Descubra la Constitución de Cardano: el marco de gobernanza de la blockchain de Cardano. Lea la carta promulgada actualmente, explore su historial de ratificación y descargue el texto completo a través de IPFS."
   },
   "contact.hero.title": {
-    "message": "Contact"
+    "message": "Contacto"
   },
   "contact.hero.description": {
-    "message": "Cardano is supported by the Cardano Foundation, IOG, EMURGO, Intersect, PRAGMA and others. Fill out the contact form below and we will put you in touch with the team best placed to assist you."
+    "message": "Cardano cuenta con el apoyo de la Fundación Cardano, IOG, EMURGO, Intersect, PRAGMA y otros. Rellene el siguiente formulario de contacto y le pondremos en contacto con el equipo mejor situado para asistirle."
   },
   "contact.intersect.title": {
-    "message": "Intersect - one of the member-based organizations"
+    "message": "Intersect es una de las organizaciones basadas en miembros"
   },
   "contact.intersect.description": {
-    "message": "Intersect is a member-based organization for the Cardano ecosystem tasked with ensuring its continuity and future development."
+    "message": "Intersect es una organización basada en miembros del ecosistema de Cardano encargado de asegurar su continuidad y desarrollo futuro."
   },
   "contact.intersect.buttonLabel": {
-    "message": "Join Intersect"
+    "message": "Unirse a Intersect"
   },
   "contact.technicalIssue.title": {
-    "message": "Report a technical issue"
+    "message": "Reportar un problema técnico"
   },
   "contact.technicalIssue.description": {
-    "message": "To get help for one of the following wallets, please raise a support ticket."
+    "message": "Para obtener ayuda para una de las siguientes carteras, por favor levanta un ticket de soporte."
   },
   "contact.technicalIssue.buttonLabel": {
-    "message": "Raise Ticket"
+    "message": "Generar ticket"
   },
   "contact.sponsorship.title": {
-    "message": "Cardano Summit Sponsorship"
+    "message": "Patrocinio del Cardano Summit"
   },
   "contact.sponsorship.description1": {
-    "message": "Thank you for your interest in sponsoring our annual Cardano Summit! Your support is crucial to the success of our summit, and we're excited about the possibility of partnering with you. Sponsorship opportunities provide significant exposure and can be tailored to meet your organization's needs and goals."
+    "message": "¡Gracias por su interés en patrocinar nuestra cumbre anual de Cardano! Su apoyo es crucial para el éxito de nuestra cumbre, y estamos entusiasmados con la posibilidad de asociarnos con usted. Las oportunidades de patrocinio proporcionan una exposición significativa y pueden adaptarse a las necesidades y metas de su organización."
   },
   "contact.sponsorship.description2": {
-    "message": "Please fill out the form below to express your interest and provide us with more details about your organization and sponsorship preferences. Our team will review your submission and get in touch with you to discuss potential sponsorship packages and how we can best collaborate for the upcoming event."
+    "message": "Por favor rellene el siguiente formulario para expresar su interés y proporcionarnos más detalles sobre su organización y preferencias de patrocinio. Nuestro equipo revisará su envío y se pondrá en contacto con usted para discutir posibles paquetes de patrocinio y cómo podemos colaborar mejor para el próximo evento."
   },
   "contact.sponsorship.buttonLabel": {
-    "message": "Sponsorship Request"
+    "message": "Solicitud de patrocinio"
   },
   "contact.meta.title": {
-    "message": "Contact Cardano, Get in Touch"
+    "message": "Contactar con Cardano"
   },
   "contact.meta.description": {
-    "message": "Get in touch with the Cardano ecosystem. Reach the Cardano Foundation, Intersect, IOG, or EMURGO for partnerships, support, or sponsorship inquiries."
+    "message": "Póngase en contacto con el ecosistema de Cardano, llegando a la Fundación Cardano, Intersect, IOG o EMURGO para consultas de asociaciones, apoyo o patrocinio."
   },
   "contact.divider.hereToHelp": {
-    "message": "Here to help"
+    "message": "Aquí para ayudar"
   },
   "contact.helpSection.title": {
-    "message": "What Can We Help You With?"
+    "message": "¿Cómo podemos ayudarte?"
   },
   "contact.select.prefix": {
-    "message": "I have"
+    "message": "Yo tengo"
   },
   "contact.select.placeholder": {
-    "message": "not yet decided (please select)"
+    "message": "aún no se ha decidido (por favor seleccionar)"
   },
   "contact.select.option.technicalIssue": {
-    "message": "a technical issue with Daedalus, Nami or Lace"
+    "message": "un problema técnico con Daedalus, Nami o Lace"
   },
   "contact.select.option.intersect": {
-    "message": "the intention to join Intersect"
+    "message": "la intención de unirse a Intersect"
   },
   "contact.select.option.sponsor": {
-    "message": "the desire to sponsor the Cardano Summit"
+    "message": "el deseo de patrocinar la Cumbre de Cardano"
   },
   "contact.select.option.different": {
-    "message": "another inquiry"
+    "message": "otra consulta"
   },
   "artworkContest.hero.title": {
-    "message": "Making the World Work Better for All"
+    "message": "Haciendo que el Mundo Funcione Mejor para Todos"
   },
   "artworkContest.hero.description": {
-    "message": "Cardano is a blockchain platform for changemakers, innovators, and visionaries, with the tools and technologies required to create possibility for the many, as well as the few, and bring about positive global change."
+    "message": "Cardano es una plataforma blockchain para innovadores y visionarios, con las herramientas y tecnologías necesarias para crear posibilidades para muchos y generar un cambio global positivo."
   },
   "artworkContest.imagePreview.alt": {
-    "message": "Preview"
+    "message": "Vista previa"
   },
   "artworkContest.layout.title": {
-    "message": "Cardano Artwork Contest"
+    "message": "Concurso de Arte en Cardano"
   },
   "artworkContest.layout.description": {
-    "message": "An open platform designed to empower billions without economic identity by offering decentralized applications for managing identity, value, and governance."
+    "message": "Una plataforma abierta diseñada para empoderar a miles de millones de personas sin identidad económica ofreciendo aplicaciones descentralizadas para el manejo de identidad, valor y gobernanza."
   },
   "artworkContest.content.title": {
-    "message": "Artwork Contest Test Page"
+    "message": "Página de pruebas del concurso de arte"
   },
   "artworkContest.content.description1": {
-    "message": "Upload your image here to see how it would look like."
+    "message": "Sube tu imagen aquí para ver cómo se vería."
   },
   "artworkContest.content.description2": {
-    "message": "Toggle dark mode and resize the browser to see how it adapts."
+    "message": "Cambia el modo oscuro y cambia el tamaño del navegador para ver cómo se adapta."
   },
   "artworkContest.content.quote1": {
-    "message": "Image will not be submitted,"
+    "message": "La imagen no será enviada,"
   },
   "artworkContest.content.quote2": {
-    "message": "This happens on your machine only"
+    "message": "Esto sólo sucede en tu máquina"
   },
   "developers.hero.title": {
-    "message": "Start Building on Cardano"
+    "message": "Empieza a construir en Cardano"
   },
   "developers.hero.description": {
-    "message": "A curated list of resources and entry points to help you get started with building on Cardano."
+    "message": "Una lista curada de recursos y puntos de entrada para ayudarle a empezar a construir en Cardano."
   },
   "developers.meta.title": {
-    "message": "Build on Cardano, Developer Tools and Documentation"
+    "message": "Construir en Cardano, Herramientas de Desarrollador y Documentación"
   },
   "developers.meta.description": {
-    "message": "Start building on Cardano. Access developer tools, smart contract languages, APIs, testnets, and tutorials to launch your first decentralized application."
+    "message": "Comienza a construir sobre Cardano. Accede a las herramientas de desarrollador, lenguajes de contrato inteligentes, APIs, redes de pruebas y tutoriales para lanzar tu primera aplicación descentralizada."
   },
   "developers.divider.resources": {
-    "message": "Developer Resources"
+    "message": "Recursos para el Desarrollador"
   },
   "developers.documentation.title": {
-    "message": "Documentation"
+    "message": "Documentación"
   },
   "developers.documentation.text": {
-    "message": "Access the essential resources and updates you need to build, integrate, and stay informed about the Cardano blockchain. Below you'll find links to the developer portal, detailed documentation, integration guides, and the latest core development updates."
+    "message": "Acceda a los recursos esenciales y actualizaciones que necesita para construir, integrar y mantenerse informado sobre la cadena de bloques de Cardano. A continuación encontrará enlaces al portal de desarrolladores, documentación detallada, guías de integración y las últimas actualizaciones de desarrollo del núcleo."
   },
   "developers.tools.title": {
-    "message": "Developer Tools"
+    "message": "Herramientas para Desarrolladores"
   },
   "developers.tools.text": {
-    "message": "Explore the tools, projects, and updates that are shaping the Cardano ecosystem. Below you'll find links to builder tools, a showcase of projects built on Cardano, and a technical updates tracker that aggregates commits within the last 7 days from all branches of Cardano development-related repos."
+    "message": "Explore las herramientas, proyectos y actualizaciones que están dando forma al ecosistema de Cardano. A continuación encontrarás enlaces a herramientas de construcción, un escaparate de proyectos construidos en Cardano, y un rastreador de actualizaciones técnicas que agrega commits en los últimos 7 días de todas las ramas de repos relacionados con el desarrollo de Cardano."
   },
   "developers.support.title": {
-    "message": "Support"
+    "message": "Soporte"
   },
   "developers.support.text": {
-    "message": "Join the vibrant Cardano developer community through various platforms. Below you'll find links to the Cardano Stack Exchange, the Cardano Forum, and the official Telegram group. Connect with fellow developers, ask questions, and share insights in our decentralized ecosystem."
+    "message": "Únete a la vibrante comunidad de desarrolladores de Cardano a través de varias plataformas. A continuación encontrará enlaces a la Cardano Stack Exchange, el Foro de Cardano y el grupo oficial de Telegram. Conéctese con otros desarrolladores, haga preguntas y comparta ideas en nuestro ecosistema descentralizado."
   },
   "developers.cta.title": {
-    "message": "Attack the protocol, fork the blockchain - or not. Explore the Ouroboros protocol firsthand in this interactive simulation."
+    "message": "Ataca el protocolo, bifurca la blockchain, o no. Explora el protocolo Ouroboros de primera mano en esta simulación interactiva."
   },
   "developers.cta.buttonLabel": {
-    "message": "Play the game"
+    "message": "Jugar"
   },
   "discoverCardano.hero.title": {
-    "message": "Discover Cardano"
+    "message": "Descubra Cardano"
   },
   "discoverCardano.hero.description": {
-    "message": "Cardano is the nexus of five principles: People, purpose, technology, research, and opportunity. Explore and learn this new constellation of knowledge."
+    "message": "Cardano es el nexo de cinco principios: Personas, propósito, tecnología, investigación y oportunidad."
   },
   "discoverCardano.meta.title": {
-    "message": "What Is Cardano, Blockchain Built for Sustainability"
+    "message": "Qué es Cardano, Blockchain construido para la Sostenibilidad"
   },
   "discoverCardano.meta.description": {
-    "message": "Discover what makes Cardano different. Built on peer-reviewed science, powered by a global community, and designed for a sustainable, decentralized future."
+    "message": "Descubra lo que hace que Cardano sea diferente. Construido en ciencia revisada por pares, impulsada por una comunidad global y diseñada para un futuro sostenible y descentralizado."
   },
   "discoverCardano.people.title": {
-    "message": "People"
+    "message": "Personas"
   },
   "discoverCardano.people.subtitle": {
-    "message": "Working together, we achieve more for the many."
+    "message": "Trabajando juntos, conseguimos más para muchos."
   },
   "discoverCardano.people.text1": {
-    "message": "Cardano is built by a decentralized community of scientists, engineers, and thought leaders united in a common purpose: to create a technology platform that will ignite the positive change the world needs. We believe the future should not be defined by the past, and that more is possible - and, through technology, can be made possible for all. We measure the worth of a task not by its challenge, but by its results."
+    "message": "Cardano es construido por una comunidad descentralizada de científicos, ingenieros y líderes de pensamiento unidos en un propósito común: crear una plataforma tecnológica que genere el cambio positivo que el mundo necesita. Creemos que el futuro no debe ser definido por el pasado, y que más es posible. A través de la tecnología, puede hacerse posible para todos. Medimos el valor de una tarea no por su reto, sino por sus resultados."
   },
   "discoverCardano.people.text2": {
-    "message": "Every ada holder also holds a stake in the Cardano network. Ada stored in a wallet can be delegated to a stake pool to earn rewards – to participate in the successful running of the network – or pledged to a stake pool to increase the pool's likelihood of receiving rewards. In time, ada will also be usable for a variety of applications and services on the Cardano platform."
+    "message": "Cada titular de ada también tiene una participación en la red de Cardano. El ada almacenado en una cartera puede ser delegado a un \"stake pool\" para ganar recompensas y participar en el seguro funcionamiento de la red o crear y operar su propio \"stake pool\". Con el tiempo, ada también será utilizable para una variedad de aplicaciones y servicios en la plataforma Cardano."
   },
   "discoverCardano.purpose.title": {
-    "message": "Purpose"
+    "message": "Propósito"
   },
   "discoverCardano.purpose.subtitle": {
-    "message": "A platform built for a sustainable future, to help people work better together, trust one another, and build global solutions to global problems."
+    "message": "Una plataforma construida para un futuro sustentable, para ayudar a la gente a trabajar mejor junta, confiar unos en otros y construir soluciones globales a los problemas globales."
   },
   "discoverCardano.purpose.text1": {
-    "message": "Cardano is a fork in the road. It takes us from where we've been to where we're destined to go: a global society that is secure, transparent, and fair, and which serves the many as well as the few. Like the technological revolutions that have come before, it offers a new template for how we work, interact, and create, as individuals, businesses, and societies."
+    "message": "Cardano es una bifurcación en el camino. Nos lleva desde donde hemos estado hacia el lugar al que estamos destinados a ir: una sociedad global segura, transparente y justa, que sirve tanto a las mayorías como a los pocos. Al igual que las revoluciones tecnológicas del pasado, ofrece un nuevo modelo para nuestra forma de trabajar, interactuar y crear, como individuos, empresas y sociedades."
   },
   "discoverCardano.purpose.text2": {
-    "message": "Cardano began with a vision of a world without intermediaries, in which power is not controlled by an accountable few, but by the empowered many. In this world, individuals have control over their data and how they interact and transact. Businesses have the opportunity to grow independent of monopolistic and bureaucratic power structures. Societies are able to pursue true democracy: self-governing, fair, and accountable. It is a world made possible by Cardano."
+    "message": "Cardano comenzó con una visión de un mundo sin intermediarios, en el que el poder no está controlado por unos pocos responsables, sino por muchos. En este mundo, los individuos tienen control sobre sus datos y cómo interactúan y transaccionan. Las empresas tienen la oportunidad de crecer independientemente de las estructuras de poder monopólicas y burocráticas. La sociedad es capaz de perseguir la verdadera misión: autosuficiencia, justa y responsable, un mundo hecho posible por Cardano."
   },
   "discoverCardano.technology.title": {
-    "message": "Technology"
+    "message": "Tecnología"
   },
   "discoverCardano.technology.subtitle": {
-    "message": "Cardano brings a new standard in technology - open and inclusive – to challenge the old and activate a new age of sustainable, globally-distributed innovation."
+    "message": "Cardano aporta un nuevo estándar en tecnología, abierta e inclusiva, para desafiar a los viejos patrones y activar una nueva era de innovación sostenible y distribuida a nivel global."
   },
   "discoverCardano.technology.text1": {
-    "message": "From the incremental to global, Cardano improves how we interact, transact, and create - and ultimately operate as a global society."
+    "message": "Desde lo local hasta el global, Cardano mejora la forma en que interactuamos, comerciamos y creamos. En última instancia Cardano opera como una sociedad global."
   },
   "discoverCardano.technology.text2": {
-    "message": "Cardano is a blockchain platform built on the groundbreaking Ouroboros proof-of-stake consensus protocol, and developed using the Haskell programming language: a functional programming language that enables Cardano to pursue evidence-based development, for unparalleled security and stability."
+    "message": "Cardano es una plataforma blockchain construida sobre el innovador protocolo de consenso de prueba Ouroboros y desarrollado utilizando el lenguaje de programación Haskell: un lenguaje de programación funcional que permite a Cardano perseguir el desarrollo basado en la evidencia para una seguridad y estabilidad sin precedentes."
   },
   "discoverCardano.technology.text3": {
-    "message": "Our technology is underpinned by [research](/research). We have redefined what it means to create a global software platform through scientific methods. We have not compromised on our belief, or in our approach. To build a better future - secure, sustainable, and governable by the many - we have taken the road less traveled. The result of our efforts is a blockchain platform unparalleled in its capability and performance, and which is truly able to support global applications, systems, and real-life business use cases."
+    "message": "Nuestra tecnología está respaldada por [research](/research). Hemos redefinido lo que significa crear una plataforma global de software a través de métodos científicos. No nos hemos comprometido en nuestra creencia ni en nuestro enfoque. Para construir un futuro mejor, seguro, sostenible y gobernable por muchos, hemos tomado el camino difícil. El resultado de nuestros esfuerzos es una plataforma blockchain incomparable en su capacidad y rendimiento,  que es capaz de soportar aplicaciones globales, sistemas y casos de uso de negocios en la vida real."
   },
   "discoverCardano.research.title": {
-    "message": "Research"
+    "message": "Investigación"
   },
   "discoverCardano.research.subtitle": {
-    "message": "Pioneering tech begins with groundbreaking research."
+    "message": "La tecnología pionera comienza con una investigación innovadora."
   },
   "discoverCardano.research.text1": {
-    "message": "Cardano began with and has grown through [research](/research). Before any technology we integrate is developed, it is specified. And before it is specified, it is researched. That [research](/research) is peer-reviewed - a unique achievement for a blockchain platform - so that our ideas may be challenged before they are validated."
+    "message": "Cardano comenzó con y ha crecido a través de [research](/research). Antes de que se desarrolle cualquier tecnología, se especifica y antes de que se especifique, se investiga. Esa [research](/research) es revisada por pares, un logro único para una plataforma blockchain, para que nuestras ideas puedan ser desafiadas antes de ser validadas."
   },
   "discoverCardano.research.text2": {
-    "message": "[Our research](/research) - led by leading academics - explores philosophy, sociology, behavior, and game theory. To achieve each outcome, we consider the minutiae of possibilities: the variables that often go unconsidered, but which may ultimately impact the integrity and sustainability of a global, decentralized platform. We take nothing for granted."
+    "message": "[Nuestra investigación](/research) - dirigida por líderes académicos, explora la filosofía, la sociología, el comportamiento y la teoría del juego. Para lograr cada resultado, analizamos las posibilidades hasta el más mínimo detalle: las variables que a menudo pasan desapercibidas, pero que puede afectar en última instancia a la integridad y sostenibilidad de una plataforma global y descentralizada. No damos nada por sentado."
   },
   "discoverCardano.opportunity.title": {
-    "message": "Opportunity"
+    "message": "Oportunidad"
   },
   "discoverCardano.opportunity.subtitle": {
-    "message": "The staging point for every new opportunity. Empower your business through Cardano, and discover the future of technology."
+    "message": "El punto de partida para cada nueva oportunidad. Potencie su negocio a través de Cardano y descubra el futuro de la tecnología."
   },
   "discoverCardano.opportunity.text1": {
-    "message": "Cardano provides the template and toolset to a new age of innovation. It introduces leading-edge technologies, models, and methodologies to help individuals, developers, and enterprises discover a new possible, realize change, and enrich their lives.."
+    "message": "Cardano proporciona las herramientas para una nueva era de innovación. Introduce tecnologías, modelos y metodologías para ayudar a las personas, desarrolladores y empresas a descubrir un nuevo posible, realizar cambios y enriquecer vidas."
   },
   "discoverCardano.opportunity.text2": {
-    "message": "Blockchain technology holds the answer to a number of legacy challenges, whether financial, societal, or technological. It disintermediates essential relationships, and redistributes power to alleviate costly dependencies, restrictive paradigms, and inefficient systems of transaction and exchange. Cardano is a realization of this potential. It is a platform with the security, privacy sustainability, and performance standards required to accelerate the mass adoption of the technology, and support a lasting ecosystem."
+    "message": "La tecnología blockchain ofrece la solución a una serie de retos tradicionales, ya sean financieros, sociales o tecnológicos. Elimina la intermediación en relaciones fundamentales y redistribuye el poder para mitigar las costosas dependencias, los paradigmas restrictivos y los sistemas ineficientes de transacción e intercambio. Cardano es una materialización de este potencial. Se trata de una plataforma que cumple con los estándares de seguridad, privacidad, sostenibilidad y rendimiento necesarios para acelerar la adopción masiva de la tecnología y sustentar un ecosistema duradero."
   },
   "discoverCardano.opportunity.text3": {
-    "message": "Cardano powers new, more secure, and globally scalable solutions. Its technology is continuously improved upon through evidence-based development methods, and guided by a democratic voting system, in which every member has a voice. The opportunity of Cardano is adaptable to your use case. It is an opportunity that creates other opportunities, continuously."
+    "message": "Cardano impulsa soluciones nuevas, más seguras y escalables a nivel mundial. Su tecnología se mejora continuamente mediante métodos de desarrollo basados en la evidencia y se rige por un sistema de votación democrático, en el que todos los miembros tienen voz. Las posibilidades que ofrece Cardano se adaptan a tus necesidades. Es una oportunidad que gcrea otras oportunidades, continuamente."
   },
   "entities.hero.title": {
-    "message": "Entities building on Cardano"
+    "message": "Empresas construyendo en Cardano"
   },
   "entities.hero.description": {
-    "message": "Numerous independent entities, including companies actively building on Cardano, collaborate to advance the platform and ensure it remains aligned with its mission."
+    "message": "Numerosas entidades independientes, incluidas las empresas que trabajan activamente en Cardano, colaboran para avanzar en la plataforma y asegurar que permanezca alineada con su misión."
   },
   "entities.meta.title": {
-    "message": "Organizations Building on Cardano"
+    "message": "Organizaciones construyendo en Cardano"
   },
   "entities.meta.description": {
-    "message": "Numerous independent entities, including companies actively building on Cardano, collaborate to advance the platform and ensure it remains aligned with its mission."
+    "message": "Numerosas entidades independientes, incluidas las empresas que trabajan activamente en Cardano, colaboran para avanzar en la plataforma y asegurar que permanezca alineada con su misión."
   },
   "entities.entitiesSection.divider": {
-    "message": "Entities advancing Cardano"
+    "message": "Entidades que avanzan Cardano"
   },
   "entities.companiesSection.divider": {
-    "message": "Companies, associations, and collaborations building on Cardano"
+    "message": "Empresas, asociaciones, y colaboraciones construyendo en Cardano"
   },
   "entities.companiesSection.description": {
-    "message": "There is a growing number of entities that build on Cardano. Below are a few of them:"
+    "message": "Cada vez son más las entidades que desarrollan proyectos basados en Cardano. A continuación se enumeran algunas de ellas:"
   },
   "entities.companiesSection.addCompanyLink": {
-    "message": "add your company"
+    "message": "añadir tu empresa"
   },
   "events.hero.title": {
-    "message": "Cardano Events"
+    "message": "Eventos de Cardano"
   },
   "events.hero.description": {
-    "message": "Upcoming Cardano events in one place, so you never miss a chance to connect, learn, and grow with the Cardano Community."
+    "message": "Los próximos eventos de Cardano, en un mismo lugar, para que nunca te pierdas la oportunidad de conectar, aprender y crecer con la comunidad de Cardano."
   },
   "events.pagination.previous": {
-    "message": "Previous"
+    "message": "Anterior"
   },
   "events.pagination.next": {
-    "message": "Next"
+    "message": "Siguiente"
   },
   "events.meta.title": {
-    "message": "Cardano Events, Conferences and Meetups"
+    "message": "Eventos de Cardano, Conferencias y Reuniones"
   },
   "events.meta.description": {
-    "message": "Upcoming Cardano events in one place, so you never miss a chance to connect, learn, and grow with the Cardano Community."
+    "message": "Los próximos eventos de Cardano, en un mismo lugar, para que nunca te pierdas la oportunidad de conectar, aprender y crecer con la comunidad de Cardano."
   },
   "events.divider.discoverWorldwide": {
-    "message": "Discover Cardano Events Worldwide"
+    "message": "Descubre eventos de Cardano en todo el mundo"
   },
   "events.platforms.luma": {
-    "message": "Events on Luma.com"
+    "message": "Eventos en Luma.com"
   },
   "events.platforms.meetup": {
-    "message": "Events on Meetup.com"
+    "message": "Eventos en Meetup.com"
   },
   "events.divider.upcomingHighlighted": {
-    "message": "Upcoming highlighted Events"
+    "message": "Próximos eventos destacados"
   },
   "events.divider.pastHighlighted": {
-    "message": "Past Highlighted Events"
+    "message": "Eventos Destacados Pasados"
   },
   "events.recapAvailable": {
-    "message": "Recap available:"
+    "message": "Resumen disponible:"
   },
   "events.watchHere": {
-    "message": "Watch here"
+    "message": "Ver aquí"
   },
   "exchanges.hero.title": {
-    "message": "Integrate Cardano"
+    "message": "Integra Cardano"
   },
   "exchanges.hero.description": {
-    "message": "Easy integration with Cardano. All of the upgrades. None of the maintenance."
+    "message": "Fácil integración con Cardano. Todas las mejoras. Nada de mantenimiento."
   },
   "exchanges.layout.title": {
-    "message": "Integrate Cardano, Exchange and Wallet Partnerships"
+    "message": "Integrar asociaciones con Cardano, plataformas de intercambio y monederos electrónicos"
   },
   "exchanges.layout.description": {
-    "message": "Integrate Cardano into your exchange, wallet, or payment platform. Access documentation, resources, and partnership opportunities for ada support."
+    "message": "Integra Cardano en tu plataforma de intercambio, billetera o plataforma de pago. Accede a la documentación, los recursos y las oportunidades de colaboración para la compatibilidad con ada."
   },
   "exchanges.intro.description": {
-    "message": "There are various [ways to integrate Cardano](https://developers.cardano.org), one of which is Adrestia. The Adrestia team focuses on supporting exchange and developer integrations by providing a wallet SDK and set of APIs that make it easier for developers and exchanges to integrate and interact with Cardano across releases."
+    "message": "Existen varias [formas de integrar Cardano](https://developers.cardano.org), una de las cuales es Adrestia. El equipo de Adrestia se centra en facilitar las integraciones de las plataformas de intercambio y los desarrolladores, proporcionando un SDK para carteras y un conjunto de API que facilitan a los desarrolladores y a las plataformas de intercambio la integración y la interacción con Cardano en todas las versiones."
   },
   "exchanges.whyAdrestia.divider": {
-    "message": "Why Adrestia?"
+    "message": "¿Por qué Adrestia?"
   },
   "exchanges.whyAdrestia.leftText": {
-    "message": "Blockchains - and especially Cardano - are fast developing. Staying up to date with releases can become a maintenance challenge. We're committed to making it as easy as possible to develop and integrate with Cardano. Through Adrestia, Cardano is adaptable to your systems and requirements."
+    "message": "Las cadenas de bloques y en especial, Cardano, están evolucionando rápidamente. Mantenerse al día de las nuevas versiones puede suponer un reto en cuanto al mantenimiento. Nos comprometemos a facilitar al máximo el desarrollo y la integración con Cardano. Gracias a Adrestia, Cardano se adapta a tus sistemas y necesidades."
   },
   "exchanges.whyAdrestia.rightText": {
-    "message": "Improvements to Cardano should not mean greater complexity or resource overhead. We want to innovate and deploy improvements as they're available, and as they become necessary. This might mean a few updates one month, and many the next. Adrestia is a consistent SDK and set of GraphQL APIs that make it easy for developers to create applications and maintain core compatibility and functionality with the Cardano network across releases."
+    "message": "Las mejoras en Cardano no deberían significar una mayor complejidad o sobrecarga de recursos. Queremos innovar y desplegar mejoras a medida que estén disponibles, y a medida que sean necesarias. Esto podría significar algunas actualizaciones un mes, y muchas el siguiente. Adrestia es un SDK consistente y un conjunto de APIs GraphQL que facilitan a los desarrolladores la creación de aplicaciones y el mantenimiento de la compatibilidad y funcionalidad de núcleo con la red Cardano a través de lanzamientos."
   },
   "exchanges.cta1.title": {
-    "message": "Focus On What Matters. Leave The Rest To Us."
+    "message": "Concéntrate en lo que importa. Déjanos el resto a nosotros."
   },
   "exchanges.cta1.buttonLabel": {
-    "message": "Access Adrestia"
+    "message": "Acceso a Adrestia"
   },
   "exchanges.accessAdrestia.divider": {
-    "message": "Access Adrestia"
+    "message": "Acceso a Adrestia"
   },
   "exchanges.whatMakesDifferent.title": {
-    "message": "What makes Adrestia different?"
+    "message": "¿Qué hace que Adrestia sea diferente?"
   },
   "exchanges.whatMakesDifferent.description1": {
-    "message": "Cardano's architecture is built for modularity and adaptability. Through Adrestia, we're able to save developers and exchanges significant maintenance overhead and, most importantly, time."
+    "message": "La arquitectura de Cardano está construida para modularidad y adaptabilidad. A través de Adrestia, podemos ahorrar desarrolladores e intercambios significativos de mantenimiento y, lo que es más importante, tiempo."
   },
   "exchanges.whatMakesDifferent.description2": {
-    "message": "Unlike most blockchain API suites, Adrestia decouples and splits out key services from the core Cardano node. The new SDK and APIs are consistent across releases, which means developers are not required to re-learn the platform with each release. Adrestia offers a host of self-contained services and ways to query, transact, and extract information."
+    "message": "A diferencia de la mayoría de las suites API de blockchain, Adrestia desconecta y divide los servicios clave del núcleo del nodo Cardano. El nuevo SDK y las APIs son consistentes a través de lanzamientos, lo que significa que los desarrolladores no están obligados a volver a aprender la plataforma con cada lanzamiento. Adrestia ofrece un gran número de servicios autónomos y formas de consultar, transaccionar y extraer información."
   },
   "exchanges.benefits.reduceTime.title": {
-    "message": "Reduce Time To Market"
+    "message": "Acelerar el tiempo de comercialización"
   },
   "exchanges.benefits.reduceTime.text": {
-    "message": "Develop applications for Cardano without worrying about new releases breaking your code."
+    "message": "Desarrollar aplicaciones para Cardano sin preocuparse por nuevas versiones que rompan tu código."
   },
   "exchanges.benefits.reduceDowntime.title": {
-    "message": "Reduce Downtime"
+    "message": "Reducir el tiempo de inactividad"
   },
   "exchanges.benefits.reduceDowntime.text": {
-    "message": "Fewer backward compatibility issues mean significantly reduced downtime."
+    "message": "Menos cuestiones de compatibilidad hacia atrás significan una reducción significativa del tiempo de inactividad."
   },
   "exchanges.benefits.reduceMaintenance.title": {
-    "message": "Reduce Maintenance Costs"
+    "message": "Reduce los costos de mantenimiento"
   },
   "exchanges.benefits.reduceMaintenance.text": {
-    "message": "Spend less time and resources on maintaining application compatibility across releases."
+    "message": "Emplea menos tiempo y recursos en mantener la compatibilidad de aplicaciones a través de los lanzamientos."
   },
   "exchanges.benefits.increaseProductivity.title": {
-    "message": "Increase Productivity"
+    "message": "Aumenta la productividad"
   },
   "exchanges.benefits.increaseProductivity.text": {
-    "message": "Focus on what matters - application and wallet development - and leave the updates to us."
+    "message": "Concéntrese en lo que importa, desarrollo de aplicaciones y billeteras y déjenos las actualizaciones a nosotros."
   },
   "exchanges.cta2.title": {
-    "message": "Discover how components work and interact with the Cardano core node, and choose the right component to suit your requirements."
+    "message": "Descubra cómo funcionan los componentes e interactúan con el nodo núcleo Cardano y elija el componente adecuado para sus necesidades."
   },
   "exchanges.cta2.buttonLabel": {
-    "message": "Learn the Core Node Architecture"
+    "message": "Aprende la Arquitectura del Nodo de Cardano"
   },
   "exchanges.learnArchitecture.divider": {
-    "message": "Learn the Core Node Architecture"
+    "message": "Aprende la Arquitectura del Nodo de Cardano"
   },
   "exchanges.howDoesItWork.title": {
-    "message": "How Does It Work?"
+    "message": "¿Cómo funciona?"
   },
   "exchanges.howDoesItWork.description": {
-    "message": "Cardano introduces an additional layer between users and developers and the core node. Within this layer, our code node team tracks and manages complex changes, potential issues, and hard forks that arise from protocol improvements. We implement necessary updates across Adrestia libraries and APIs, and take care of the maintenance so you don't have to."
+    "message": "Cardano introduce una capa adicional entre usuarios y desarrolladores y el nodo principal. Dentro de esta capa, nuestro equipo de nodos de código rastrea y administra cambios complejos, problemas potenciales y bifurcaciones duras que surgen de mejoras de protocolo. Implementamos las actualizaciones necesarias a través de las bibliotecas de Adrestia y APIs, y nos encargamos del mantenimiento para que no tengas que hacerlo."
   },
   "exchanges.ctaTwoColumn.leftTitle": {
-    "message": "Adrestia User Guide"
+    "message": "Guía de usuario de Adrestia"
   },
   "exchanges.ctaTwoColumn.leftText": {
-    "message": "Find out more about Adrestia and what it could mean for you. Our user guide is a handy, straight-forward resource to help you determine which actions to take and when."
+    "message": "Averigua más sobre Adrestia y lo que podría significar para ti. Nuestra guía de usuario es un recurso práctico y directo para ayudarle a determinar qué acciones tomar y cuándo."
   },
   "exchanges.ctaTwoColumn.leftButtonLabel": {
-    "message": "Access Adrestia"
+    "message": "Dirección de Adrestia"
   },
   "exchanges.ctaTwoColumn.rightTitle": {
-    "message": "Adrestia Component Overview & Flow Chart Guide"
+    "message": "Guía de Gráficos de Flujo y Resumen de Componentes Adrestia"
   },
   "exchanges.ctaTwoColumn.rightText": {
-    "message": "Discover our new, self-contained set of libraries and APIs to decide which is right for you."
+    "message": "Descubra nuestro nuevo conjunto de bibliotecas autónomo y APIs independientes para decidir que es el adecuado para usted."
   },
   "exchanges.ctaTwoColumn.rightButtonLabel": {
-    "message": "Find out more"
+    "message": "Descubre más"
   },
   "genesis.hero.title": {
-    "message": "Genesis"
+    "message": "Génesis"
   },
   "genesis.hero.description": {
-    "message": "Distribution of ada token vouchers, which are part of the Cardano settlement layer, took place in Asia in four stages between October 2015 and the start of January 2017."
+    "message": "La distribución del token de ada, que son parte de la capa de asentamiento de Cardano, tuvo lugar en Asia en cuatro etapas, entre octubre de 2015 y principios de enero de 2017."
   },
   "genesis.layout.title": {
-    "message": "Cardano Genesis Distribution, Initial ada Allocation"
+    "message": "Distribución Génesis Cardano, Asignación Inicial de Ada"
   },
   "genesis.layout.description": {
-    "message": "Distribution of ada token vouchers, which are part of the Cardano settlement layer, took place in Asia in four stages between October 2015 and the start of January 2017."
+    "message": "La distribución del token de ada, que son parte de la capa de asentamiento de Cardano, tuvo lugar en Asia en cuatro etapas, entre octubre de 2015 y principios de enero de 2017."
   },
   "genesis.divider.distribution": {
-    "message": "Genesis Distribution"
+    "message": "Distribución Génesis"
   },
   "genesis.distribution.title": {
-    "message": "Distribution"
+    "message": "Distribución"
   },
   "genesis.distribution.paragraph1": {
-    "message": "The initial distribution of ada, essentially a pre-launch sales event, was the first in the cryptocurrency industry to set Know Your Customer guidelines, and an audit was performed on the distribution process. Information and statistics about the voucher distribution are detailed below in the Ada Voucher Distribution Stats section."
+    "message": "La distribución inicial de ada, esencialmente un evento de ventas previas al lanzamiento, fue la primera en la industria de criptomonedas en establecer las pautas para conocer sus clientes y se realizó una auditoría en el proceso de distribución. Información y estadísticas sobre la distribución de cupones se detallan a continuación en la sección Estadísticas de distribución de cupones de Ada."
   },
   "genesis.distribution.paragraph2": {
-    "message": "In addition to these ada, the Genesis Block Distribution includes an amount equal to 20% of the ada vouchers sold during the Sale period, or **5,185,414,108 ada**. These have been generated and distributed to three groups of entities of the Cardano ecosystem that are part of the Technical and Business Development Pool; IOHK, EMURGO, and the Cardano Foundation, as follows:"
+    "message": "Además de esto, la Distribución por Bloques Génesis incluye una cantidad equivalente al 20% de los cupones de ada vendidos durante el período de venta. o **5,185,414,108 ada**. Estos han sido generados y distribuidos a tres grupos de entidades del ecosistema Cardano que forman parte del Grupo de Desarrollo Técnico y Empresarial; IOHK, EMURGO y la Fundación Cardano, de la siguiente manera:"
   },
   "genesis.distribution.cardanoFoundation": {
-    "message": "The Cardano Foundation, Switzerland: **648,176,761 ada**"
+    "message": "La Fundación Cardano, Suiza: **648,176,761 ada**"
   },
   "genesis.distribution.emurgo": {
     "message": "EMURGO: **2,074,165,644 ada**"
@@ -2369,70 +2369,70 @@
     "message": "IOHK: **2,463,071,701 ada**"
   },
   "genesis.distribution.totalAmount": {
-    "message": "The public sales distribution accounts for **25,927,070,538 ada**. The total amount of ada available at launch was therefore equal to **31,112,484,646 ada**."
+    "message": "La distribución de ventas públicas representa **25,927,070,538 ada**. La cantidad total de ada disponible en el lanzamiento fue por lo tanto igual a **31,112,484,646 ada**."
   },
   "genesis.distribution.supplyTracking": {
-    "message": "Since the Genesis Block, and especially since the Shelley phase with staking rewards, Cardano token distribution and supply have been continuously expanding. This can be tracked epoch by epoch on the [Supply Insight page](/insights/supply)."
+    "message": "Desde el Bloque Génesis y especialmente desde la fase de Shelley con recompensas acumuladas, la distribución y el suministro de tokens de Cardano se han ido expandiendo continuamente. Esto se puede rastrear época a época en la [Página de Información de Suministros](/insights/supply)."
   },
   "genesis.divider.proceeds": {
-    "message": "Genesis Proceeds"
+    "message": "Procedimientos Génesis"
   },
   "genesis.proceeds.title": {
-    "message": "Proceeds"
+    "message": "Procedimientos"
   },
   "genesis.proceeds.paragraph1": {
-    "message": "The ada vouchers were sold by a Japanese corporation and its sales force in Japan with total gross sales of 108,844.5 BTC. Further information on the sale can be found here."
+    "message": "Los vouchers de ada fueron vendidos por una corporación japonesa y su fuerza de venta en Japón con ventas brutas totales de 108.844.5 BTC Aquí encontrará más información sobre la venta."
   },
   "genesis.proceeds.paragraph2": {
-    "message": "A part of the total sales proceeds were donated to the Cardano Foundation as follows:"
+    "message": "Una parte de los ingresos totales de ventas fueron donados a la Fundación Cardano de la siguiente manera:"
   },
   "genesis.proceeds.isleOfMan": {
-    "message": "Cardano Foundation, Isle of Man (predecessor): **1,090.00 BTC**"
+    "message": "Fundación Cardano, Isla de Man (predecesor): **1,090,00 BTC**"
   },
   "genesis.proceeds.switzerland": {
-    "message": "Cardano Foundation, Switzerland: **7,168.00 BTC**"
+    "message": "Fundación Cardano, Suiza: **7,168.00 BTC**"
   },
   "governance.hero.title": {
-    "message": "Governance on Cardano"
+    "message": "Gobernanza en Cardano"
   },
   "governance.hero.description": {
-    "message": "Cardano runs on a secure, decentralized system where ada holders shape the platform's development and influence the ecosystem's direction."
+    "message": "Cardano funciona en un sistema seguro y descentralizado en el que los poseedores de ada conforman el desarrollo de la plataforma e influyen en la dirección del ecosistema."
   },
   "governance.meta.title": {
-    "message": "Cardano Governance, Community-Driven Decision Making"
+    "message": "Gobernanza de Cardano, Toma de Decisiones Comunitarias"
   },
   "governance.meta.description": {
-    "message": "Cardano governance gives every ada holder a voice. Delegate to a DRep, vote on proposals, or register as a delegate representative to shape the network."
+    "message": "El gobierno de Cardano da una voz a cada titular de ada; Delega a un DRep, vota propuestas o regístrate como representante delegado para dar forma a la red."
   },
   "governance.divider.withinCardano": {
-    "message": "Governance Within Cardano"
+    "message": "Gobernanza en Cardano"
   },
   "governance.withinCardano.text1": {
-    "message": "Cardano is defined by its community. Its governance model shows that true democracy - in which individuals are incentivized to play a role and votes are immutably recorded - is possible. It is a way for token holders to decide the future of a platform, and for the community to dictate the use of Cardano's treasury funds."
+    "message": "Cardano está definido por su comunidad. Su modelo de gobierno muestra que es posible una verdadera democracia en la que los individuos están incentivados para desempeñar un papel y los votos son inmutablemente registrados. Es una forma de que los poseedores de tokens decidan el futuro de una plataforma y para que la comunidad dicte el uso de los fondos de tesorería de Cardano."
   },
   "governance.withinCardano.text2": {
-    "message": "This model and the pioneering technology that underpins it can be applied to any application, system, or even society. It is a blueprint for change that is decided by the many, as well as the few, and which will redistribute power, eliminating intermediaries, to improve the lives of all."
+    "message": "Este modelo y la tecnología que lo sustenta pueden aplicarse a cualquier aplicación, sistema o incluso sociedad. Es una oportunidad para el cambio en la que deciden muchos y que redistribuirá el poder, eliminando intermediarios, para mejorar las vidas de todos."
   },
   "governance.withinCardano.quote": {
-    "message": "Change begins with one voice. But is realized through the Combination of many."
+    "message": "El cambio comienza con una sola voz, pero se realiza a través de la acción de muchos."
   },
   "governance.withinCardano.buttonText": {
-    "message": "Stay up to date"
+    "message": "Mantente informado"
   },
   "governance.divider.delegateVoting": {
-    "message": "Delegate your voting power"
+    "message": "Delegar tu poder de voto"
   },
   "governance.delegateVoting.text": {
-    "message": "Delegation is the act of lending your voting power—equal to the ada balance in your wallet—to a Delegate Representative (DRep), who votes on your behalf like a parliamentary representative. Alternatively, you can use automatic voting options to abstain or signal \"No Confidence\" in all proposals."
+    "message": "La delegación es el acto de prestar su poder de voto, igual al saldo de ada de su cartera, a un Representante Delegado (DRep), quién vota en su nombre como un representante parlamentario. Alternativamente, puede utilizar las opciones de votación automática para abstenerse o indicar \"Sin Confianza\" en todas las propuestas."
   },
   "governance.delegateVoting.buttonText": {
-    "message": "Find a DRep"
+    "message": "Encontrar un DRep"
   },
   "governance.divider.becomeDRep": {
-    "message": "Become a DRep on Cardano"
+    "message": "Conviértete en DRep en Cardano"
   },
   "governance.becomeDRep.text1": {
-    "message": "DReps are key participants in governing the Cardano network. They actively engage in governance and represent other Cardano members. DReps must stay informed on governance actions to make wise decisions."
+    "message": "Los DReps son participantes clave en el gobierno de la red de Cardano, participan activamente en el gobierno y representan a otros miembros del Cardano. Los DReps deben mantenerse informados sobre las acciones de gobierno para tomar decisiones sabias."
   },
   "governance.becomeDRep.text2": {
     "message": "If you have the time and commitment to contribute to Cardano's governance, register as a DRep. A refundable deposit of 500 ada is required and will be returned upon retirement."
@@ -2522,7 +2522,7 @@
     "message": "Timeline"
   },
   "hardforks.loading": {
-    "message": "Loading..."
+    "message": "Cargando..."
   },
   "hardforks.divider.transactionIds": {
     "message": "hard fork transaction ids"
@@ -2531,7 +2531,7 @@
     "message": "Note that some hard forks, particularly Byron and Shelley, transitioned through a series of updates and may not have a single specific transaction id associated with them. For the others, the provided transaction ids correspond to significant parameter updates leading to the hard forks."
   },
   "learn.hero.title": {
-    "message": "Learn"
+    "message": "Aprender"
   },
   "learn.hero.description": {
     "message": "Empowering the digital architects of the future."
@@ -2639,13 +2639,13 @@
     "message": "Ouroboros solves the greatest challenge faced by existing blockchains: the need for more and more energy to achieve consensus. Using Ouroboros, Cardano is able to securely, sustainably, and ethically scale, with up to [four million times the energy efficiency of bitcoin](https://iohk.io/en/blog/posts/2020/03/23/from-classic-to-hydra-the-implementations-of-ouroboros-explained/)."
   },
   "ouroboros.cta.title": {
-    "message": "Attack the protocol, fork the blockchain - or not. Explore the Ouroboros protocol firsthand in this interactive simulation."
+    "message": "Ataca el protocolo, bifurca la blockchain, o no. Explora el protocolo Ouroboros de primera mano en esta simulación interactiva."
   },
   "ouroboros.cta.buttonLabel": {
-    "message": "Play the game"
+    "message": "Jugar"
   },
   "research.hero.title": {
-    "message": "Research"
+    "message": "Investigación"
   },
   "research.hero.description": {
     "message": "Cardano relevant research papers and specifications."
@@ -2720,7 +2720,7 @@
     "message": "Available Topics"
   },
   "solutions.hero.title": {
-    "message": "Enterprise Solutions"
+    "message": "Soluciones para empresas"
   },
   "solutions.hero.description": {
     "message": "Proven blockchain solutions for supply chain, identity, and beyond."
@@ -2747,7 +2747,7 @@
     "message": "Ready to build on Cardano? Connect with the Cardano Foundation to explore partnership opportunities."
   },
   "solutions.cta.button": {
-    "message": "Contact Us"
+    "message": "Contáctenos"
   },
   "delegation.faq.q1": {
     "message": "What is a stake pool?"
@@ -2984,7 +2984,7 @@
     "message": "Try Out"
   },
   "useCases.hero.title": {
-    "message": "Use Cases"
+    "message": "Casos de Uso"
   },
   "useCases.hero.description": {
     "message": "How Cardano blockchain solves real-world problems across industries."
@@ -2999,7 +2999,7 @@
     "message": "Explore blockchain applications across industries. From identity verification to supply chain tracking, Cardano provides secure, scalable solutions for real-world challenges."
   },
   "useCases.divider.enterprise": {
-    "message": "Enterprise Solutions"
+    "message": "Soluciones para empresas"
   },
   "useCases.enterprise.description": {
     "message": "Looking for proven enterprise deployments? Explore case studies and real-world implementations by the Cardano Foundation and partners."
@@ -3122,7 +3122,7 @@
     "message": "Vote"
   },
   "apps.intent.build": {
-    "message": "Build"
+    "message": "Construye"
   },
   "apps.intent.mintNfts": {
     "message": "Mint NFTs"
@@ -3245,10 +3245,10 @@
     "message": "The newest apps in the showcase"
   },
   "apps.carousel.prev": {
-    "message": "Previous"
+    "message": "Anterior"
   },
   "apps.carousel.next": {
-    "message": "Next"
+    "message": "Siguiente"
   },
   "apps.mostActive.leaderboardLink": {
     "message": "Live from the transaction leaderboard"
@@ -3281,7 +3281,7 @@
     "message": "Have a say in Cardano"
   },
   "apps.guidedPaths.developers": {
-    "message": "Build on Cardano"
+    "message": "Construye sobre Cardano"
   },
   "apps.submit.enableTracking": {
     "message": "Enable tracking"
@@ -3317,7 +3317,7 @@
     "message": "Filter by topic"
   },
   "insights.filter.clear": {
-    "message": "Clear"
+    "message": "Borrar"
   },
   "insights.pagination.prevAriaLabel": {
     "message": "Previous page"
@@ -3332,7 +3332,7 @@
     "message": "Next page"
   },
   "insights.pagination.next": {
-    "message": "Next"
+    "message": "Siguiente"
   },
   "insights.noResults": {
     "message": "No insights matched your filters."
@@ -3691,6 +3691,9 @@
   "ambassadors.directory.socialAria.youtube": {
     "message": "YouTube channel"
   },
+  "ambassadors.directory.socialAria.github": {
+    "message": "GitHub profile"
+  },
   "ambassadors.stories.divider": {
     "message": "Impact Stories"
   },
@@ -3740,7 +3743,7 @@
     "message": "Open-source contributions that make Cardano easier to use for developers everywhere."
   },
   "enterprise.label.solutions": {
-    "message": "Solutions"
+    "message": "Soluciones"
   },
   "enterprise.label.products": {
     "message": "Products"
@@ -3977,7 +3980,7 @@
     "message": "You scored {score} out of {totalQuestions}"
   },
   "quiz.ui.tryAgain": {
-    "message": "Try again"
+    "message": "Inténtelo de nuevo"
   },
   "quiz.ui.correct": {
     "message": "Correct!"
@@ -4028,7 +4031,7 @@
     "message": "An era of optimization, improving the scalability and interoperability of the network. Enhancing the network performance, Basho will introduce sidechains, new blockchains, interoperable with the main Cardano chain, with immense potential to extend the network's capabilities."
   },
   "research.voltaire.subtitle": {
-    "message": "Governance"
+    "message": "Gobernanza"
   },
   "research.voltaire.description": {
     "message": "The development era is currently enabling the Cardano network to become a self-sustaining system. Voltaire is introducing a voting and treasury system that allows network participants to use their stake and voting rights to influence the future development of the blockchain."
@@ -4037,7 +4040,7 @@
     "message": "Learn more"
   },
   "solutions.section.title": {
-    "message": "Enterprise Solutions"
+    "message": "Soluciones para empresas"
   },
   "termExplainer.divider": {
     "message": "{category} Terms you should know"
@@ -4316,7 +4319,7 @@
     "message": "For internal links use:"
   },
   "insightsTemplate.content.internalLinkText": {
-    "message": "where to get ada?"
+    "message": "¿dónde obtener ada?"
   },
   "insightsTemplate.content.externalLinksLabel": {
     "message": "For external links use:"
@@ -4406,7 +4409,7 @@
     "message": "Last updated: {lastUpdated}. Charts are using real time data."
   },
   "apps.card.getStarted": {
-    "message": "Get Started"
+    "message": "Comenzar"
   },
   "apps.card.source": {
     "message": "Source"

--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -1,536 +1,536 @@
 {
   "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
-    "message": "Expand the dropdown",
+    "message": "ドロップダウンを展開",
     "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
   },
   "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
-    "message": "Collapse the dropdown",
+    "message": "ドロップダウンを折りたたむ",
     "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
   },
   "theme.docs.sidebar.expandButtonTitle": {
-    "message": "Expand sidebar",
+    "message": "サイドバーを開く",
     "description": "The ARIA label and title attribute for expand button of doc sidebar"
   },
   "theme.docs.sidebar.expandButtonAriaLabel": {
-    "message": "Expand sidebar",
+    "message": "サイドバーを開く",
     "description": "The ARIA label and title attribute for expand button of doc sidebar"
   },
   "theme.ErrorPageContent.title": {
-    "message": "This page crashed.",
+    "message": "エラーが発生しました",
     "description": "The title of the fallback page when the page crashed"
   },
   "theme.blog.archive.title": {
-    "message": "Archive",
+    "message": "アーカイブ",
     "description": "The page & hero title of the blog archive page"
   },
   "theme.blog.archive.description": {
-    "message": "Archive",
+    "message": "アーカイブ",
     "description": "The page & hero description of the blog archive page"
   },
   "theme.BackToTopButton.buttonAriaLabel": {
-    "message": "Scroll back to top",
+    "message": "先頭へ戻る",
     "description": "The ARIA label for the back to top button"
   },
   "theme.blog.paginator.navAriaLabel": {
-    "message": "Blog list page navigation",
+    "message": "ブログ記事一覧のナビゲーション",
     "description": "The ARIA label for the blog pagination"
   },
   "theme.blog.paginator.newerEntries": {
-    "message": "Newer entries",
+    "message": "新しい記事",
     "description": "The label used to navigate to the newer blog posts page (previous page)"
   },
   "theme.blog.paginator.olderEntries": {
-    "message": "Older entries",
+    "message": "過去の記事",
     "description": "The label used to navigate to the older blog posts page (next page)"
   },
   "theme.blog.post.paginator.navAriaLabel": {
-    "message": "Blog post page navigation",
+    "message": "ブログ記事のナビゲーション",
     "description": "The ARIA label for the blog posts pagination"
   },
   "theme.blog.post.paginator.newerPost": {
-    "message": "Newer post",
+    "message": "新しい記事",
     "description": "The blog post button label to navigate to the newer/previous post"
   },
   "theme.blog.post.paginator.olderPost": {
-    "message": "Older post",
+    "message": "過去の記事",
     "description": "The blog post button label to navigate to the older/next post"
   },
   "theme.tags.tagsPageLink": {
-    "message": "View all tags",
+    "message": "全てのタグを見る",
     "description": "The label of the link targeting the tag list page"
   },
   "theme.colorToggle.ariaLabel.mode.system": {
-    "message": "system mode",
+    "message": "システムモード",
     "description": "The name for the system color mode"
   },
   "theme.colorToggle.ariaLabel.mode.light": {
-    "message": "light mode",
+    "message": "ライトモード",
     "description": "The name for the light color mode"
   },
   "theme.colorToggle.ariaLabel.mode.dark": {
-    "message": "dark mode",
+    "message": "ダークモード",
     "description": "The name for the dark color mode"
   },
   "theme.colorToggle.ariaLabel": {
-    "message": "Switch between dark and light mode (currently {mode})",
+    "message": "ダークモードを切り替える(現在は{mode})",
     "description": "The ARIA label for the color mode toggle"
   },
   "theme.docs.breadcrumbs.navAriaLabel": {
-    "message": "Breadcrumbs",
+    "message": "パンくずリストのナビゲーション",
     "description": "The ARIA label for the breadcrumbs"
   },
   "theme.docs.DocCard.categoryDescription.plurals": {
-    "message": "1 item|{count} items",
+    "message": "{count}項目",
     "description": "The default description for a category card in the generated index about how many items this category includes"
   },
   "theme.docs.paginator.navAriaLabel": {
-    "message": "Docs pages",
+    "message": "ドキュメントページ",
     "description": "The ARIA label for the docs pagination"
   },
   "theme.docs.paginator.previous": {
-    "message": "Previous",
+    "message": "前へ",
     "description": "The label used to navigate to the previous doc"
   },
   "theme.docs.paginator.next": {
-    "message": "Next",
+    "message": "次へ",
     "description": "The label used to navigate to the next doc"
   },
   "theme.docs.tagDocListPageTitle.nDocsTagged": {
-    "message": "One doc tagged|{count} docs tagged",
+    "message": "{count}記事",
     "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.docs.tagDocListPageTitle": {
-    "message": "{nDocsTagged} with \"{tagName}\"",
+    "message": "「{tagName}」タグのついた{nDocsTagged}",
     "description": "The title of the page for a docs tag"
   },
   "theme.docs.versionBadge.label": {
-    "message": "Version: {versionLabel}"
+    "message": "バージョン: {versionLabel}"
   },
   "theme.docs.versions.unreleasedVersionLabel": {
-    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "message": "これはリリース前のバージョン{versionLabel}の{siteTitle}のドキュメントです。",
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "message": "これはバージョン{versionLabel}の{siteTitle}のドキュメントで現在はメンテナンスされていません",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
   },
   "theme.docs.versions.latestVersionSuggestionLabel": {
-    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "message": "最新のドキュメントは{latestVersionLink} ({versionLabel}) を見てください",
     "description": "The label used to tell the user to check the latest version"
   },
   "theme.docs.versions.latestVersionLinkLabel": {
-    "message": "latest version",
+    "message": "最新バージョン",
     "description": "The label used for the latest version suggestion link label"
   },
   "theme.common.editThisPage": {
-    "message": "Edit this page",
+    "message": "このページを編集",
     "description": "The link label to edit the current page"
   },
   "theme.common.headingLinkTitle": {
-    "message": "Direct link to {heading}",
+    "message": "{heading} への直接リンク",
     "description": "Title for link to heading"
   },
   "theme.lastUpdated.atDate": {
-    "message": " on {date}",
+    "message": "{date}に",
     "description": "The words used to describe on which date a page has been last updated"
   },
   "theme.lastUpdated.byUser": {
-    "message": " by {user}",
+    "message": "{user}が",
     "description": "The words used to describe by who the page has been last updated"
   },
   "theme.lastUpdated.lastUpdatedAtBy": {
-    "message": "Last updated{atDate}{byUser}",
+    "message": "{atDate}{byUser}最終更新",
     "description": "The sentence used to display when a page has been last updated, and by who"
   },
   "theme.NotFound.title": {
-    "message": "Page Not Found",
+    "message": "ページが見つかりません",
     "description": "The title of the 404 page"
   },
   "theme.navbar.mobileVersionsDropdown.label": {
-    "message": "Versions",
+    "message": "他のバージョン",
     "description": "The label for the navbar versions dropdown on mobile view"
   },
   "theme.tags.tagsListLabel": {
-    "message": "Tags:",
+    "message": "タグ:",
     "description": "The label alongside a tag list"
   },
   "theme.admonition.caution": {
-    "message": "caution",
+    "message": "注意",
     "description": "The default label used for the Caution admonition (:::caution)"
   },
   "theme.admonition.danger": {
-    "message": "danger",
+    "message": "危険",
     "description": "The default label used for the Danger admonition (:::danger)"
   },
   "theme.admonition.info": {
-    "message": "info",
+    "message": "備考",
     "description": "The default label used for the Info admonition (:::info)"
   },
   "theme.admonition.note": {
-    "message": "note",
+    "message": "注記",
     "description": "The default label used for the Note admonition (:::note)"
   },
   "theme.admonition.tip": {
-    "message": "tip",
+    "message": "ヒント",
     "description": "The default label used for the Tip admonition (:::tip)"
   },
   "theme.admonition.warning": {
-    "message": "warning",
+    "message": "警告",
     "description": "The default label used for the Warning admonition (:::warning)"
   },
   "theme.AnnouncementBar.closeButtonAriaLabel": {
-    "message": "Close",
+    "message": "閉じる",
     "description": "The ARIA label for close button of announcement bar"
   },
   "theme.blog.sidebar.navAriaLabel": {
-    "message": "Blog recent posts navigation",
+    "message": "最近のブログ記事のナビゲーション",
     "description": "The ARIA label for recent posts in the blog sidebar"
   },
   "theme.DocSidebarItem.expandCategoryAriaLabel": {
-    "message": "Expand sidebar category '{label}'",
+    "message": "'{label}'の目次を開く",
     "description": "The ARIA label to expand the sidebar category"
   },
   "theme.DocSidebarItem.collapseCategoryAriaLabel": {
-    "message": "Collapse sidebar category '{label}'",
+    "message": "'{label}'の目次を隠す",
     "description": "The ARIA label to collapse the sidebar category"
   },
   "theme.IconExternalLink.ariaLabel": {
-    "message": "(opens in new tab)",
+    "message": "(新しいタブで開く)",
     "description": "The ARIA label for the external link icon"
   },
   "theme.NavBar.navAriaLabel": {
-    "message": "Main",
+    "message": "ナビゲーション",
     "description": "The ARIA label for the main navigation"
   },
   "theme.navbar.mobileLanguageDropdown.label": {
-    "message": "Languages",
+    "message": "他の言語",
     "description": "The label for the mobile language switcher dropdown"
   },
   "theme.TOCCollapsible.toggleButtonLabel": {
-    "message": "On this page",
+    "message": "このページの見出し",
     "description": "The label used by the button on the collapsible TOC component"
   },
   "theme.NotFound.p1": {
-    "message": "We could not find what you were looking for.",
+    "message": "お探しのページが見つかりませんでした",
     "description": "The first paragraph of the 404 page"
   },
   "theme.NotFound.p2": {
-    "message": "Please contact the owner of the site that linked you to the original URL and let them know their link is broken.",
+    "message": "このページにリンクしているサイトの所有者にリンクが壊れていることを伝えてください",
     "description": "The 2nd paragraph of the 404 page"
   },
   "theme.blog.post.readMore": {
-    "message": "Read more",
+    "message": "もっと見る",
     "description": "The label used in blog post item excerpts to link to full blog posts"
   },
   "theme.blog.post.readMoreLabel": {
-    "message": "Read more about {title}",
+    "message": "{title}についてもっと見る",
     "description": "The ARIA label for the link to full blog posts from excerpts"
   },
   "theme.blog.post.readingTime.plurals": {
-    "message": "One min read|{readingTime} min read",
+    "message": "約{readingTime}分",
     "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.CodeBlock.copy": {
-    "message": "Copy",
+    "message": "コピー",
     "description": "The copy button label on code blocks"
   },
   "theme.CodeBlock.copied": {
-    "message": "Copied",
+    "message": "コピーしました",
     "description": "The copied button label on code blocks"
   },
   "theme.CodeBlock.copyButtonAriaLabel": {
-    "message": "Copy code to clipboard",
+    "message": "クリップボードにコードをコピー",
     "description": "The ARIA label for copy code blocks button"
   },
   "theme.CodeBlock.wordWrapToggle": {
-    "message": "Toggle word wrap",
+    "message": "折り返し",
     "description": "The title attribute for toggle word wrapping button of code block lines"
   },
   "theme.docs.breadcrumbs.home": {
-    "message": "Home page",
+    "message": "ホームページ",
     "description": "The ARIA label for the home page in the breadcrumbs"
   },
   "theme.docs.sidebar.collapseButtonTitle": {
-    "message": "Collapse sidebar",
+    "message": "サイドバーを隠す",
     "description": "The title attribute for collapse button of doc sidebar"
   },
   "theme.docs.sidebar.collapseButtonAriaLabel": {
-    "message": "Collapse sidebar",
+    "message": "サイドバーを隠す",
     "description": "The title attribute for collapse button of doc sidebar"
   },
   "theme.docs.sidebar.navAriaLabel": {
-    "message": "Docs sidebar",
+    "message": "ドキュメントのサイドバー",
     "description": "The ARIA label for the sidebar navigation"
   },
   "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
-    "message": "Close navigation bar",
+    "message": "ナビゲーションバーを閉じる",
     "description": "The ARIA label for close button of mobile sidebar"
   },
   "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
-    "message": "Back to main menu",
+    "message": "メインメニューに戻る",
     "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
   },
   "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
-    "message": "Toggle navigation bar",
+    "message": "ナビゲーションバーを開く",
     "description": "The ARIA label for hamburger menu button of mobile navigation"
   },
   "theme.SearchBar.seeAll": {
-    "message": "See all {count} results"
+    "message": "検索結果{count}件をすべて見る"
   },
   "theme.SearchPage.documentsFound.plurals": {
-    "message": "One document found|{count} documents found",
+    "message": "{count}件のドキュメントが見つかりました",
     "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.SearchPage.existingResultsTitle": {
-    "message": "Search results for \"{query}\"",
+    "message": "『{query}』の検索結果",
     "description": "The search page title for non-empty query"
   },
   "theme.SearchPage.emptyResultsTitle": {
-    "message": "Search the documentation",
+    "message": "ドキュメントを検索",
     "description": "The search page title for empty query"
   },
   "theme.SearchPage.inputPlaceholder": {
-    "message": "Type your search here",
+    "message": "検索するキーワードを入力してください",
     "description": "The placeholder for search page input"
   },
   "theme.SearchPage.inputLabel": {
-    "message": "Search",
+    "message": "検索",
     "description": "The ARIA label for search page input"
   },
   "theme.SearchPage.algoliaLabel": {
-    "message": "Powered by Algolia",
+    "message": "Algolia提供",
     "description": "The description label for Algolia mention"
   },
   "theme.SearchPage.noResultsText": {
-    "message": "No results were found",
+    "message": "検索結果が見つかりませんでした",
     "description": "The paragraph for empty search result"
   },
   "theme.SearchPage.fetchingNewResults": {
-    "message": "Fetching new results...",
+    "message": "新しい検索結果を取得しています...",
     "description": "The paragraph for fetching new search results"
   },
   "theme.SearchBar.label": {
-    "message": "Search",
+    "message": "検索",
     "description": "The ARIA label and placeholder for search button"
   },
   "theme.SearchModal.searchBox.resetButtonTitle": {
-    "message": "Clear the query",
+    "message": "クリア",
     "description": "The label and ARIA label for search box reset button"
   },
   "theme.SearchModal.searchBox.cancelButtonText": {
-    "message": "Cancel",
+    "message": "キャンセル",
     "description": "The label and ARIA label for search box cancel button"
   },
   "theme.SearchModal.searchBox.placeholderText": {
-    "message": "Search docs",
+    "message": "ドキュメントを検索",
     "description": "The placeholder text for the main search input field"
   },
   "theme.SearchModal.searchBox.placeholderTextAskAi": {
-    "message": "Ask another question...",
+    "message": "別の質問をする...",
     "description": "The placeholder text when in AI question mode"
   },
   "theme.SearchModal.searchBox.placeholderTextAskAiStreaming": {
-    "message": "Answering...",
+    "message": "回答中...",
     "description": "The placeholder text for search box when AI is streaming an answer"
   },
   "theme.SearchModal.searchBox.enterKeyHint": {
-    "message": "search",
+    "message": "検索",
     "description": "The hint for the search box enter key text"
   },
   "theme.SearchModal.searchBox.enterKeyHintAskAi": {
-    "message": "enter",
+    "message": "確定",
     "description": "The hint for the Ask AI search box enter key text"
   },
   "theme.SearchModal.searchBox.searchInputLabel": {
-    "message": "Search",
+    "message": "検索",
     "description": "The ARIA label for search input"
   },
   "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
-    "message": "Back to keyword search",
+    "message": "キーワード検索に戻る",
     "description": "The text for back to keyword search button"
   },
   "theme.SearchModal.searchBox.backToKeywordSearchButtonAriaLabel": {
-    "message": "Back to keyword search",
+    "message": "キーワード検索に戻る",
     "description": "The ARIA label for back to keyword search button"
   },
   "theme.SearchModal.startScreen.recentSearchesTitle": {
-    "message": "Recent",
+    "message": "最近の検索",
     "description": "The title for recent searches"
   },
   "theme.SearchModal.startScreen.noRecentSearchesText": {
-    "message": "No recent searches",
+    "message": "最近の検索履歴はありません",
     "description": "The text when there are no recent searches"
   },
   "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
-    "message": "Save this search",
+    "message": "この検索をお気に入りに追加",
     "description": "The title for save recent search button"
   },
   "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
-    "message": "Remove this search from history",
+    "message": "この検索を履歴から削除",
     "description": "The title for remove recent search button"
   },
   "theme.SearchModal.startScreen.favoriteSearchesTitle": {
-    "message": "Favorite",
+    "message": "お気に入り",
     "description": "The title for favorite searches"
   },
   "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
-    "message": "Remove this search from favorites",
+    "message": "この検索をお気に入りから削除",
     "description": "The title for remove favorite search button"
   },
   "theme.SearchModal.startScreen.recentConversationsTitle": {
-    "message": "Recent conversations",
+    "message": "最近の会話",
     "description": "The title for recent conversations"
   },
   "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
-    "message": "Remove this conversation from history",
+    "message": "この会話を履歴から削除",
     "description": "The title for remove recent conversation button"
   },
   "theme.SearchModal.errorScreen.titleText": {
-    "message": "Unable to fetch results",
+    "message": "検索結果の取得に失敗しました",
     "description": "The title for error screen"
   },
   "theme.SearchModal.errorScreen.helpText": {
-    "message": "You might want to check your network connection.",
+    "message": "ネットワーク接続を確認してください",
     "description": "The help text for error screen"
   },
   "theme.SearchModal.resultsScreen.askAiPlaceholder": {
-    "message": "Ask AI: ",
+    "message": "AIに質問：",
     "description": "The placeholder text for Ask AI input"
   },
   "theme.SearchModal.askAiScreen.disclaimerText": {
-    "message": "Answers are generated with AI which can make mistakes. Verify responses.",
+    "message": "回答はAIによって生成されており、誤りがある可能性があります。必ず内容を確認してください。",
     "description": "The disclaimer text for AI answers"
   },
   "theme.SearchModal.askAiScreen.relatedSourcesText": {
-    "message": "Related sources",
+    "message": "関連ソース",
     "description": "The text for related sources"
   },
   "theme.SearchModal.askAiScreen.thinkingText": {
-    "message": "Thinking...",
+    "message": "考え中...",
     "description": "The text when AI is thinking"
   },
   "theme.SearchModal.askAiScreen.copyButtonText": {
-    "message": "Copy",
+    "message": "コピー",
     "description": "The text for copy button"
   },
   "theme.SearchModal.askAiScreen.copyButtonCopiedText": {
-    "message": "Copied!",
+    "message": "コピーしました！",
     "description": "The text for copy button when copied"
   },
   "theme.SearchModal.askAiScreen.copyButtonTitle": {
-    "message": "Copy",
+    "message": "コピー",
     "description": "The title for copy button"
   },
   "theme.SearchModal.askAiScreen.likeButtonTitle": {
-    "message": "Like",
+    "message": "いいね",
     "description": "The title for like button"
   },
   "theme.SearchModal.askAiScreen.dislikeButtonTitle": {
-    "message": "Dislike",
+    "message": "よくない",
     "description": "The title for dislike button"
   },
   "theme.SearchModal.askAiScreen.thanksForFeedbackText": {
-    "message": "Thanks for your feedback!",
+    "message": "フィードバックありがとうございます！",
     "description": "The text for thanks for feedback"
   },
   "theme.SearchModal.askAiScreen.preToolCallText": {
-    "message": "Searching...",
+    "message": "検索中...",
     "description": "The text before tool call"
   },
   "theme.SearchModal.askAiScreen.duringToolCallText": {
-    "message": "Searching for ",
+    "message": "検索中：",
     "description": "The text during tool call"
   },
   "theme.SearchModal.askAiScreen.afterToolCallText": {
-    "message": "Searched for",
+    "message": "検索完了：",
     "description": "The text after tool call"
   },
   "theme.SearchModal.footer.selectText": {
-    "message": "Select",
+    "message": "選ぶ",
     "description": "The select text for footer"
   },
   "theme.SearchModal.footer.submitQuestionText": {
-    "message": "Submit question",
+    "message": "質問を送信",
     "description": "The submit question text for footer"
   },
   "theme.SearchModal.footer.selectKeyAriaLabel": {
-    "message": "Enter key",
+    "message": "エンターキー",
     "description": "The ARIA label for select key in footer"
   },
   "theme.SearchModal.footer.navigateText": {
-    "message": "Navigate",
+    "message": "移動",
     "description": "The navigate text for footer"
   },
   "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
-    "message": "Arrow up",
+    "message": "上矢印キー",
     "description": "The ARIA label for navigate up key in footer"
   },
   "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
-    "message": "Arrow down",
+    "message": "下矢印キー",
     "description": "The ARIA label for navigate down key in footer"
   },
   "theme.SearchModal.footer.closeText": {
-    "message": "Close",
+    "message": "閉じる",
     "description": "The close text for footer"
   },
   "theme.SearchModal.footer.closeKeyAriaLabel": {
-    "message": "Escape key",
+    "message": "エスケープキー",
     "description": "The ARIA label for close key in footer"
   },
   "theme.SearchModal.footer.searchByText": {
-    "message": "Powered by",
+    "message": "検索",
     "description": "The 'Powered by' text for footer"
   },
   "theme.SearchModal.footer.backToSearchText": {
-    "message": "Back to search",
+    "message": "検索に戻る",
     "description": "The back to search text for footer"
   },
   "theme.SearchModal.noResultsScreen.noResultsText": {
-    "message": "No results found for",
+    "message": "見つかりませんでした",
     "description": "The text when there are no results"
   },
   "theme.SearchModal.noResultsScreen.suggestedQueryText": {
-    "message": "Try searching for",
+    "message": "次の検索を試す:",
     "description": "The text for suggested query"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
-    "message": "Believe this query should return results?",
+    "message": "よりよい検索結果がありますか?",
     "description": "The text for reporting missing results"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
-    "message": "Let us know.",
+    "message": "報告する",
     "description": "The link text for reporting missing results"
   },
   "theme.SearchModal.placeholder": {
-    "message": "Search docs",
+    "message": "ドキュメントを検索",
     "description": "The placeholder of the input of the DocSearch pop-up modal"
   },
   "theme.IdealImageMessage.loading": {
-    "message": "Loading...",
+    "message": "読み込み中...",
     "description": "When the full-scale image is loading"
   },
   "theme.IdealImageMessage.load": {
-    "message": "Click to load{sizeMessage}",
+    "message": "クリックして読み込む{sizeMessage}",
     "description": "To prompt users to load the full image. sizeMessage is a parenthesized size figure."
   },
   "theme.IdealImageMessage.offline": {
-    "message": "Your browser is offline. Image not loaded",
+    "message": "オフライン中は画像は読み込まれません",
     "description": "When the user is viewing an offline document"
   },
   "theme.IdealImageMessage.404error": {
-    "message": "404. Image not found",
+    "message": "画像が存在しません",
     "description": "When the image is not found"
   },
   "theme.IdealImageMessage.error": {
-    "message": "Error. Click to reload",
+    "message": "画像の読み込みに失敗しました",
     "description": "When the image fails to load for unknown error"
   },
   "theme.blog.post.plurals": {
-    "message": "One post|{count} posts",
+    "message": "{count}件",
     "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.blog.tagTitle": {
-    "message": "{nPosts} tagged with \"{tagName}\"",
+    "message": "「{tagName}」タグの記事が{nPosts}件あります",
     "description": "The title of the page for a blog tag"
   },
   "theme.blog.author.pageTitle": {
@@ -538,560 +538,560 @@
     "description": "The title of the page for a blog author"
   },
   "theme.blog.authorsList.pageTitle": {
-    "message": "Authors",
+    "message": "著者一覧",
     "description": "The title of the authors page"
   },
   "theme.blog.authorsList.viewAll": {
-    "message": "View all authors",
+    "message": "すべての著者を見る",
     "description": "The label of the link targeting the blog authors page"
   },
   "theme.blog.author.noPosts": {
-    "message": "This author has not written any posts yet.",
+    "message": "この著者による投稿はまだありません。",
     "description": "The text for authors with 0 blog post"
   },
   "theme.contentVisibility.unlistedBanner.title": {
-    "message": "Unlisted page",
+    "message": "非公開のページ",
     "description": "The unlisted content banner title"
   },
   "theme.contentVisibility.unlistedBanner.message": {
-    "message": "This page is unlisted. Search engines will not index it, and only users having a direct link can access it.",
+    "message": "このページは非公開です。 検索対象外となり、このページのリンクに直接アクセスできるユーザーのみに公開されます。",
     "description": "The unlisted content banner message"
   },
   "theme.contentVisibility.draftBanner.title": {
-    "message": "Draft page",
+    "message": "下書きのページ",
     "description": "The draft content banner title"
   },
   "theme.contentVisibility.draftBanner.message": {
-    "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
+    "message": "このページは下書きです。開発環境でのみ表示され、本番環境のビルドには含まれません。",
     "description": "The draft content banner message"
   },
   "theme.ErrorPageContent.tryAgain": {
-    "message": "Try again",
+    "message": "もう一度試してください",
     "description": "The label of the button to try again rendering when the React error boundary captures an error"
   },
   "theme.common.skipToMainContent": {
-    "message": "Skip to main content",
+    "message": "メインコンテンツまでスキップ",
     "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
   },
   "theme.tags.tagsPageTitle": {
-    "message": "Tags",
+    "message": "タグ",
     "description": "The title of the tag list page"
   },
   "whatIsAda.hero.title": {
-    "message": "What is ada?"
+    "message": "ADAとは？"
   },
   "whatIsAda.hero.description1": {
-    "message": "A new type of currency. A new means of transaction."
+    "message": "新しい通貨のかたち。新しい取引のかたち。"
   },
   "whatIsAda.hero.description2": {
-    "message": "Direct. Secure. From Anywhere. For Everyone."
+    "message": "ダイレクトに。安全に。どこからでも。誰でも。"
   },
   "whatIsAda.meta.title": {
-    "message": "What Is ada, the Native Token of Cardano"
+    "message": "What is ada? | cardano.org"
   },
   "whatIsAda.meta.description": {
-    "message": "ada is the native cryptocurrency of the Cardano blockchain. Use it for transactions, staking, governance voting, and interacting with decentralized applications."
+    "message": "A new type of currency. A new means of transaction. Direct. Secure. From Anywhere. For Everyone."
   },
   "whatIsAda.section.headline": {
-    "message": "What is ada?"
+    "message": "ADAとは？"
   },
   "whatIsAda.section.title": {
-    "message": "Ada Is The Native Token Of Cardano"
+    "message": "ADAはCardanoのネイティブトークン"
   },
   "whatIsAda.section.description1": {
-    "message": "It is named after Ada Lovelace: a 19th-century mathematician who is recognized as the first computer programmer, and is the daughter of the poet Lord Byron."
+    "message": "ADAの名前は、19世紀の数学者であり世界初のコンピュータプログラマーとして知られるエイダ・ラブレスに由来しています。彼女は詩人バイロン卿の娘でもあります。"
   },
   "whatIsAda.section.description2": {
-    "message": "Ada is a digital currency. Any user, located anywhere in the world, can use ada as a secure exchange of value – without requiring a third party to mediate the exchange. Every transaction is permanently, securely, and transparently recorded on the Cardano blockchain."
+    "message": "ADAはデジタル通貨です。世界中の誰もが、第三者を介さずにADAで安全に価値を交換できます。すべての取引はCardanoブロックチェーン上に永続的、安全、透明に記録されます。"
   },
   "whatIsAda.section.description3": {
-    "message": "Every ada holder also holds a stake in the Cardano network. Ada stored in a wallet can be delegated to a stake pool to earn rewards – to participate in the successful running of the network – or found and run your own stake pool to increase the pool's likelihood of receiving rewards. In time, ada will also be usable for a variety of applications and services on the Cardano platform."
+    "message": "ADA保有者はCardanoネットワークにステークを持っています。ウォレットに保管されたADAはステークプールに委任して報酬を得ることができます。ネットワークの運営に参加するだけでなく、自分でステークプールを運営して報酬獲得の確率を高めることも可能です。将来的には、Cardanoプラットフォーム上のさまざまなアプリケーションやサービスにもADAが利用できるようになります。"
   },
   "whatIsAda.section.quote": {
-    "message": "What can I do with ada?"
+    "message": "ADAで何ができる？"
   },
   "howToBuyAda.title": {
-    "message": "How Do I Buy/Sell Ada?"
+    "message": "ADAの購入・売却方法"
   },
   "howToBuyAda.description1": {
-    "message": "There are many ways to obtain ada to use the Cardano blockchain. Find out on {whereToGetAdaLink}"
+    "message": "Cardanoブロックチェーンを利用するためのADAの入手方法はさまざまです。詳しくは{whereToGetAdaLink}をご覧ください。"
   },
   "howToBuyAda.whereToGetAdaLink": {
-    "message": "where to get ada?"
+    "message": "ADAの入手方法"
   },
   "howToBuyAda.description2": {
-    "message": "As an ada holder, it is important to keep your funds secure, and that means you need to keep your private keys private. It is highly recommended to avoid keeping your cryptocurrency in an exchange longer than necessary, and instead to use a cryptocurrency wallet."
+    "message": "ADA保有者として、資産を安全に保つことが重要です。秘密鍵は必ず自分だけのものにしてください。暗号資産を取引所に必要以上に長く置かず、暗号資産ウォレットの利用を強くお勧めします。"
   },
   "walletSection.typhon.title": {
     "message": "Typhon Wallet"
   },
   "walletSection.typhon.text": {
-    "message": "Blazing fast, feature-rich, secure, beautiful web and extension Cardano wallet. Delegate to multiple pools of your choice with multi-accounts."
+    "message": "超高速で機能豊富、安全で美しいウェブ＆拡張機能のCardanoウォレット。マルチアカウントで複数のプールに委任できます。"
   },
   "walletSection.typhon.subtext": {
-    "message": "Browser extension for Chrome, Brave and Edge"
+    "message": "Chrome、Brave、Edgeのブラウザ拡張機能"
   },
   "walletSection.typhon.label": {
-    "message": "Get Typhon"
+    "message": "Typhonを入手"
   },
   "walletSection.vespr.title": {
     "message": "VESPR Wallet"
   },
   "walletSection.vespr.text": {
-    "message": "VESPR is a non-custodial mobile light wallet for the Cardano network, prioritizing the security and safety of your digital assets while ensuring exceptional ease-of-use."
+    "message": "VESPRはCardanoネットワーク向けのノンカストディアルモバイルライトウォレットで、デジタル資産のセキュリティと安全性を最優先しながら、優れた使いやすさを実現しています。"
   },
   "walletSection.vespr.subtext": {
-    "message": "App for iOS and Android"
+    "message": "iOS・Androidアプリ"
   },
   "walletSection.vespr.label": {
-    "message": "Get VESPR"
+    "message": "VESPRを入手"
   },
   "walletSection.yoroi.title": {
     "message": "Yoroi Wallet"
   },
   "walletSection.yoroi.text": {
-    "message": "A user-friendly, [open-source](https://github.com/Emurgo/yoroi-frontend) Cardano wallet with a browser-based interface, providing a convenient way to manage ada holdings securely. Yoroi is also available as mobile app."
+    "message": "ブラウザベースのインターフェースを備えたユーザーフレンドリーな[オープンソース](https://github.com/Emurgo/yoroi-frontend)Cardanoウォレットで、ADAを安全に管理できます。モバイルアプリとしても利用可能です。"
   },
   "walletSection.yoroi.subtext": {
-    "message": "Browser extension and app for iOS and Android"
+    "message": "ブラウザ拡張機能、iOS・Androidアプリ"
   },
   "walletSection.yoroi.label": {
-    "message": "Get Yoroi"
+    "message": "Yoroiを入手"
   },
   "walletSection.eternl.title": {
     "message": "Eternl Wallet"
   },
   "walletSection.eternl.text": {
-    "message": "The alternative Cardano light wallet in the browser. Aims to add features most requested by the Cardano community. Eternl is also available as mobile app."
+    "message": "ブラウザで使える代替Cardanoライトウォレット。Cardanoコミュニティから最もリクエストの多い機能を追加することを目指しています。モバイルアプリとしても利用可能です。"
   },
   "walletSection.eternl.subtext": {
-    "message": "Browser extension and app for iOS and Android"
+    "message": "ブラウザ拡張機能、iOS・Androidアプリ"
   },
   "walletSection.eternl.label": {
-    "message": "Get Eternl"
+    "message": "Eternlを入手"
   },
   "walletSection.lace.title": {
     "message": "Lace Wallet"
   },
   "walletSection.lace.text": {
-    "message": "An [open-source](https://github.com/input-output-hk/lace) light wallet platform from IOG, one of the creators of Cardano. Manually verified by an independent auditor, Lace lets you quickly, easily, and securely manage your digital assets and enjoy Web3."
+    "message": "Cardanoの創設者の一つであるIOGの[オープンソース](https://github.com/input-output-hk/lace)ライトウォレットプラットフォーム。独立した監査人による手動検証済みで、デジタル資産を素早く、簡単に、安全に管理しWeb3を楽しめます。"
   },
   "walletSection.lace.subtext": {
-    "message": "Browser extension for Chrome, Brave"
+    "message": "Chrome、Braveのブラウザ拡張機能"
   },
   "walletSection.lace.label": {
-    "message": "Get Lace"
+    "message": "Laceを入手"
   },
   "walletSection.daedalus.title": {
     "message": "Daedalus Wallet"
   },
   "walletSection.daedalus.text": {
-    "message": "The [open-source](https://github.com/input-output-hk/daedalus) full node wallet for Cardano. It offers enhanced control and security by maintaining a complete copy of the blockchain, but this comes at the cost of a more complex user experience. As a result, they are typically geared towards professional users who require these advanced features."
+    "message": "Cardanoの[オープンソース](https://github.com/input-output-hk/daedalus)フルノードウォレット。ブロックチェーンの完全なコピーを維持することで、高度な制御とセキュリティを提供しますが、より複雑なユーザー体験を伴います。そのため、高度な機能を必要とするプロフェッショナルユーザー向けです。"
   },
   "walletSection.daedalus.subtext": {
-    "message": "Only for powerful desktop PCs"
+    "message": "高性能デスクトップPC専用"
   },
   "walletSection.daedalus.label": {
-    "message": "Get Daedalus"
+    "message": "Daedalusを入手"
   },
   "walletSection.explore.title": {
-    "message": "Explore Apps"
+    "message": "アプリを探索"
   },
   "walletSection.explore.text": {
-    "message": "Discover a wide variety of wallets designed to facilitate your interaction."
+    "message": "やり取りを容易にするさまざまなウォレットを見つけましょう。"
   },
   "walletSection.explore.label": {
-    "message": "More Wallets"
+    "message": "その他のウォレット"
   },
   "walletSection.divider": {
-    "message": "Cardano Wallets"
+    "message": "Cardanoウォレット"
   },
   "walletSection.disclaimer": {
-    "message": "The example applications are provided for informational purposes only and not endorsed or approved. Their use is strictly at your own risk. The descriptions have been provided by the respective project teams."
+    "message": "サンプルアプリケーションは情報提供のみを目的としており、推奨や承認を意味するものではありません。利用は完全に自己責任で行ってください。説明は各プロジェクトチームによって提供されています。"
   },
   "walletSection.storageTitle": {
-    "message": "How Do I Store My Ada And Keep It Safe?"
+    "message": "ADAの保管と安全な管理方法"
   },
   "walletSection.storageDescription1": {
-    "message": "A cryptocurrency wallet is a software program designed to store your public and private keys, send and receive digital currencies, monitor your balance, and interact with supported blockchains."
+    "message": "暗号資産ウォレットは、公開鍵と秘密鍵の保管、デジタル通貨の送受信、残高の確認、対応するブロックチェーンとのやり取りのために設計されたソフトウェアです。"
   },
   "walletSection.storageDescription2": {
-    "message": "In addition to the variation of wallets available, there are also two types of wallets: a hot wallet and a cold wallet."
+    "message": "利用可能なウォレットのバリエーションに加え、ホットウォレットとコールドウォレットの2種類があります。"
   },
   "walletSection.hotWalletText": {
-    "message": "A hot wallet is connected to the internet and can be accessed at any time with the requisite keys. Examples of hot wallets include mobile and software wallets, and funds stored on exchanges."
+    "message": "ホットウォレットはインターネットに接続されており、必要な鍵があればいつでもアクセスできます。モバイルウォレット、ソフトウェアウォレット、取引所に保管された資金がホットウォレットの例です。"
   },
   "walletSection.coldWalletText": {
-    "message": "A cold wallet is an offline wallet. It is not connected to the internet and is used for securing storing funds that do not have to be frequently accessed. Examples include hardware wallets - which is a secure hardware device that stores the wallet's private keys - and paper wallets. Cardano is supported by both Trezor and Ledger hardware wallets."
+    "message": "コールドウォレットはオフラインのウォレットです。インターネットに接続されておらず、頻繁にアクセスする必要のない資金の安全な保管に使用されます。ハードウェアウォレット（ウォレットの秘密鍵を保管するセキュアなハードウェアデバイス）やペーパーウォレットが例です。CardanoはTrezorとLedgerの両方のハードウェアウォレットに対応しています。"
   },
   "whatIsAda.button.getStarted": {
-    "message": "Get started with Cardano"
+    "message": "Cardanoをはじめよう"
   },
   "whatIsAda.button.whereToGetAda": {
-    "message": "Where to get ada?"
+    "message": "ADAの入手方法"
   },
   "getStarted.hero.title": {
-    "message": "Get started with Cardano"
+    "message": "Cardanoをはじめよう"
   },
   "getStarted.hero.description": {
-    "message": "Step into the new world yourself and learn all the basics in just few steps."
+    "message": "自分の目で新しい世界を確かめよう。わずか数ステップで基本がわかります。"
   },
   "getStarted.meta.title": {
-    "message": "Get Started with Cardano, Your First Steps"
+    "message": "Get started with Cardano | cardano.org"
   },
   "getStarted.meta.description": {
-    "message": "Set up a Cardano wallet, get ada, and start exploring DApps and staking in a few simple steps. Your beginner's guide to the Cardano ecosystem."
+    "message": "Step into the new world yourself and learn all the basics in just few steps."
   },
   "getStarted.step1.title": {
-    "message": "Download a wallet"
+    "message": "ウォレットをダウンロード"
   },
   "getStarted.step1.description": {
-    "message": "A wallet is an app that allows you to receive, send cryptocurrencies and manage your Cardano account."
+    "message": "ウォレットは暗号資産の受け取り、送金、Cardanoアカウントの管理ができるアプリです。"
   },
   "getStarted.step1.heading": {
-    "message": "Download a wallet"
+    "message": "ウォレットをダウンロード"
   },
   "getStarted.step1.text1": {
-    "message": "A Cardano wallet is your personal interface to the blockchain, much like a web browser is your interface to the internet. It lets you securely manage your ada, use dApps, and interact with the network."
+    "message": "Cardanoウォレットは、ブロックチェーンへの個人的なインターフェースです。ウェブブラウザがインターネットへの窓口であるように、ウォレットはADAの管理、dAppの利用、ネットワークとのやり取りを安全に行えます。"
   },
   "getStarted.step1.text2": {
-    "message": "You will create your wallet in the next steps. Downloading alone does not create one."
+    "message": "ウォレットは次のステップで作成します。ダウンロードしただけではウォレットは作られません。"
   },
   "getStarted.step1.securityNote": {
-    "message": "Your recovery phrase is required to regain access to your wallet. Cardano wallets are non-custodial, which means there is no central service, help desk, or recovery mechanism."
+    "message": "リカバリーフレーズはウォレットへのアクセスを回復するために必要です。Cardanoウォレットはノンカストディアル（非管理型）のため、中央のサービス、ヘルプデスク、復旧手段はありません。"
   },
   "getStarted.step1.checkbox": {
-    "message": "I downloaded a wallet."
+    "message": "ウォレットをダウンロードしました。"
   },
   "getStarted.common.scamLink": {
-    "message": "Be aware of the most common scams."
+    "message": "よくある詐欺に注意しましょう。"
   },
   "getStarted.step2.title": {
-    "message": "Backup your recovery phrase"
+    "message": "リカバリーフレーズをバックアップ"
   },
   "getStarted.step2.description": {
-    "message": "When you create a new wallet, you'll receive a set of 12, 15, or 24 words. This is your recovery phrase, also called a seed phrase. It is the master key to your wallet. Keep it safe!"
+    "message": "新しいウォレットを作成すると、12語、15語、または24語の単語セットが表示されます。これがリカバリーフレーズ（シードフレーズ）です。ウォレットのマスターキーなので、大切に保管してください。"
   },
   "getStarted.step2.heading": {
-    "message": "Save your recovery phrase"
+    "message": "リカバリーフレーズを保存"
   },
   "getStarted.step2.whatToDo": {
-    "message": "What to do:"
+    "message": "やるべきこと："
   },
   "getStarted.step2.tip1": {
-    "message": "Write it down on paper and store it securely offline"
+    "message": "紙に書き留めて、オフラインで安全に保管する"
   },
   "getStarted.step2.tip2": {
-    "message": "Never share it with anyone or store it digitally"
+    "message": "誰とも共有せず、デジタルで保存しない"
   },
   "getStarted.step2.tip3": {
-    "message": "Anyone with your recovery phrase can access your funds"
+    "message": "リカバリーフレーズを知っている人は誰でもあなたの資産にアクセスできます"
   },
   "getStarted.step2.tip4": {
-    "message": "Keep multiple copies in different secure locations"
+    "message": "異なる安全な場所に複数のコピーを保管する"
   },
   "getStarted.step2.checkbox": {
-    "message": "I've backed up my recovery phrase."
+    "message": "リカバリーフレーズをバックアップしました。"
   },
   "getStarted.step3.title": {
-    "message": "Complete wallet setup"
+    "message": "ウォレットのセットアップを完了"
   },
   "getStarted.step3.description": {
-    "message": "Finish setting up your wallet with a password and verification."
+    "message": "パスワード設定と確認でウォレットの初期設定を完了しましょう。"
   },
   "getStarted.step3.heading": {
-    "message": "Final setup steps"
+    "message": "最後のセットアップ手順"
   },
   "getStarted.step3.intro": {
-    "message": "After backing up your recovery phrase, complete these two important steps:"
+    "message": "リカバリーフレーズをバックアップしたら、次の2つの重要なステップを完了してください："
   },
   "getStarted.step3.passwordLabel": {
-    "message": "Spending password:"
+    "message": "送金パスワード："
   },
   "getStarted.step3.passwordText": {
-    "message": "Create a strong password to protect everyday transactions. This password is different from your recovery phrase and secures your wallet on this device."
+    "message": "日常の取引を保護するために、強力なパスワードを作成してください。このパスワードはリカバリーフレーズとは異なり、このデバイス上のウォレットを保護します。"
   },
   "getStarted.step3.verifyLabel": {
-    "message": "Verify your backup:"
+    "message": "バックアップの確認："
   },
   "getStarted.step3.verifyText": {
-    "message": "Most wallets will ask you to confirm your recovery phrase by selecting words in order. This ensures you've correctly saved it."
+    "message": "ほとんどのウォレットでは、単語を順番に選択してリカバリーフレーズを確認するよう求められます。これにより、正しく保存されたことが確認できます。"
   },
   "getStarted.step3.ready": {
-    "message": "Once these steps are complete, your wallet is ready to use!"
+    "message": "これらのステップが完了すれば、ウォレットの準備完了です！"
   },
   "getStarted.step3.securityNote": {
-    "message": "If you forget your spending password, you can restore your wallet using your recovery phrase."
+    "message": "送金パスワードを忘れた場合は、リカバリーフレーズを使ってウォレットを復元できます。"
   },
   "getStarted.step3.securityWarning": {
-    "message": "However, anyone who obtains your recovery phrase can fully access and empty your wallet without needing the spending password."
+    "message": "ただし、リカバリーフレーズを入手した人は、送金パスワードなしでウォレットに完全にアクセスし、資産を移動できます。"
   },
   "getStarted.step3.checkbox": {
-    "message": "I've completed the wallet setup."
+    "message": "ウォレットのセットアップを完了しました。"
   },
   "getStarted.step4.title": {
-    "message": "Connect your wallet"
+    "message": "ウォレットを接続"
   },
   "getStarted.step4.description": {
-    "message": "Use your wallet as a single account for apps and projects on Cardano. A wallet connector, like the one shown below, lets websites securely connect to your wallet so you can interact without creating separate accounts or passwords."
+    "message": "ウォレットをCardano上のアプリやプロジェクトの共通アカウントとして使いましょう。下のようなウォレットコネクターを使えば、ウェブサイトがウォレットに安全に接続でき、別々のアカウントやパスワードを作らずにやり取りできます。"
   },
   "getStarted.step4.securityNote": {
-    "message": "When you approve a connection or transaction, you are granting that site specific permissions. Always check the website address and review what you are asked to approve before continuing."
+    "message": "接続やトランザクションを承認する際は、そのサイトに特定の権限を付与することになります。承認前に必ずウェブサイトのアドレスを確認し、何を承認するか確認してください。"
   },
   "getStarted.step4.checkbox": {
-    "message": "I've connected my wallet."
+    "message": "ウォレットを接続しました。"
   },
   "getStarted.step5.title": {
-    "message": "Get ada"
+    "message": "ADAを入手"
   },
   "getStarted.step5.description": {
-    "message": "Obtain ada, Cardano's native cryptocurrency, to start using the blockchain."
+    "message": "Cardanoのネイティブ暗号資産ADAを入手して、ブロックチェーンの利用を始めましょう。"
   },
   "getStarted.step5.heading": {
-    "message": "Where to get ada"
+    "message": "ADAの入手方法"
   },
   "getStarted.step5.text": {
-    "message": "There are several ways to obtain ada, but the most common method is buying it on cryptocurrency exchanges using fiat currency or other cryptocurrencies."
+    "message": "ADAを入手するにはいくつかの方法がありますが、最も一般的なのは暗号資産取引所で法定通貨や他の暗号資産を使って購入する方法です。"
   },
   "getStarted.step5.button": {
-    "message": "View all options"
+    "message": "すべての方法を見る"
   },
   "getStarted.step5.securityNote": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers."
+    "message": "暗号資産の世界にはチャンスが多い反面、詐欺師の活動の場でもあります。"
   },
   "getStarted.step5.checkbox": {
-    "message": "I have ada in my wallet."
+    "message": "ウォレットにADAが入りました。"
   },
   "getStarted.step6.title": {
-    "message": "Explore the ecosystem"
+    "message": "エコシステムを探索"
   },
   "getStarted.step6.description": {
-    "message": "Now that you have a wallet and ada, you are ready to explore everything Cardano has to offer. A good place to start is by exploring popular apps."
+    "message": "ウォレットとADAの準備ができたら、Cardanoが提供するすべてを探索する準備が整いました。まずは人気アプリを見てみましょう。"
   },
   "whereToGetAda.hero.title": {
-    "message": "Where to get ada?"
+    "message": "ADAの入手方法"
   },
   "whereToGetAda.hero.description": {
-    "message": "There are many ways to obtain ada to use the Cardano blockchain."
+    "message": "Cardanoブロックチェーンを利用するためのADAを入手する方法はたくさんあります。"
   },
   "whereToGetAda.meta.title": {
-    "message": "Buy ada, Where to Get Cardano's Native Token"
+    "message": "Get ada | cardano.org"
   },
   "whereToGetAda.meta.description": {
-    "message": "Buy ada on centralized or decentralized exchanges, earn staking rewards, or receive it directly. Find the best way to get Cardano's native token."
+    "message": "There are many ways to obtain ada to use the Cardano blockchain."
   },
   "whereToGetAda.divider.exchanges": {
-    "message": "Buy ada using Exchanges"
+    "message": "取引所でADAを購入"
   },
   "whereToGetAda.cex.title": {
-    "message": "Centralized Exchanges"
+    "message": "中央集権型取引所"
   },
   "whereToGetAda.cex.description": {
-    "message": "Centralized exchanges (CEXs) are platforms where cryptocurrencies and other digital assets are traded. They act as intermediaries between buyers and sellers, facilitating transactions and often providing additional services such as custodial storage, order matching, and regulatory compliance. Note that CEXs have custody over [ada](/what-is-ada/) and other native tokens until you send them to a [wallet](/what-is-ada/#wallets) that you control."
+    "message": "中央集権型取引所（CEX）は、暗号資産やその他のデジタル資産を取引するプラットフォームです。買い手と売り手の仲介役として、取引の促進に加え、カストディ（資産保管）、注文マッチング、規制対応などのサービスも提供しています。CEXでは、自分で管理する[ウォレット](/what-is-ada/#wallets)に送金するまで、[ADA](/what-is-ada/)やその他のネイティブトークンはCEXが管理しています。"
   },
   "whereToGetAda.cex.disclaimer": {
-    "message": "Listing here does not imply endorsement. This data is crowd-sourced by the community. Visit [CoinMarketCap](https://coinmarketcap.com/currencies/cardano/#Markets) to see a full list of exchanges that support [ada](/what-is-ada/)."
+    "message": "ここに掲載されていることは推奨を意味しません。このデータはコミュニティから提供されたものです。[ADA](/what-is-ada/)をサポートする取引所の完全なリストは[CoinMarketCap](https://coinmarketcap.com/currencies/cardano/#Markets)をご覧ください。"
   },
   "whereToGetAda.dex.title": {
-    "message": "Decentralized Exchanges"
+    "message": "分散型取引所"
   },
   "whereToGetAda.dex.description": {
-    "message": "Decentralized exchanges (DEXs) are platforms for trading cryptocurrencies that operate without a central authority. They allow users to trade directly with each other (peer-to-peer) through automated processes facilitated by smart contracts. This approach enhances security and privacy, reducing the risk of hacking and custodial failures associated with centralized exchanges."
+    "message": "分散型取引所（DEX）は、中央管理者なしに運営される暗号資産取引プラットフォームです。スマートコントラクトによる自動化されたプロセスを通じて、ユーザー同士が直接（ピアツーピアで）取引できます。このアプローチにより、中央集権型取引所に伴うハッキングやカストディの障害リスクを軽減し、セキュリティとプライバシーが向上します。"
   },
   "whereToGetAda.dex.disclaimer": {
-    "message": "DEXs are not suitable for beginners, as you must already have [ada](/what-is-ada/) to use them. Listing here does not imply endorsement. Transaction data is based on the last 30 days."
+    "message": "DEXは初心者向けではありません。利用するにはすでに[ADA](/what-is-ada/)を持っている必要があります。ここへの掲載は推奨を意味しません。取引データは過去30日間に基づいています。"
   },
   "whereToGetAda.divider.receive": {
-    "message": "Receive ada from people around the world"
+    "message": "世界中の人からADAを受け取る"
   },
   "whereToGetAda.receive.title": {
-    "message": "Receive ada"
+    "message": "ADAを受け取る"
   },
   "whereToGetAda.receive.description1": {
-    "message": "Before receiving or buying [ada](/what-is-ada/), you need to set up a [Cardano wallet](/what-is-ada/#wallets)."
+    "message": "[ADA](/what-is-ada/)を受け取ったり購入したりする前に、[Cardanoウォレット](/what-is-ada/#wallets)を作成する必要があります。"
   },
   "whereToGetAda.receive.description2": {
-    "message": "Once you have a [Cardano wallet](/what-is-ada/#wallets), all you need to do is share your address to start sending and receiving [ada](/what-is-ada/) (and other native tokens) peer-to-peer."
+    "message": "[Cardanoウォレット](/what-is-ada/#wallets)があれば、アドレスを共有するだけで[ADA](/what-is-ada/)（およびその他のネイティブトークン）のピアツーピア送受信が始められます。"
   },
   "whereToGetAda.receive.description3": {
-    "message": "Some [wallets](/what-is-ada/#wallets) let you purchase crypto with a debit/credit card, bank transfer, or Apple Pay. Availability depends on your location."
+    "message": "一部の[ウォレット](/what-is-ada/#wallets)では、デビット/クレジットカード、銀行振込、Apple Payで暗号資産を購入できます。利用可能かどうかはお住まいの地域によります。"
   },
   "whereToGetAda.divider.funding": {
-    "message": "Get funded in ada"
+    "message": "ADAで資金を得る"
   },
   "whereToGetAda.funding.title": {
     "message": "Project Catalyst"
   },
   "whereToGetAda.funding.description": {
-    "message": "Discover Cardano's innovation fund designed to support groundbreaking projects and ideas. By participating, you can receive [ada](/what-is-ada/) funding to bring your vision to life. Visit [Project Catalyst](https://projectcatalyst.io) and learn how to create a proposal."
+    "message": "画期的なプロジェクトやアイデアを支援するCardanoのイノベーションファンドを発見しましょう。参加することで、ビジョンを実現するための[ADA](/what-is-ada/)資金を受け取ることができます。[Project Catalyst](https://projectcatalyst.io)にアクセスして、提案の作成方法を学びましょう。"
   },
   "whereToGetAda.divider.rewards": {
-    "message": "Staking rewards"
+    "message": "ステーキング報酬"
   },
   "whereToGetAda.staking.title": {
-    "message": "Staking rewards"
+    "message": "ステーキング報酬"
   },
   "whereToGetAda.staking.description1": {
-    "message": "If you already have some [ada](/what-is-ada/), you can earn more by [delegating your ada to a stake pool](/stake-pool-delegation/). This allows you to participate in the network's proof-of-stake system and earn rewards. Alternatively, you can [run your own stake pool](/stake-pool-operation/), which requires more effort and technical knowledge but can be more rewarding."
+    "message": "すでに[ADA](/what-is-ada/)をお持ちなら、[ステークプールにADAを委任する](/stake-pool-delegation/)ことで、さらにADAを獲得できます。これにより、ネットワークのプルーフ・オブ・ステーク・システムに参加して報酬を得ることができます。より多くの努力と技術的知識が必要ですが、[自分でステークプールを運営する](/stake-pool-operation/)こともでき、より大きな報酬が期待できます。"
   },
   "whereToGetAda.staking.description2": {
-    "message": "Cardano offers several advantages for staking: there is no minimum amount of [ada](/what-is-ada/) required to stake, no risk of slashing (losing your staked [ada](/what-is-ada/)), and no locking period. You always maintain custody over your delegated [ada](/what-is-ada/), ensuring that your funds remain secure and accessible at all times. Additionally, rewards are distributed by the protocol itself, not by the pools, ensuring a fair and transparent distribution process."
+    "message": "Cardanoのステーキングにはいくつかの利点があります。ステークに必要な[ADA](/what-is-ada/)の最低額はなく、スラッシング（ステークした[ADA](/what-is-ada/)の没収）のリスクもなく、ロック期間もありません。委任した[ADA](/what-is-ada/)の管理権は常に自分にあり、資産は安全で、いつでもアクセス可能です。さらに、報酬はプールではなくプロトコル自体が分配するため、公平で透明な分配プロセスが保証されます。"
   },
   "commonScams.hero.title": {
-    "message": "Common Cardano scams"
+    "message": "よくあるCardano詐欺"
   },
   "commonScams.hero.description": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers."
+    "message": "暗号資産の世界はチャンスに満ちていますが、詐欺師の活動の場でもあります。"
   },
   "commonScams.meta.title": {
-    "message": "Common Cardano Scams, How to Stay Safe"
+    "message": "Common Cardano scams you should avoid | cardano.org"
   },
   "commonScams.meta.description": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers."
+    "message": "暗号資産の世界はチャンスに満ちていますが、詐欺師の活動の場でもあります。"
   },
   "commonScams.quiz.title": {
-    "message": "Test Your Knowledge"
+    "message": "知識をテストしよう"
   },
   "commonScams.quiz.description": {
-    "message": "Take the 5-question quiz to see how well you can identify and avoid common blockchain scams."
+    "message": "5問のクイズに挑戦して、ブロックチェーン詐欺の見分け方と回避方法を確認しましょう。"
   },
   "commonScams.quiz.buttonText": {
-    "message": "Start Quiz"
+    "message": "クイズを始める"
   },
   "commonScams.intro.title": {
-    "message": "Protecting your ada from scammers"
+    "message": "詐欺からADAを守る"
   },
   "commonScams.intro.description1": {
-    "message": "The cryptocurrency space is full of opportunities, but it's also a playground for scammers. Cardano (ada), one of the most popular blockchains, isn't immune to these threats. From fake giveaways to phishing attacks, scammers are constantly innovating new ways to exploit users. As artificial intelligence continues to improve, these scams are also becoming more sophisticated. This page outlines the most common scams in the Cardano ecosystem and how you can protect yourself."
+    "message": "暗号資産の世界はチャンスに満ちていますが、詐欺師の活動の場でもあります。最も人気のあるブロックチェーンの一つであるCardano（ADA）もこれらの脅威と無縁ではありません。偽のプレゼント企画からフィッシング攻撃まで、詐欺師は常にユーザーを騙す新しい手口を考案しています。人工知能の進歩に伴い、これらの詐欺もますます巧妙になっています。このページでは、Cardanoエコシステムにおける最も一般的な詐欺とその対策を紹介します。"
   },
   "commonScams.intro.description2": {
-    "message": "**Remember:** If someone gains access to your seed words (recovery phrase), they can take full control of your wallet—no spending password can protect you. Once your ada is stolen, it's gone forever, with no way to recover it."
+    "message": "**覚えておいてください：** シードワード（リカバリーフレーズ）にアクセスされると、ウォレットの完全なコントロールを奪われます。送金パスワードでは守れません。ADAが盗まれたら、二度と取り戻すことはできません。"
   },
   "commonScams.divider.giveaway": {
-    "message": "Giveaway"
+    "message": "プレゼント詐欺"
   },
   "commonScams.giveaway.title": {
-    "message": "Ada Giveaway Scam"
+    "message": "ADAプレゼント詐欺"
   },
   "commonScams.giveaway.description1": {
-    "message": "One of the most well-known scams targeting the Cardano community is the **Ada Giveaway Scam.** Scammers promise to double your ada if you send them a certain amount first. These scams often feature fake live streams of Charles Hoskinson, or other well-known personalities, to appear legitimate. The streams may mimic genuine events and include a wallet address for you to send your ada."
+    "message": "Cardanoコミュニティを狙う最も有名な詐欺の一つが**ADAプレゼント詐欺**です。詐欺師は一定量のADAを送れば倍にして返すと約束します。多くの場合、Charles Hoskinsonや他の著名人の偽ライブストリームを使って正当に見せかけます。本物のイベントを模倣し、ADAを送るウォレットアドレスを含むことがあります。"
   },
   "commonScams.giveaway.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "身を守る方法："
   },
   "commonScams.giveaway.tip1": {
-    "message": "Legitimate giveaways **never** ask for money upfront."
+    "message": "正当なプレゼント企画は**絶対に**先にお金を要求しません。"
   },
   "commonScams.giveaway.tip2": {
-    "message": "Avoid clicking on links in unsolicited messages or live streams."
+    "message": "不審なメッセージやライブストリームのリンクをクリックしないでください。"
   },
   "commonScams.giveaway.tip3": {
-    "message": "Remember: Once sent, your ada is gone forever."
+    "message": "送ったADAは二度と戻りません。"
   },
   "commonScams.giveaway.tip4": {
-    "message": "Read reports and scam sightings from users in [the Cardano forum](https://forum.cardano.org/c/english/report-a-scam/184)."
+    "message": "[Cardanoフォーラム](https://forum.cardano.org/c/english/report-a-scam/184)でユーザーからの報告や詐欺目撃情報を確認しましょう。"
   },
   "commonScams.divider.phishing": {
-    "message": "Phishing"
+    "message": "フィッシング"
   },
   "commonScams.phishing.title": {
-    "message": "Phishing Attacks"
+    "message": "フィッシング攻撃"
   },
   "commonScams.phishing.description": {
-    "message": "Phishing scams involve fake websites, apps or emails designed to steal sensitive information, such as your wallet credentials or recovery phrase (seed words). These fraudulent sites often mimic popular wallets like [Typhon, VESPR or Eternl](/what-is-ada/#wallets)."
+    "message": "フィッシング詐欺は、ウォレットの認証情報やリカバリーフレーズ（シードワード）などの機密情報を盗むために設計された偽のウェブサイト、アプリ、メールを使います。これらの不正サイトは、[Typhon、VESPR、Eternl](/what-is-ada/#wallets)などの人気ウォレットを模倣することがよくあります。"
   },
   "commonScams.phishing.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "身を守る方法："
   },
   "commonScams.phishing.tip1": {
-    "message": "Double-check URLs to ensure they match actual wallet websites."
+    "message": "URLが実際のウォレットのウェブサイトと一致しているか再確認してください。"
   },
   "commonScams.phishing.tip2": {
-    "message": "**Never** share your recovery phrase, **even** with \"support\" staff or \"moderators\"."
+    "message": "「サポート」スタッフや「モデレーター」であっても、リカバリーフレーズは**絶対に**共有しないでください。"
   },
   "commonScams.phishing.tip3": {
-    "message": "Consider using hardware wallets."
+    "message": "ハードウェアウォレットの使用を検討してください。"
   },
   "commonScams.phishing.tip4": {
-    "message": "Use two-factor authentication where possible."
+    "message": "可能な限り二要素認証を使用してください。"
   },
   "commonScams.divider.investment": {
-    "message": "Fake Investment"
+    "message": "偽の投資"
   },
   "commonScams.investment.title": {
-    "message": "Fake Investment Opportunities"
+    "message": "偽の投資機会"
   },
   "commonScams.investment.description": {
-    "message": "Fraudulent investment schemes are another popular scam. Scammers promote fake projects, claiming they are \"Cardano-backed\" or \"ada-specific\" opportunities with guaranteed high returns. Victims are urged to send ada or other funds to a provided wallet address, with promises of earning exponential profits."
+    "message": "不正な投資スキームもよくある詐欺です。詐欺師は「Cardano公認」や「ADA専用」と称する偽プロジェクトを宣伝し、高いリターンを保証すると主張します。被害者はウォレットアドレスにADAや他の資金を送るよう促され、莫大な利益が約束されます。"
   },
   "commonScams.investment.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "身を守る方法："
   },
   "commonScams.investment.tip1": {
-    "message": "Legitimate projects **never** promise guaranteed returns."
+    "message": "正当なプロジェクトは**絶対に**リターンを保証しません。"
   },
   "commonScams.investment.tip2": {
-    "message": "Be skeptical of unsolicited investment offers."
+    "message": "不審な投資提案には懐疑的になりましょう。"
   },
   "commonScams.investment.tip3": {
-    "message": "Research projects thoroughly, checking for transparency and a credible team."
+    "message": "プロジェクトを徹底的に調査し、透明性と信頼できるチームを確認しましょう。"
   },
   "commonScams.divider.support": {
-    "message": "Fake Support"
+    "message": "偽のサポート"
   },
   "commonScams.support.title": {
-    "message": "Fake Tech Support"
+    "message": "偽のテクニカルサポート"
   },
   "commonScams.support.description1": {
-    "message": "In this scam, fraudsters pose as \"official\" Cardano support representatives. They often reach out via social media, forums, or email, claiming they can fix your wallet or troubleshoot an issue. They also often copy the profiles of real moderators and to \"help,\" they'll ask for your recovery phrase (seed words) or private keys."
+    "message": "この詐欺では、詐欺師が「公式」のCardanoサポート担当者を装います。ソーシャルメディア、フォーラム、メールを通じて連絡してきて、ウォレットの修復や問題のトラブルシューティングができると主張します。実在のモデレーターのプロフィールをコピーし、「お手伝い」のためにリカバリーフレーズや秘密鍵を要求します。"
   },
   "commonScams.support.description2": {
-    "message": "This scam is often seen when a [new user enters a channel](/docs/communities) and asks a question about a wallet. Scammers quickly respond, pretending to be official support."
+    "message": "この詐欺は、[新規ユーザーがチャンネルに参加して](/docs/communities)ウォレットについて質問したときによく見られます。詐欺師はすぐに応答し、公式サポートを装います。"
   },
   "commonScams.support.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "身を守る方法："
   },
   "commonScams.support.tip1": {
-    "message": "Legitimate people on [forums and channels](/docs/communities) will **never** ask for your passwords, recovery phrases or private keys."
+    "message": "[フォーラムやチャンネル](/docs/communities)の正当なメンバーは、パスワード、リカバリーフレーズ、秘密鍵を**絶対に**要求しません。"
   },
   "commonScams.support.tip2": {
-    "message": "Never engage with unsolicited messages claiming to be from support."
+    "message": "サポートを名乗る不審なメッセージには応じないでください。"
   },
   "commonScams.support.tip3": {
-    "message": "Legitimate people on forums and channels will **never** contact you first in a private message."
+    "message": "フォーラムやチャンネルの正当なメンバーは、プライベートメッセージで先に連絡してくることは**絶対に**ありません。"
   },
   "commonScams.divider.rug": {
-    "message": "Rug Pulls"
+    "message": "ラグプル"
   },
   "commonScams.rug.title": {
-    "message": "Rug Pulls in Cardano Ecosystem"
+    "message": "Cardanoエコシステムのラグプル"
   },
   "commonScams.rug.description": {
-    "message": "Cardano is a public, permissionless Layer 1 blockchain and everyone can use it. Some fraudulent projects launch on Cardano, gaining attention with big promises and flashy marketing. After collecting a significant amount of ada from investors, these projects disappear—this is known as a \"rug pull.\""
+    "message": "Cardanoはパブリックでパーミッションレスなレイヤー1ブロックチェーンであり、誰でも利用できます。一部の不正プロジェクトがCardano上でローンチし、大きな約束と派手なマーケティングで注目を集めます。投資家から相当量のADAを集めた後、プロジェクトが消滅します。これが「ラグプル」です。"
   },
   "commonScams.rug.howToProtect": {
-    "message": "How to protect yourself:"
+    "message": "身を守る方法："
   },
   "commonScams.rug.tip1": {
-    "message": "Research the project team's credentials and reputation."
+    "message": "プロジェクトチームの経歴と評判を調べましょう。"
   },
   "commonScams.rug.tip2": {
-    "message": "Check for audits or transparent documentation."
+    "message": "監査や透明なドキュメントがあるか確認しましょう。"
   },
   "commonScams.rug.tip3": {
-    "message": "Avoid projects with anonymous teams or unrealistic promises."
+    "message": "匿名チームや非現実的な約束のプロジェクトは避けましょう。"
   },
   "commonScams.rug.tip4": {
-    "message": "Only get utility tokens when you need to use the utility."
+    "message": "ユーティリティトークンは、そのユーティリティを使う必要があるときにのみ入手しましょう。"
   },
   "commonScams.rug.tip5": {
-    "message": "Find out what other people think about projects in [the Cardano forum](https://forum.cardano.org/c/english/report-a-scam/184)."
+    "message": "[Cardanoフォーラム](https://forum.cardano.org/c/english/report-a-scam/184)で他の人がプロジェクトについてどう思っているか確認しましょう。"
   },
   "home.meta.title": {
-    "message": "Cardano, Secure Decentralized Blockchain Platform"
+    "message": "ホーム | cardano.org"
   },
   "home.meta.description": {
-    "message": "Cardano is a decentralized blockchain platform built through peer-reviewed research. Explore ada, staking, governance, DApps, and a global open-source community."
+    "message": "経済的なアイデンティティを持たない数十億の人々に、分散型アプリケーションによるID管理・価値移転・ガバナンスの手段を提供するオープンプラットフォーム。"
   },
   "home.hero.title": {
     "message": "Making the World Work Better for All"
@@ -1100,219 +1100,219 @@
     "message": "Cardano is the most secure, reliable and censorship-resistant blockchain for mission critical applications to power economies and societies of the future."
   },
   "home.hero.ctaWhatIsAda": {
-    "message": "What is ada?"
+    "message": "adaとは？"
   },
   "home.hero.ctaGetStarted": {
-    "message": "Get Started"
+    "message": "はじめる"
   },
   "home.featured.title": {
-    "message": "Our World Is Changing. Together, We Can Change It For The Better."
+    "message": "世界は変わりつつあります。共に、より良い方向へ変えていきましょう。"
   },
   "home.featured.description1": {
-    "message": "Cardano is a proof-of-stake blockchain platform: the first to be founded on [peer-reviewed research](/research) and developed through evidence-based methods. It combines pioneering technologies to provide unparalleled security and sustainability to decentralized applications, systems, and societies."
+    "message": "Cardanoはプルーフ・オブ・ステーク型のブロックチェーンプラットフォームです。[peer-reviewされた研究](/research)に基づき、エビデンスに基づく手法で開発された初のプラットフォームとして、最先端テクノロジーを組み合わせ、分散型アプリケーション・システム・社会に比類ない安全性と持続可能性を提供します。"
   },
   "home.featured.description2": {
-    "message": "With a leading team of engineers, Cardano exists to redistribute power from unaccountable structures to the margins – to individuals – and be an enabling force for positive change and progress."
+    "message": "優秀なエンジニアチームとともに、Cardanoは不透明な権力構造から個人へと力を再分配し、ポジティブな変化と進歩を実現する原動力となることを目指しています。"
   },
   "home.featured.quote1": {
-    "message": "A History Of Impossible,"
+    "message": "不可能の歴史を、"
   },
   "home.featured.quote2": {
-    "message": "Made Possible"
+    "message": "可能に変える"
   },
   "home.featured.buttonLabel": {
-    "message": "Use Cardano Apps"
+    "message": "Cardanoアプリを使う"
   },
   "home.divider.benefits": {
-    "message": "Benefits"
+    "message": "メリット"
   },
   "home.quoteBox.description": {
-    "message": "Cardano restores trust to global systems – creating, through science, a more secure, transparent, and sustainable foundation for individuals to transact and exchange, systems to govern, and enterprises to grow."
+    "message": "Cardanoは科学の力でグローバルシステムに信頼を取り戻します。個人が安全に取引し、システムが効果的に機能し、企業が成長するための、より安全で透明性のある持続可能な基盤を構築します。"
   },
   "home.quoteBox.quote": {
-    "message": "Cardano brings a new standard in technology – open and inclusive – to challenge the old and activate a new age of sustainable, globally-distributed innovation."
+    "message": "Cardanoはテクノロジーに新たな基準をもたらします — オープンでインクルーシブ — 既存の常識に挑み、持続可能でグローバルに分散されたイノベーションの新時代を切り開きます。"
   },
   "home.benefits.ouroboros.label": {
-    "message": "Proof-of-stake and Ouroboros"
+    "message": "プルーフ・オブ・ステークとOuroboros"
   },
   "home.benefits.ouroboros.category": {
-    "message": "Protocol"
+    "message": "プロトコル"
   },
   "home.benefits.ouroboros.title": {
-    "message": "Proof-Of-Stake And Ouroboros: The Most Environmentally Sustainable Blockchain Protocol"
+    "message": "プルーフ・オブ・ステークとOuroboros：最も環境に優しいブロックチェーンプロトコル"
   },
   "home.benefits.ouroboros.body": {
-    "message": "Ouroboros is the first peer-reviewed, verifiably-secure blockchain protocol, and Cardano is the first blockchain to implement it. Ouroboros enables decentralization in the Cardano network on a sustainable scale for global requirements and most crucially, without compromising security.<br /><br />The protocol is the result of tireless efforts, based on foundational research, propelled by a vision for more secure and transparent global payment systems, and provides the means to equitably redistribute power and control."
+    "message": "Ouroborosは、peer-reviewされ検証可能な安全性を持つ初のブロックチェーンプロトコルであり、Cardanoはそれを実装した最初のブロックチェーンです。セキュリティを犠牲にすることなく、グローバル規模での持続可能な分散化を実現します。<br /><br />このプロトコルは、より安全で透明性の高いグローバル決済システムを目指す基礎研究に基づく絶え間ない努力の成果です。権力と支配を公平に再分配する手段を提供します。"
   },
   "home.benefits.ouroboros.cta": {
-    "message": "Learn about Ouroboros"
+    "message": "Ouroborosについて"
   },
   "home.benefits.research.label": {
-    "message": "Evidence-based development"
+    "message": "エビデンスに基づく開発"
   },
   "home.benefits.research.category": {
-    "message": "Research"
+    "message": "研究"
   },
   "home.benefits.research.title": {
-    "message": "The Highest Standards In Development, Rooted In Science"
+    "message": "科学に根ざした、最高水準の開発"
   },
   "home.benefits.research.body": {
-    "message": "Cardano is developed using evidence-based methods; a novel combination of formal methods, normally found in critical high-stakes applications, and an agile approach, which helps the project remain adaptable and responsive to emerging requirements and new innovations. To support global applications, systems, and solutions, we believe security assurance is not a choice: it is a requirement. Our protocol implementations and platform integrations are first researched, challenged, and mathematically modeled and tested before they are specified. These specifications then inform development which, in turn, is independently audited. The result is a codebase offering an unrivaled level of assurance."
+    "message": "Cardanoはエビデンスに基づく手法で開発されています。ミッションクリティカルなアプリケーションで使用される形式手法と、柔軟性を維持するアジャイル手法を独自に組み合わせた画期的なアプローチです。グローバルなアプリケーションやシステムをサポートするため、セキュリティの保証は選択肢ではなく必須要件と考えています。プロトコルの実装とプラットフォームの統合は、まず研究・検証・数学的モデリングとテストを経て仕様化されます。その仕様に基づく開発は独立監査を受けます。その結果、比類のない信頼性を持つコードベースが実現しています。"
   },
   "home.benefits.research.cta": {
-    "message": "Discover the research"
+    "message": "研究を見る"
   },
   "home.benefits.secure.label": {
-    "message": "Secure"
+    "message": "セキュア"
   },
   "home.benefits.secure.category": {
-    "message": "Transact"
+    "message": "トランザクション"
   },
   "home.benefits.secure.title": {
-    "message": "Unparalleled Security - And The Makings Of A Trustless World"
+    "message": "比類ないセキュリティ — トラストレスな世界の実現"
   },
   "home.benefits.secure.body": {
-    "message": "Cardano makes it possible for any actors who do not know each other - and have no reason to trust one another - to interact and transact, securely. It is a platform for building trust where none might naturally exist, opening up whole new markets and opportunities. Through Ouroboros, Cardano is provably secure against bad actors and Sybil attacks. Every transaction, interaction, and exchange is immutably and transparently recovered, and securely validated using multi-signature and a pioneering extended UTXO model."
+    "message": "Cardanoは、互いに面識がなく信頼関係もない当事者同士が安全にやり取りや取引を行うことを可能にします。信頼が自然には存在しない場面で信頼を構築するプラットフォームであり、まったく新しい市場と機会を切り開きます。Ouroborosにより、悪意ある攻撃やシビル攻撃に対して証明可能なセキュリティを実現しています。すべてのトランザクションは不変かつ透明に記録され、マルチシグネチャと革新的な拡張UTXOモデルによって安全に検証されます。"
   },
   "home.benefits.secure.cta": {
-    "message": "Visit the roadmap"
+    "message": "ロードマップを見る"
   },
   "home.benefits.participation.label": {
-    "message": "Incentivized participation"
+    "message": "インセンティブ付きの参加"
   },
   "home.benefits.participation.category": {
-    "message": "Open"
+    "message": "オープン"
   },
   "home.benefits.participation.title": {
-    "message": "Open And Incentivized Participation"
+    "message": "オープンでインセンティブに基づく参加"
   },
   "home.benefits.participation.body": {
-    "message": "With a committed community at its core, Cardano is an open-source project developed through open participation. To ensure the longevity and health of the network, Cardano features an incentive mechanism that rewards users - either as stake pool operators or stake delegators - for their participation. The platform is built and expanded through enhancement and improvement proposals. Cardano's governance system gives everyone a democratic voice; ada holders can submit or vote on proposals to upgrade the platform or help determine the direction of development. The governance model uniquely positions Cardano for future growth and development, and provides the means to introduce new capabilities tailored to user needs. It ensures Cardano and its community can continuously fund and decide upon platform and ecosystem improvements."
+    "message": "熱心なコミュニティを核に、Cardanoはオープンな参加を通じて開発されるオープンソースプロジェクトです。ネットワークの長期的な健全性を確保するため、ステークプールオペレーターやステーク委任者として参加するユーザーに報酬を与えるインセンティブを備えています。プラットフォームは改善提案を通じて進化します。Cardanoのガバナンスはすべての人に民主的な発言権を与え、adaホルダーはプラットフォームのアップグレードや開発方針に関する提案の提出・投票ができます。このガバナンスモデルにより、将来の成長に向けた独自の立ち位置を確立し、ユーザーニーズに合わせた新機能導入の手段を提供します。コミュニティが継続的にプラットフォームとエコシステムの改善に資金を提供し、意思決定できる仕組みです。"
   },
   "home.benefits.participation.cta": {
-    "message": "Learn about governance"
+    "message": "ガバナンスについて"
   },
   "home.benefits.scalable.label": {
-    "message": "Scalable and sustainable"
+    "message": "スケーラブルで持続可能"
   },
   "home.benefits.scalable.category": {
-    "message": "Ecosystem"
+    "message": "エコシステム"
   },
   "home.benefits.scalable.title": {
-    "message": "Extremely Scalable And Environmentally Sustainable"
+    "message": "高いスケーラビリティと環境への持続可能性"
   },
   "home.benefits.scalable.body": {
-    "message": "Ouroboros allows Cardano to scale to global requirements with minimal energy consumption. Unlike other blockchains, Cardano does not require exponentially increasing energy to enhance performance and add blocks. The balance between performance and sustainability is achieved through a combination of novel approaches, including multi-ledger, side chains, and parallel transaction processing through multi-party state channels.<br /><br />The network proliferates as the number of stake pools increases, while parameters are set and adjusted to measure the attractiveness of specific stake pools. This is a network that rewards participation directly. Cardano is designed to ensure that those who act in the best interests of the network are also acting in their own best interests. This ensures the development of a healthy ecosystem with a durable, healthy, and robust network, now and into the future. The combination of sustainability and scalability allows Cardano to achieve the throughput required to meet the evolving demands of global systems— financial, logistical, identity-related, societal."
+    "message": "Ouroborosにより、Cardanoは最小限のエネルギー消費でグローバル規模にスケールできます。他のブロックチェーンとは異なり、パフォーマンスの向上やブロック追加に指数関数的なエネルギー増加を必要としません。パフォーマンスと持続可能性のバランスは、マルチレジャー、サイドチェーン、マルチパーティステートチャネルによる並列トランザクション処理など、革新的なアプローチの組み合わせで達成されています。<br /><br />ステークプール数の増加とともにネットワークは拡大し、各プールの魅力度を測るパラメータが設定・調整されます。参加に直接報酬を与えるネットワークです。Cardanoは、ネットワークの利益のために行動する者が自身の利益のためにも行動するよう設計されています。これにより、耐久性のある健全で堅牢なネットワークとエコシステムの発展が確保されます。持続可能性とスケーラビリティの組み合わせにより、金融・物流・アイデンティティ・社会に関わるグローバルシステムの進化する需要に対応するスループットを実現します。"
   },
   "home.benefits.scalable.cta": {
-    "message": "Learn about Hydra"
+    "message": "Hydraについて"
   },
   "home.vision.title1": {
-    "message": "Define Your Possible."
+    "message": "あなたの可能性を定義しよう。"
   },
   "home.vision.title2": {
-    "message": "Change Your World."
+    "message": "あなたの世界を変えよう。"
   },
   "home.divider.makeTheChange": {
-    "message": "Make the Change"
+    "message": "変革を起こす"
   },
   "home.discover.title": {
-    "message": "Discover Cardano"
+    "message": "Cardanoを知る"
   },
   "home.discover.description": {
-    "message": "Cardano is the first blockchain platform to be built through [peer-reviewed research](/research), to be secure enough to protect the data of billions, scalable enough to accommodate global systems, and robust enough to support foundational change."
+    "message": "Cardanoは、[peer-reviewされた研究](/research)に基づいて構築された初のブロックチェーンプラットフォームです。数十億のデータを守るセキュリティ、グローバルシステムに対応するスケーラビリティ、そして根本的な変革を支える堅牢性を兼ね備えています。"
   },
   "home.discover.people": {
-    "message": "People"
+    "message": "人々"
   },
   "home.discover.purpose": {
-    "message": "Purpose"
+    "message": "目的"
   },
   "home.discover.research": {
-    "message": "Research"
+    "message": "研究"
   },
   "home.discover.technology": {
-    "message": "Technology"
+    "message": "テクノロジー"
   },
   "home.discover.opportunity": {
-    "message": "Opportunity"
+    "message": "機会"
   },
   "home.discover.quote1": {
-    "message": "We have changed science. We have changed what it means to build global systems and sustainable models of exchange and governance."
+    "message": "私たちは科学を変えました。グローバルシステムの構築、持続可能な交換とガバナンスのモデルが意味するものを変えました。"
   },
   "home.discover.quote2": {
-    "message": "Alongside the community, entities, and companies building on Cardano, a new future is being defined: a decentralized future without intermediaries, where power is returned to the individual"
+    "message": "Cardano上で構築するコミュニティ・組織・企業とともに、新しい未来が形づくられています — 仲介者のいない分散型の未来、権力が個人に戻される未来です。"
   },
   "home.divider.entities": {
-    "message": "Entities"
+    "message": "エンティティ"
   },
   "home.entities.description": {
-    "message": "Multiple independent entities collaborate within a decentralized team framework to drive Cardano forward, ensuring that it remains aligned with its core mission as it progresses and develops. These are a few of them:"
+    "message": "複数の独立した組織が分散型のチームフレームワークの中で協力し、Cardanoの前進を推進しています。進化と発展を続けながらも、コアミッションとの一致を確保しています。以下はその一部です："
   },
   "home.follow.divider": {
-    "message": "Social"
+    "message": "ソーシャル"
   },
   "home.follow.title": {
-    "message": "Get Involved"
+    "message": "参加しよう"
   },
   "navbar.mega.column.Get to know": {
-    "message": "Get to know",
+    "message": "知る",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Take part": {
-    "message": "Take part",
+    "message": "参加する",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Research": {
-    "message": "Research",
+    "message": "リサーチ",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Connect": {
-    "message": "Connect",
+    "message": "つながる",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Engage": {
-    "message": "Engage",
+    "message": "関わる",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Governance": {
-    "message": "Governance",
+    "message": "ガバナンス",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Get started": {
-    "message": "Get started",
+    "message": "はじめる",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Tools": {
-    "message": "Tools",
+    "message": "ツール",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.For Enterprise": {
-    "message": "For Enterprise",
+    "message": "企業向け",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Use Cases": {
-    "message": "Use Cases",
+    "message": "ユースケース",
     "description": "Mega menu column title"
   },
   "navbar.mega.label.What is ada?": {
-    "message": "What is ada?",
+    "message": "ADAとは？",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Get started with Cardano": {
-    "message": "Get started with Cardano",
+    "message": "Cardanoをはじめよう",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Where to get ada?": {
-    "message": "Where to get ada?",
+    "message": "ADAの入手方法",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Protect your ada": {
-    "message": "Protect your ada",
+    "message": "ADAを守る",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Delegate your ada": {
-    "message": "Delegate your ada",
+    "message": "ADAを委任する",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Delegate your vote": {
@@ -1320,123 +1320,123 @@
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Use Cardano Apps": {
-    "message": "Use Cardano Apps",
+    "message": "Cardanoアプリを使う",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Code of Conduct": {
-    "message": "Code of Conduct",
+    "message": "行動規範",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Research": {
-    "message": "Cardano Research",
+    "message": "Cardanoリサーチ",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Insights": {
-    "message": "Cardano Insights",
+    "message": "Cardanoインサイト",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Hard Forks": {
-    "message": "Hard Forks",
+    "message": "ハードフォーク",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.News": {
-    "message": "News",
+    "message": "ニュース",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Newsletter": {
-    "message": "Newsletter",
+    "message": "ニュースレター",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Online Communities": {
-    "message": "Online Communities",
+    "message": "オンラインコミュニティ",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Ambassador Program": {
-    "message": "Ambassador Program",
+    "message": "アンバサダープログラム",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Events": {
-    "message": "Cardano Events",
+    "message": "Cardanoイベント",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Forum": {
-    "message": "Cardano Forum",
+    "message": "Cardanoフォーラム",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Get involved in cardano.org": {
-    "message": "Get involved in cardano.org",
+    "message": "cardano.orgに参加する",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Participate in governance": {
-    "message": "Participate in governance",
+    "message": "ガバナンスに参加する",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Governance Tools": {
-    "message": "Governance Tools",
+    "message": "ガバナンスツール",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Constitution": {
-    "message": "Cardano Constitution",
+    "message": "Cardano憲法",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Start building on Cardano": {
-    "message": "Start building on Cardano",
+    "message": "Cardanoで開発を始める",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Integrate Cardano": {
-    "message": "Integrate Cardano",
+    "message": "Cardanoを統合する",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Developer Portal": {
-    "message": "Developer Portal",
+    "message": "開発者ポータル",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Builder Tools": {
-    "message": "Builder Tools",
+    "message": "ビルダーツール",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Companies building on Cardano": {
-    "message": "Companies building on Cardano",
+    "message": "Cardano上の企業",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Enterprise Solutions": {
-    "message": "Enterprise Solutions",
+    "message": "エンタープライズソリューション",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Contact the Foundation": {
-    "message": "Contact the Foundation",
+    "message": "Cardano Foundationに連絡",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.All Use Cases": {
-    "message": "All Use Cases",
+    "message": "すべてのユースケース",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Identity": {
-    "message": "Identity",
+    "message": "アイデンティティ",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Supply Chain": {
-    "message": "Supply Chain",
+    "message": "サプライチェーン",
     "description": "Mega menu item label"
   },
   "navbar.mega.description.What is ada?": {
-    "message": "Cardano's native token",
+    "message": "Cardanoのネイティブトークン",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Get started with Cardano": {
-    "message": "Learn the basics and start using Cardano",
+    "message": "基本を学んでCardanoを使い始めよう",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Where to get ada?": {
-    "message": "Obtain ada to use Cardano",
+    "message": "ADAを入手してCardanoを利用する",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Protect your ada": {
-    "message": "Don't fall for scams",
+    "message": "詐欺に騙されないために",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Delegate your ada": {
-    "message": "Be a part of it and earn rewards",
+    "message": "ネットワークに参加して報酬を得る",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Delegate your vote": {
@@ -1444,1622 +1444,1622 @@
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Use Cardano Apps": {
-    "message": "Explore curated applications",
+    "message": "厳選されたアプリケーションを探す",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Code of Conduct": {
-    "message": "Community standards and values",
+    "message": "コミュニティの基準と価値観",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Research": {
-    "message": "Peer-reviewed research and papers",
+    "message": "査読済みの研究と論文",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Insights": {
-    "message": "On-chain or regularly refreshed data",
+    "message": "オンチェーンデータと定期更新情報",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Hard Forks": {
-    "message": "Implemented Upgrades",
+    "message": "実施済みのアップグレード",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.News": {
-    "message": "Latest Cardano news and updates",
+    "message": "Cardanoの最新ニュースとアップデート",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Newsletter": {
-    "message": "Stay updated with Cardano news",
+    "message": "Cardanoの最新情報を受け取る",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Online Communities": {
-    "message": "Recommended Channels",
+    "message": "おすすめのコミュニティチャンネル",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Ambassador Program": {
-    "message": "Meet Cardano Ambassadors",
+    "message": "Cardanoアンバサダーに会う",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Events": {
-    "message": "Join Cardano community events",
+    "message": "Cardanoコミュニティイベントに参加する",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Forum": {
-    "message": "Structured long-format discussions",
+    "message": "体系的なロングフォーマットのディスカッション",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Get involved in cardano.org": {
-    "message": "If you'd like to participate, this will get you started",
+    "message": "参加したい方はこちらから",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Participate in governance": {
-    "message": "Shape Cardano's future",
+    "message": "Cardanoの未来を形作る",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Governance Tools": {
-    "message": "Tools for transparent, community-driven decisions",
+    "message": "透明でコミュニティ主導の意思決定ツール",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Constitution": {
-    "message": "Learn about governance",
+    "message": "ガバナンスについて学ぶ",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Start building on Cardano": {
-    "message": "Developer resources and tooling",
+    "message": "開発者向けリソースとツール",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Integrate Cardano": {
-    "message": "Exchange and integration guides",
+    "message": "取引所・統合ガイド",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Developer Portal": {
-    "message": "Cardano developer portal and docs",
+    "message": "Cardano開発者ポータルとドキュメント",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Builder Tools": {
-    "message": "Tools to build on Cardano",
+    "message": "Cardano上で開発するためのツール",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Companies building on Cardano": {
-    "message": "Companies, associations, and collaborations",
+    "message": "企業・団体・コラボレーション",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Enterprise Solutions": {
-    "message": "Case studies and proven deployments",
+    "message": "導入事例と実績",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Contact the Foundation": {
-    "message": "Partner with the Cardano Foundation",
+    "message": "Cardano Foundationと連携する",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.All Use Cases": {
-    "message": "Explore blockchain applications",
+    "message": "ブロックチェーン活用事例を探す",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Identity": {
-    "message": "Credentials & verification",
+    "message": "認証と本人確認",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Supply Chain": {
-    "message": "Traceability & provenance",
+    "message": "トレーサビリティと来歴証明",
     "description": "Mega menu item description"
   },
   "solutions.data.dpp.title": {
-    "message": "Digital Product Passport"
+    "message": "デジタルプロダクトパスポート"
   },
   "solutions.data.dpp.description": {
-    "message": "EU-compliant digital product passports for transparency and sustainability."
+    "message": "透明性と持続可能性のためのEU準拠デジタルプロダクトパスポート。"
   },
   "solutions.data.category.supplyChain": {
-    "message": "Supply Chain"
+    "message": "サプライチェーン"
   },
   "solutions.data.traceability.title": {
-    "message": "Traceability"
+    "message": "トレーサビリティ"
   },
   "solutions.data.traceability.description": {
-    "message": "End-to-end supply chain traceability powered by blockchain."
+    "message": "ブロックチェーンで実現するエンドツーエンドのサプライチェーントレーサビリティ。"
   },
   "solutions.data.authenticity.title": {
-    "message": "Authenticity"
+    "message": "真正性"
   },
   "solutions.data.authenticity.description": {
-    "message": "Combat counterfeiting with blockchain-verified product authenticity."
+    "message": "ブロックチェーン検証による製品の真正性で偽造品に対抗。"
   },
   "solutions.data.sustainability.title": {
-    "message": "Sustainability"
+    "message": "サステナビリティ"
   },
   "solutions.data.sustainability.description": {
-    "message": "Track and verify sustainability claims with immutable records."
+    "message": "不変の記録でサステナビリティの主張を追跡・検証。"
   },
   "solutions.data.storage.title": {
-    "message": "Decentralized Storage"
+    "message": "分散型ストレージ"
   },
   "solutions.data.storage.description": {
-    "message": "Secure, distributed data storage solutions for enterprises."
+    "message": "企業向けの安全な分散型データストレージソリューション。"
   },
   "solutions.data.category.dataTech": {
-    "message": "Data & Technology"
+    "message": "データ＆テクノロジー"
   },
   "solutions.data.navio.description": {
-    "message": "Blockchain-based solution for supply chain management."
+    "message": "サプライチェーン管理のためのブロックチェーンベースのソリューション。"
   },
   "solutions.data.caseStudies.title": {
-    "message": "Case Studies"
+    "message": "導入事例"
   },
   "solutions.data.caseStudies.description": {
-    "message": "Explore real-world implementations of Cardano blockchain solutions."
+    "message": "Cardanoブロックチェーンソリューションの実際の導入事例を探索。"
   },
   "useCases.category.identity": {
-    "message": "Identity"
+    "message": "アイデンティティ"
   },
   "useCases.card.education.title": {
-    "message": "Education"
+    "message": "教育"
   },
   "useCases.card.education.summary": {
-    "message": "Blockchain-verified academic credentials"
+    "message": "ブロックチェーンで検証された学術資格"
   },
   "useCases.card.digitalIdentity.title": {
-    "message": "Digital Identity"
+    "message": "デジタルアイデンティティ"
   },
   "useCases.card.digitalIdentity.summary": {
-    "message": "Own and control your digital identity"
+    "message": "自分のデジタルアイデンティティを管理"
   },
   "useCases.card.financeKyc.title": {
-    "message": "Finance KYC"
+    "message": "金融KYC"
   },
   "useCases.card.financeKyc.summary": {
-    "message": "Streamlined identity verification"
+    "message": "効率的な本人確認"
   },
   "useCases.card.government.title": {
-    "message": "Government"
+    "message": "行政"
   },
   "useCases.card.government.summary": {
-    "message": "Tamper-proof official documents"
+    "message": "改ざん不可能な公式文書"
   },
   "useCases.category.finance": {
-    "message": "Finance"
+    "message": "金融"
   },
   "useCases.card.defi.summary": {
-    "message": "Decentralized lending and exchanges"
+    "message": "分散型レンディングと取引所"
   },
   "useCases.card.payments.title": {
-    "message": "Payments"
+    "message": "決済"
   },
   "useCases.card.payments.summary": {
-    "message": "Fast, low-cost cross-border transfers"
+    "message": "高速・低コストの国際送金"
   },
   "useCases.category.supplyChain": {
-    "message": "Supply Chain"
+    "message": "サプライチェーン"
   },
   "useCases.card.agriculture.title": {
-    "message": "Agriculture"
+    "message": "農業"
   },
   "useCases.card.agriculture.summary": {
-    "message": "Farm-to-table traceability"
+    "message": "農場から食卓へのトレーサビリティ"
   },
   "useCases.card.retail.title": {
-    "message": "Retail"
+    "message": "小売"
   },
   "useCases.card.retail.summary": {
-    "message": "Combat counterfeiting with provenance"
+    "message": "来歴証明で偽造品に対抗"
   },
   "useCases.card.logistics.title": {
-    "message": "Logistics"
+    "message": "物流"
   },
   "useCases.card.logistics.summary": {
-    "message": "Real-time tracking and verification"
+    "message": "リアルタイム追跡と検証"
   },
   "useCases.category.socialImpact": {
-    "message": "Social Impact"
+    "message": "ソーシャルインパクト"
   },
   "useCases.card.socialPrograms.title": {
-    "message": "Social Programs"
+    "message": "社会プログラム"
   },
   "useCases.card.socialPrograms.summary": {
-    "message": "Transparent fund distribution"
+    "message": "透明な資金分配"
   },
   "useCases.category.dataTech": {
-    "message": "Data & Technology"
+    "message": "データ＆テクノロジー"
   },
   "useCases.card.dataStorage.title": {
-    "message": "Data Storage"
+    "message": "データストレージ"
   },
   "useCases.card.dataStorage.summary": {
-    "message": "Decentralized, secure storage"
+    "message": "分散型の安全なストレージ"
   },
   "useCases.card.tokenizedAssets.title": {
-    "message": "Tokenized Assets"
+    "message": "トークン化資産"
   },
   "useCases.card.tokenizedAssets.summary": {
-    "message": "Fractional ownership of real-world assets"
+    "message": "実物資産の分割所有"
   },
   "useCases.category.emerging": {
-    "message": "Emerging Applications"
+    "message": "新興アプリケーション"
   },
   "useCases.card.votingSystems.title": {
-    "message": "Voting Systems"
+    "message": "投票システム"
   },
   "useCases.card.votingSystems.summary": {
-    "message": "Secure, transparent elections"
+    "message": "安全で透明な選挙"
   },
   "useCases.card.healthcare.title": {
-    "message": "Healthcare"
+    "message": "ヘルスケア"
   },
   "useCases.card.healthcare.summary": {
-    "message": "Portable, secure health records"
+    "message": "ポータブルで安全な健康記録"
   },
   "useCases.card.musicIp.title": {
-    "message": "Music & IP"
+    "message": "音楽＆知的財産"
   },
   "useCases.card.musicIp.summary": {
-    "message": "Direct royalty payments to artists"
+    "message": "アーティストへの直接ロイヤリティ支払い"
   },
   "ambassadors.hero.title": {
-    "message": "Ambassadors"
+    "message": "アンバサダー"
   },
   "ambassadors.hero.description": {
-    "message": "The Cardano Ambassador Program celebrates community leaders driving the expansion of the Cardano ecosystem. Established in 2018 and continuously refined by the Cardano Foundation, it empowers dedicated contributors to make a global impact."
+    "message": "Cardanoアンバサダープログラムは、Cardanoエコシステムの拡大を推進するコミュニティリーダーを称えるプログラムです。2018年に設立され、Cardano Foundationによって継続的に改良され、献身的なコントリビューターがグローバルな影響を生み出す力を与えています。"
   },
   "ambassadors.layout.title": {
-    "message": "Cardano Ambassador Program, Join the Community"
+    "message": "Ambassador Program | cardano.org"
   },
   "ambassadors.layout.description": {
-    "message": "The Cardano Ambassador Program recognizes community leaders who educate, engage, and raise awareness to drive Cardano's adoption."
+    "message": "Cardanoアンバサダープログラムは、Cardanoの普及を促進するために教育、参加、意識向上を行うコミュニティリーダーを認定します。"
   },
   "ambassadors.cta.leftTitle": {
-    "message": "Become a Cardano Ambassador"
+    "message": "Cardanoアンバサダーになる"
   },
   "ambassadors.cta.leftText1": {
-    "message": "The journey to becoming an Ambassador is built on dedication, collaboration, and meaningful contributions. Ambassadors emerge from the community by actively participating and making a lasting impact."
+    "message": "アンバサダーへの道は、献身、協力、意義ある貢献によって築かれます。アンバサダーは積極的に参加し、持続的な影響を生み出すことでコミュニティから自然に現れます。"
   },
   "ambassadors.cta.leftText2": {
-    "message": "Your first step begins in the Cardano Forum, a dynamic space for collaboration, discussion, and knowledge sharing. By contributing valuable insights, engaging in conversations, and supporting fellow community members, you build a strong foundation of trust and influence. As you progress through different levels, new opportunities for deeper involvement and leadership open up."
+    "message": "最初のステップはCardano Forumから始まります。コラボレーション、ディスカッション、知識共有のためのダイナミックな場です。価値ある洞察を貢献し、会話に参加し、仲間のコミュニティメンバーをサポートすることで、信頼と影響力の強固な基盤を築きます。レベルが上がるにつれ、より深い関与とリーダーシップの新しい機会が開かれます。"
   },
   "ambassadors.cta.leftText3": {
-    "message": "Ambassadorship is a reflection of commitment and contribution. Those who actively support the community and help Cardano grow naturally step into this role."
+    "message": "アンバサダーシップは、コミットメントと貢献の反映です。コミュニティを積極的にサポートし、Cardanoの成長に貢献する人が自然とこの役割に就きます。"
   },
   "ambassadors.cta.rightButtonLabel": {
-    "message": "Get Started"
+    "message": "はじめる"
   },
   "brandAssets.hero.title": {
-    "message": "Brand Assets"
+    "message": "ブランドアセット"
   },
   "brandAssets.hero.description": {
-    "message": "Our brand is a reflection of everything that we create. Here are some of the things that make up our brand and how you can use them."
+    "message": "ブランドは、私たちが創り出すすべてを映し出すものです。ブランドを構成する要素と、その使用方法をご紹介します。"
   },
   "brandAssets.layout.title": {
-    "message": "Cardano Brand Assets, Logos and Guidelines"
+    "message": "Brand Assets | cardano.org"
   },
   "brandAssets.layout.description": {
-    "message": "Our brand is a reflection of everything that we create. Here are some of the things that make up our brand and how you can use them."
+    "message": "ブランドは、私たちが創り出すすべてを映し出すものです。ブランドを構成する要素と、その使用方法をご紹介します。"
   },
   "codeOfConduct.hero.title": {
-    "message": "Community Code Of Conduct"
+    "message": "コミュニティ行動規範"
   },
   "codeOfConduct.hero.description": {
-    "message": "The Cardano community consists of people from all over the world, who have come together to grow and safeguard the spirit and the future of Cardano."
+    "message": "Cardanoコミュニティは世界中の人々で構成されており、Cardanoの精神と未来を守り育てるために集まっています。"
   },
   "codeOfConduct.layout.title": {
-    "message": "Cardano Community Code of Conduct"
+    "message": "Community Code of Conduct | cardano.org"
   },
   "codeOfConduct.layout.description": {
-    "message": "The Cardano community consists of people from all over the world, who have come together to grow and safeguard the spirit and the future of Cardano."
+    "message": "Cardanoコミュニティは世界中の人々で構成されており、Cardanoの精神と未来を守り育てるために集まっています。"
   },
   "codeOfConduct.intro.description": {
-    "message": "The Cardano community consists of people from all over the world, who have come together to grow and safeguard the spirit and the future of Cardano. All participants in the community are expected to act lawfully, honestly, ethically and in the best interest of the project. This Code of Conduct offers rules and guidelines designed to aid judgment within our community and keep it a clean and well-lighted place for civilised public discourse about the project. By joining and participating in any of the official Cardano community channels, you confirm that you agree to be bound by the Code of Conduct."
+    "message": "Cardanoコミュニティは世界中の人々で構成されており、Cardanoの精神と未来を守り育てるために集まっています。コミュニティのすべての参加者は、合法的、誠実、倫理的に、プロジェクトの最善の利益のために行動することが求められます。この行動規範は、コミュニティ内の判断を助け、プロジェクトについての文明的な公開議論の場を清潔で明るく保つためのルールとガイドラインを提供します。公式のCardanoコミュニティチャンネルに参加することで、この行動規範に同意したものとみなされます。"
   },
   "codeOfConduct.improveDiscussion.title": {
-    "message": "Improve the discussion"
+    "message": "議論を改善する"
   },
   "codeOfConduct.improveDiscussion.description1": {
-    "message": "Help us make the community a great place for discussion by always working to improve the discussion in some way, however small. If you are not sure your post adds to the conversation, think over what you want to say and try again later. The topics discussed in the community matter to us, and we want you to act as if they matter to you, too. Be respectful of the topics and the people discussing them, even if you disagree with some of what is being said."
+    "message": "常に何らかの形で議論を改善することに努め、コミュニティを素晴らしいディスカッションの場にしましょう。投稿が会話に貢献するか確信が持てない場合は、言いたいことをよく考えて後で再試行してください。コミュニティで議論されるトピックは私たちにとって重要であり、あなたにとっても同様であってほしいと思います。"
   },
   "codeOfConduct.improveDiscussion.description2": {
-    "message": "One way to improve the discussion is by discovering ones that are already happening. Spend some time to search the community platform before replying and you'll have a better chance of meeting others who share your interests. Always look to add value. Discussion should be healthy and informative and members should provide meaningful contribution towards the development of Cardano. This means any content shared or uploaded online should be relevant to the community. Please also refrain from posting or spread misinformation or fake news that attempt to create fear or doubt."
+    "message": "議論を改善する一つの方法は、すでに進行中のものを発見することです。返信する前にコミュニティプラットフォームを検索する時間を取れば、同じ興味を持つ人に出会える可能性が高まります。常に価値を付加しましょう。議論は健全で有益であるべきで、メンバーはCardanoの発展に向けた意味のある貢献をすべきです。投稿されるコンテンツはコミュニティに関連するものにしてください。また、恐怖や疑念を煽る誤情報やフェイクニュースの投稿や拡散は控えてください。"
   },
   "codeOfConduct.improveDiscussion.description3": {
-    "message": "We also do not allow trading or shilling of ada or any other tokens, goods or services."
+    "message": "ADAやその他のトークン、商品、サービスの取引や宣伝も許可されていません。"
   },
   "codeOfConduct.beAgreeable.title": {
-    "message": "Be agreeable, even when you disagree"
+    "message": "意見が合わなくても礼儀正しく"
   },
   "codeOfConduct.beAgreeable.description1": {
-    "message": "You may wish to respond to something by disagreeing with it. That's fine. But remember to criticise ideas, not people. Please avoid:"
+    "message": "何かに反対意見を述べたいこともあるでしょう。それは構いません。ただし、人ではなくアイデアを批判してください。以下のことは避けてください："
   },
   "codeOfConduct.beAgreeable.list1": {
-    "message": "Name-calling"
+    "message": "個人攻撃"
   },
   "codeOfConduct.beAgreeable.list2": {
-    "message": "Ad hominem attacks"
+    "message": "人身攻撃"
   },
   "codeOfConduct.beAgreeable.list3": {
-    "message": "Responding to a post's tone instead of its actual content"
+    "message": "投稿の内容ではなくトーンに反応すること"
   },
   "codeOfConduct.beAgreeable.list4": {
-    "message": "Knee-jerk reaction"
+    "message": "感情的な反射反応"
   },
   "codeOfConduct.beAgreeable.list5": {
-    "message": "Caps Lock. We consider this as electronic shouting"
+    "message": "全角大文字の使用。電子的な叫びとみなされます"
   },
   "codeOfConduct.beAgreeable.description2": {
-    "message": "Instead, provide reasoned counter-arguments that improve the conversation. Please also remember the rule above to add value and meaningful discussion. The Cardano community channels should not be used for personal disputes between community members."
+    "message": "代わりに、会話を改善する理にかなった反論を提供してください。価値のある意味のある議論を加えるという上記のルールも覚えておいてください。Cardanoコミュニティチャンネルは、コミュニティメンバー間の個人的な紛争に使用すべきではありません。"
   },
   "codeOfConduct.participation.title": {
-    "message": "Your participation counts"
+    "message": "あなたの参加が大切"
   },
   "codeOfConduct.participation.description": {
-    "message": "The conversations we have in the community sets the tone for every new arrival. Help us influence the future of this community by choosing to engage in discussions that make this forum an interesting place to be --- and avoiding those that do not."
+    "message": "コミュニティでの会話が、新しく参加する人すべてのトーンを決定します。このフォーラムを興味深い場所にするディスカッションに参加し、そうでないものは避けることで、コミュニティの未来に影響を与えましょう。"
   },
   "codeOfConduct.reportProblem.title": {
-    "message": "If you see a problem, report it"
+    "message": "問題を見つけたら報告を"
   },
   "codeOfConduct.reportProblem.description1": {
-    "message": "Moderators have special authority within the community; they are responsible for ensuring members adhere to this conduct. But so are you. With your help, moderators can be community facilitators. When you see bad behaviour, don't reply. It encourages the bad behaviour by acknowledging it, consumes your energy, and wastes everyone's time. Just report it! Below are specific instructions on how to report violations in each channel."
+    "message": "モデレーターはコミュニティ内で特別な権限を持ち、メンバーがこの行動規範を守ることを確認する責任があります。しかし、あなたもそうです。あなたの協力があれば、モデレーターはコミュニティのファシリテーターになれます。悪い行動を見たら、返信しないでください。返信は悪い行動を認めることになり、あなたのエネルギーを消費し、皆の時間を無駄にします。報告してください！各チャンネルでの違反報告の具体的な方法を以下に示します。"
   },
   "codeOfConduct.reportProblem.list1": {
-    "message": "[Cardano Forum](https://forum.cardano.org): if you see a post that you think violates the Cardano Community Code of Conduct, click the options button and flag it as inappropriate or leave a more detailed message for the moderators."
+    "message": "[Cardano Forum](https://forum.cardano.org)：行動規範に違反していると思う投稿を見つけたら、オプションボタンをクリックして不適切としてフラグを立てるか、モデレーターへの詳細メッセージを残してください。"
   },
   "codeOfConduct.reportProblem.list2": {
-    "message": "[Reddit](https://www.reddit.com/r/cardano): you can report any post in Reddit by clicking on the 'Report' button underneath all posts. You are required to provide further information as to which rules or laws the post infringes. Reddit moderators will then review your request."
+    "message": "[Reddit](https://www.reddit.com/r/cardano)：すべての投稿の下にある「Report」ボタンをクリックして報告できます。どのルールや法律に違反しているかの詳細情報を提供する必要があります。Redditモデレーターがリクエストを確認します。"
   },
   "codeOfConduct.reportProblem.list3": {
-    "message": "[Telegram](https://t.me/CardanoAnnouncements): any message can be reported by right clicking on it. This will go to the platform. There is also a [Report to Admin](https://t.me/CardanoReportToAdmin) channel, specifically for reporting offensive content or abusive users. You can also forward any messages in violation of the code in a DM to any of our admins."
+    "message": "[Telegram](https://t.me/CardanoAnnouncements)：メッセージを右クリックして報告できます。これはプラットフォームに送信されます。攻撃的なコンテンツや悪質なユーザーを報告するための[Report to Admin](https://t.me/CardanoReportToAdmin)チャンネルもあります。違反メッセージを管理者にDMで転送することもできます。"
   },
   "codeOfConduct.reportProblem.list4": {
-    "message": "[Facebook](https://www.facebook.com/groups/CardanoCommunity): you can report any post in our Facebook group by clicking the arrow in the top right corner of the post and selecting Report. This alerts the moderators and admins to review."
+    "message": "[Facebook](https://www.facebook.com/groups/CardanoCommunity)：投稿の右上の矢印をクリックして「Report」を選択すると報告できます。これにより、モデレーターと管理者にレビューが通知されます。"
   },
   "codeOfConduct.reportProblem.list5": {
-    "message": "[Twitter](https://twitter.com/cardano): you can report any tweet directly to Twitter by clicking on the drop down menu on the tweet itself. Please note that reports on tweets will go directly to Twitter and not the Cardano moderating team."
+    "message": "[Twitter](https://twitter.com/cardano)：ツイートのドロップダウンメニューをクリックして直接Twitterに報告できます。ツイートの報告はCardanoモデレーションチームではなくTwitterに直接送信されます。"
   },
   "codeOfConduct.reportProblem.description2": {
-    "message": "In order to maintain our community, moderators reserve the right to remove any content and any user account for any reason at any time. Moderators do not preview new posts; the moderators and site operators take no responsibility for any content posted by the community."
+    "message": "コミュニティを維持するために、モデレーターはいつでも理由を問わずコンテンツやユーザーアカウントを削除する権利を有します。モデレーターは新しい投稿をプレビューしません。モデレーターとサイト運営者は、コミュニティが投稿したコンテンツに対して一切の責任を負いません。"
   },
   "codeOfConduct.reportProblem.description3": {
-    "message": "And on the other hand, if you feel your content has been inaccurately removed, the Community team can perform a secondary review. Please provide details of your post to community *at* cardano *dot* org. Please be aware that escalating to secondary review should only be for serious concerns and it may take some time for the community team to respond."
+    "message": "一方、コンテンツが不正確に削除されたと感じる場合は、コミュニティチームがセカンドレビューを行うことができます。投稿の詳細をcommunity *at* cardano *dot* orgにお送りください。セカンドレビューへのエスカレーションは重大な懸念のみに限り、コミュニティチームの返答には時間がかかる場合があります。"
   },
   "codeOfConduct.beCivil.title": {
-    "message": "Always be civil"
+    "message": "常に礼儀正しく"
   },
   "codeOfConduct.beCivil.description1": {
-    "message": "Nothing sabotages a healthy conversation like rudeness:"
+    "message": "健全な会話を台無しにするものはありません。無礼な振る舞いほど："
   },
   "codeOfConduct.beCivil.list1": {
-    "message": "Be civil. Don't post anything that a reasonable person would consider offensive, abusive, or hate speech."
+    "message": "礼儀正しくしましょう。合理的な人が不快、侮辱的、またはヘイトスピーチと見なすような投稿はしないでください。"
   },
   "codeOfConduct.beCivil.list2": {
-    "message": "Keep it clean. Don't post anything obscene or sexually explicit."
+    "message": "清潔に保ちましょう。わいせつまたは性的に露骨なものは投稿しないでください。"
   },
   "codeOfConduct.beCivil.list3": {
-    "message": "Respect each other. Don't harass or grief anyone, impersonate people, or expose their private information."
+    "message": "互いを尊重しましょう。嫌がらせや攻撃をしたり、なりすましたり、個人情報を公開したりしないでください。"
   },
   "codeOfConduct.beCivil.list4": {
-    "message": "Respect our community. Don't post spam or otherwise vandalise the forum."
+    "message": "コミュニティを尊重しましょう。スパムの投稿やフォーラムの破壊行為はしないでください。"
   },
   "codeOfConduct.beCivil.list5": {
-    "message": "We take harassment seriously. Harassment includes offensive verbal comments related to gender, age, sexual orientation, disability, physical appearance, body size, race, religion, but also includes deliberate intimidation, stalking, following, sustained disruption of conversation. Harassment of members, admins or moderators will not be tolerated."
+    "message": "ハラスメントを深刻に受け止めています。ハラスメントには、性別、年齢、性的指向、障害、外見、体型、人種、宗教に関する攻撃的な言葉だけでなく、意図的な脅迫、ストーキング、つきまとい、会話の持続的な妨害も含まれます。メンバー、管理者、モデレーターへのハラスメントは容認されません。"
   },
   "codeOfConduct.beCivil.list6": {
-    "message": "Do not post another community member's personal information including but not limited to name, address, phone number, social-media accounts."
+    "message": "他のコミュニティメンバーの個人情報（名前、住所、電話番号、ソーシャルメディアアカウントを含むがこれに限定されない）を投稿しないでください。"
   },
   "codeOfConduct.beCivil.list7": {
-    "message": "Do not repost removed or deleted information."
+    "message": "削除された情報を再投稿しないでください。"
   },
   "codeOfConduct.beCivil.description2": {
-    "message": "These are not concrete terms with precise definitions --- avoid even the appearance of any of these things. If you're unsure, ask yourself how you would feel if your post was featured on the front page of a global news website. This is a public community, and search engines index these discussions. Keep the language, links, and images safe for family and friends."
+    "message": "これらは正確な定義を持つ具体的な用語ではありません。これらに見えるようなことも避けてください。確信が持てない場合は、自分の投稿が世界的なニュースサイトのトップページに掲載されたらどう感じるか考えてみてください。これは公開コミュニティであり、検索エンジンがこれらの議論をインデックスします。言語、リンク、画像は家族や友人にとっても安全なものにしてください。"
   },
   "codeOfConduct.keepTidy.title": {
-    "message": "Keep it tidy"
+    "message": "整理整頓を心がけて"
   },
   "codeOfConduct.keepTidy.description": {
-    "message": "Make the effort to put things in the right place, so that we can spend more time discussing and less cleaning up. A healthy community requires conversations to be structured and categorized. So:"
+    "message": "物事を適切な場所に置く努力をして、整理ではなくディスカッションにより多くの時間を費やせるようにしましょう。健全なコミュニティには会話が構造化されカテゴリ分けされていることが必要です。だから："
   },
   "codeOfConduct.keepTidy.list1": {
-    "message": "Don't start a conversation in the wrong category or channel."
+    "message": "間違ったカテゴリやチャンネルで会話を始めないでください。"
   },
   "codeOfConduct.keepTidy.list2": {
-    "message": "Don't cross-post the same thing in multiple channels."
+    "message": "同じ内容を複数のチャンネルにクロスポストしないでください。"
   },
   "codeOfConduct.postOwnStuff.title": {
-    "message": "Post only your own stuff"
+    "message": "自分のコンテンツだけを投稿"
   },
   "codeOfConduct.postOwnStuff.description": {
-    "message": "You may not post anything digital that belongs to someone else without permission. You may not post descriptions of, links to, or methods for stealing someone's intellectual property (software, video, audio, images), or for breaking any other law. Credit should always be attributed back to the original content producer."
+    "message": "他人のものを許可なくデジタルで投稿することはできません。知的財産（ソフトウェア、動画、音声、画像）の窃取方法やその他の法律違反の方法の説明、リンク、手段を投稿することはできません。クレジットは常に元のコンテンツ制作者に帰属させるべきです。"
   },
   "codeOfConduct.multipleAccounts.title": {
-    "message": "Multiple Accounts"
+    "message": "複数アカウント"
   },
   "codeOfConduct.multipleAccounts.description": {
-    "message": "Multiple accounts by the same user will not be allowed. This helps foster a more human experience in the online world and restricts spamming. Note that duplicate accounts may be investigated and removed."
+    "message": "同一ユーザーによる複数アカウントは許可されません。これにより、オンラインの世界でより人間的な体験が促進され、スパムが制限されます。重複アカウントは調査され、削除される場合があります。"
   },
   "codeOfConduct.violation.title": {
-    "message": "Violation of rules"
+    "message": "ルール違反"
   },
   "codeOfConduct.violation.description1": {
-    "message": "If any of the rules are broken, moderators will perform the following sanctions:"
+    "message": "ルールに違反した場合、モデレーターは以下の制裁を行います："
   },
   "codeOfConduct.violation.list1": {
-    "message": "First offence: warning is given and the user will be suspended from their account for 24 hours."
+    "message": "初回：警告が与えられ、24時間アカウントが停止されます。"
   },
   "codeOfConduct.violation.list2": {
-    "message": "Second offence: warning is given and the user will be suspended for a period of up to 1 month depending on the severity of the violation."
+    "message": "2回目：警告が与えられ、違反の深刻さに応じて最大1か月間アカウントが停止されます。"
   },
   "codeOfConduct.violation.list3": {
-    "message": "Third and final offence: if the user continues to repeatedly break community rules, their account will be banned from the community platform. This penalty may be applied across all community channels if necessary."
+    "message": "3回目（最終）：コミュニティルールに繰り返し違反し続ける場合、コミュニティプラットフォームからアカウントが永久追放されます。必要に応じて、すべてのコミュニティチャンネルにこのペナルティが適用される場合があります。"
   },
   "codeOfConduct.violation.description2": {
-    "message": "The community team reserves the right to deny access to the official Community channels to anyone who has violated the Cardano Community Code of Conduct."
+    "message": "コミュニティチームは、Cardanoコミュニティ行動規範に違反した人の公式コミュニティチャンネルへのアクセスを拒否する権利を有します。"
   },
   "codeOfConduct.poweredByYou.title": {
-    "message": "Powered by you"
+    "message": "あなたの力で"
   },
   "codeOfConduct.poweredByYou.description": {
-    "message": "This community is operated by the community staff and you, the community. If you have any further questions about how things should work here, open a new topic in the [community feedback category](https://forum.cardano.org/c/english/community-feedback/16) of the forum and let's discuss! If there is ever a critical or urgent issue please contact us directly at community *at* cardano *dot* org."
+    "message": "このコミュニティはコミュニティスタッフとあなた、コミュニティによって運営されています。ここでの運営方法についてさらに質問がある場合は、フォーラムの[コミュニティフィードバックカテゴリ](https://forum.cardano.org/c/english/community-feedback/16)で新しいトピックを開いて議論しましょう！重要または緊急の問題がある場合は、community *at* cardano *dot* orgに直接ご連絡ください。"
   },
   "constitution.error.title": {
-    "message": "Current Enacted Constitution"
+    "message": "現在制定されている憲法"
   },
   "constitution.error.localCopy": {
-    "message": "(Local Copy)"
+    "message": "（ローカルコピー）"
   },
   "constitution.error.fetchError": {
-    "message": "Could not fetch from data.cardano.org:"
+    "message": "data.cardano.orgから取得できませんでした："
   },
   "constitution.error.showingLocal": {
-    "message": "Showing local copy below."
+    "message": "以下にローカルコピーを表示します。"
   },
   "constitution.link.download": {
-    "message": "Download Constitution"
+    "message": "憲法をダウンロード"
   },
   "constitution.link.viewRawMarkdown": {
-    "message": "View Raw Markdown"
+    "message": "Raw Markdownを表示"
   },
   "constitution.loading.versions": {
-    "message": "Loading constitution versions..."
+    "message": "憲法バージョンを読み込み中..."
   },
   "constitution.enacted.title": {
-    "message": "Current Enacted Cardano Constitution"
+    "message": "現在制定されているCardano憲法"
   },
   "constitution.enacted.description": {
-    "message": "Discover the Cardano Constitution: the governance framework of the Cardano blockchain. Read the current enacted charter, explore its ratification history, and download the full text via IPFS."
+    "message": "Cardano憲法を探索しましょう：Cardanoブロックチェーンのガバナンスフレームワーク。現在制定されている憲章を読み、批准の経緯をたどり、IPFS経由で全文をダウンロードできます。"
   },
   "constitution.link.viewOnIPFS": {
-    "message": "View on IPFS"
+    "message": "IPFSで表示"
   },
   "constitution.error.loadDocument": {
-    "message": "Could not load constitution document:"
+    "message": "憲法ドキュメントを読み込めませんでした："
   },
   "constitution.loading.document": {
-    "message": "Loading document..."
+    "message": "ドキュメントを読み込み中..."
   },
   "constitution.history.title": {
-    "message": "Constitution Ratification History"
+    "message": "憲法批准の履歴"
   },
   "constitution.history.description": {
-    "message": "Below you can find the Cardano Constitution and its ratification history. Click any version to view the full text on IPFS."
+    "message": "以下でCardano憲法とその批准の履歴を確認できます。任意のバージョンをクリックして、IPFS上の全文を表示できます。"
   },
   "constitution.history.versionRatified": {
-    "message": "Version ratified at epoch"
+    "message": "バージョンが批准されたエポック"
   },
   "constitution.history.enactedAtEpoch": {
-    "message": "Enacted at epoch"
+    "message": "制定されたエポック"
   },
   "constitution.history.hash": {
-    "message": "Hash:"
+    "message": "ハッシュ："
   },
   "constitution.link.viewOnIPFSHistory": {
-    "message": "View this constitution on IPFS"
+    "message": "この憲法をIPFSで表示"
   },
   "constitution.hero.title": {
-    "message": "The Cardano Constitution"
+    "message": "Cardano憲法"
   },
   "constitution.hero.description": {
-    "message": "Discover the Cardano Constitution: the governance framework of the Cardano blockchain."
+    "message": "Cardano憲法を知る：Cardanoブロックチェーンのガバナンスフレームワーク。"
   },
   "constitution.layout.title": {
-    "message": "The Cardano Constitution, On-Chain Governance Framework"
+    "message": "The Cardano Constitution | cardano.org"
   },
   "constitution.layout.description": {
-    "message": "Discover the Cardano Constitution: the governance framework of the Cardano blockchain. Read the current enacted charter, explore its ratification history, and download the full text via IPFS."
+    "message": "Cardano憲法を探索しましょう：Cardanoブロックチェーンのガバナンスフレームワーク。現在制定されている憲章を読み、批准の経緯をたどり、IPFS経由で全文をダウンロードできます。"
   },
   "contact.hero.title": {
-    "message": "Contact"
+    "message": "Contact | cardano.org"
   },
   "contact.hero.description": {
-    "message": "Cardano is supported by the Cardano Foundation, IOG, EMURGO, Intersect, PRAGMA and others. Fill out the contact form below and we will put you in touch with the team best placed to assist you."
+    "message": "CardanoはCardano Foundation、IOG、EMURGO、Intersect、PRAGMAなどによって支えられています。以下のフォームにご記入いただければ、最適なチームをご紹介します。"
   },
   "contact.intersect.title": {
-    "message": "Intersect - one of the member-based organizations"
+    "message": "Intersect - メンバーベースの組織"
   },
   "contact.intersect.description": {
-    "message": "Intersect is a member-based organization for the Cardano ecosystem tasked with ensuring its continuity and future development."
+    "message": "Intersectは、Cardanoエコシステムの継続と将来の発展を担うメンバーベースの組織です。"
   },
   "contact.intersect.buttonLabel": {
-    "message": "Join Intersect"
+    "message": "Intersectに参加"
   },
   "contact.technicalIssue.title": {
-    "message": "Report a technical issue"
+    "message": "技術的な問題を報告"
   },
   "contact.technicalIssue.description": {
-    "message": "To get help for one of the following wallets, please raise a support ticket."
+    "message": "以下のウォレットに関するサポートが必要な場合は、サポートチケットを作成してください。"
   },
   "contact.technicalIssue.buttonLabel": {
-    "message": "Raise Ticket"
+    "message": "チケットを作成"
   },
   "contact.sponsorship.title": {
-    "message": "Cardano Summit Sponsorship"
+    "message": "Cardano Summitスポンサーシップ"
   },
   "contact.sponsorship.description1": {
-    "message": "Thank you for your interest in sponsoring our annual Cardano Summit! Your support is crucial to the success of our summit, and we're excited about the possibility of partnering with you. Sponsorship opportunities provide significant exposure and can be tailored to meet your organization's needs and goals."
+    "message": "年次Cardano Summitのスポンサーシップにご関心をお寄せいただきありがとうございます。サミットの成功にはご支援が不可欠です。スポンサーシップの機会は大きな露出を提供し、組織のニーズや目標に合わせてカスタマイズできます。"
   },
   "contact.sponsorship.description2": {
-    "message": "Please fill out the form below to express your interest and provide us with more details about your organization and sponsorship preferences. Our team will review your submission and get in touch with you to discuss potential sponsorship packages and how we can best collaborate for the upcoming event."
+    "message": "以下のフォームにご記入いただき、ご関心をお寄せください。組織情報とスポンサーシップの希望をお知らせいただければ、チームが確認の上、スポンサーシップパッケージと最適な連携方法についてご連絡いたします。"
   },
   "contact.sponsorship.buttonLabel": {
-    "message": "Sponsorship Request"
+    "message": "スポンサーシップ申請"
   },
   "contact.meta.title": {
-    "message": "Contact Cardano, Get in Touch"
+    "message": "Cardano - making the world work better for all"
   },
   "contact.meta.description": {
-    "message": "Get in touch with the Cardano ecosystem. Reach the Cardano Foundation, Intersect, IOG, or EMURGO for partnerships, support, or sponsorship inquiries."
+    "message": "An open platform designed to empower billions without economic identity by offering decentralized applications for managing identity, value, and governance."
   },
   "contact.divider.hereToHelp": {
-    "message": "Here to help"
+    "message": "お力になります"
   },
   "contact.helpSection.title": {
-    "message": "What Can We Help You With?"
+    "message": "何かお手伝いできることはありますか？"
   },
   "contact.select.prefix": {
-    "message": "I have"
+    "message": "私は"
   },
   "contact.select.placeholder": {
-    "message": "not yet decided (please select)"
+    "message": "まだ選択していません（選択してください）"
   },
   "contact.select.option.technicalIssue": {
-    "message": "a technical issue with Daedalus, Nami or Lace"
+    "message": "Daedalus、Nami、Laceに技術的な問題がある"
   },
   "contact.select.option.intersect": {
-    "message": "the intention to join Intersect"
+    "message": "Intersectに参加したい"
   },
   "contact.select.option.sponsor": {
-    "message": "the desire to sponsor the Cardano Summit"
+    "message": "Cardano Summitのスポンサーになりたい"
   },
   "contact.select.option.different": {
-    "message": "another inquiry"
+    "message": "その他のお問い合わせ"
   },
   "artworkContest.hero.title": {
     "message": "Making the World Work Better for All"
   },
   "artworkContest.hero.description": {
-    "message": "Cardano is a blockchain platform for changemakers, innovators, and visionaries, with the tools and technologies required to create possibility for the many, as well as the few, and bring about positive global change."
+    "message": "Cardanoは変革者、イノベーター、ビジョナリーのためのブロックチェーンプラットフォームです。多くの人、そして少数の人にも可能性を生み出し、ポジティブなグローバル変化をもたらすためのツールとテクノロジーを備えています。"
   },
   "artworkContest.imagePreview.alt": {
-    "message": "Preview"
+    "message": "プレビュー"
   },
   "artworkContest.layout.title": {
-    "message": "Cardano Artwork Contest"
+    "message": "Home | cardano.org"
   },
   "artworkContest.layout.description": {
-    "message": "An open platform designed to empower billions without economic identity by offering decentralized applications for managing identity, value, and governance."
+    "message": "経済的アイデンティティを持たない数十億の人々に力を与えるために設計されたオープンプラットフォーム。アイデンティティ、価値、ガバナンスを管理するための分散型アプリケーションを提供します。"
   },
   "artworkContest.content.title": {
-    "message": "Artwork Contest Test Page"
+    "message": "アートワークコンテスト テストページ"
   },
   "artworkContest.content.description1": {
-    "message": "Upload your image here to see how it would look like."
+    "message": "ここに画像をアップロードして、どのように表示されるか確認しましょう。"
   },
   "artworkContest.content.description2": {
-    "message": "Toggle dark mode and resize the browser to see how it adapts."
+    "message": "ダークモードに切り替えたりブラウザのサイズを変更して、適応の仕方を確認できます。"
   },
   "artworkContest.content.quote1": {
-    "message": "Image will not be submitted,"
+    "message": "画像は送信されません。"
   },
   "artworkContest.content.quote2": {
-    "message": "This happens on your machine only"
+    "message": "すべてはあなたのマシン上でのみ行われます"
   },
   "developers.hero.title": {
-    "message": "Start Building on Cardano"
+    "message": "Cardanoで開発を始めよう"
   },
   "developers.hero.description": {
-    "message": "A curated list of resources and entry points to help you get started with building on Cardano."
+    "message": "Cardano上での開発を始めるためのリソースとエントリーポイントを厳選しました。"
   },
   "developers.meta.title": {
-    "message": "Build on Cardano, Developer Tools and Documentation"
+    "message": "Start Building on Cardano | cardano.org"
   },
   "developers.meta.description": {
-    "message": "Start building on Cardano. Access developer tools, smart contract languages, APIs, testnets, and tutorials to launch your first decentralized application."
+    "message": "A curated list of resources and entry points to help you get started with building on Cardano."
   },
   "developers.divider.resources": {
-    "message": "Developer Resources"
+    "message": "開発者リソース"
   },
   "developers.documentation.title": {
-    "message": "Documentation"
+    "message": "ドキュメント"
   },
   "developers.documentation.text": {
-    "message": "Access the essential resources and updates you need to build, integrate, and stay informed about the Cardano blockchain. Below you'll find links to the developer portal, detailed documentation, integration guides, and the latest core development updates."
+    "message": "Cardanoブロックチェーンの構築、統合、最新情報の入手に必要な基本リソースとアップデートにアクセスしましょう。以下には、開発者ポータル、詳細なドキュメント、統合ガイド、最新のコア開発アップデートへのリンクがあります。"
   },
   "developers.tools.title": {
-    "message": "Developer Tools"
+    "message": "開発者ツール"
   },
   "developers.tools.text": {
-    "message": "Explore the tools, projects, and updates that are shaping the Cardano ecosystem. Below you'll find links to builder tools, a showcase of projects built on Cardano, and a technical updates tracker that aggregates commits within the last 7 days from all branches of Cardano development-related repos."
+    "message": "Cardanoエコシステムを形作るツール、プロジェクト、アップデートを探索しましょう。以下には、ビルダーツール、Cardano上に構築されたプロジェクトのショーケース、過去7日間のCardano開発関連リポジトリの全ブランチからコミットを集約した技術アップデートトラッカーへのリンクがあります。"
   },
   "developers.support.title": {
-    "message": "Support"
+    "message": "サポート"
   },
   "developers.support.text": {
-    "message": "Join the vibrant Cardano developer community through various platforms. Below you'll find links to the Cardano Stack Exchange, the Cardano Forum, and the official Telegram group. Connect with fellow developers, ask questions, and share insights in our decentralized ecosystem."
+    "message": "さまざまなプラットフォームを通じて、活気あるCardano開発者コミュニティに参加しましょう。以下には、Cardano Stack Exchange、Cardano Forum、公式Telegramグループへのリンクがあります。分散型エコシステムで仲間の開発者とつながり、質問し、知見を共有しましょう。"
   },
   "developers.cta.title": {
-    "message": "Attack the protocol, fork the blockchain - or not. Explore the Ouroboros protocol firsthand in this interactive simulation."
+    "message": "プロトコルを攻撃するか、ブロックチェーンをフォークするか。このインタラクティブシミュレーションでOuroborosプロトコルを直接体験しましょう。"
   },
   "developers.cta.buttonLabel": {
-    "message": "Play the game"
+    "message": "ゲームをプレイ"
   },
   "discoverCardano.hero.title": {
-    "message": "Discover Cardano"
+    "message": "Cardanoを知る"
   },
   "discoverCardano.hero.description": {
-    "message": "Cardano is the nexus of five principles: People, purpose, technology, research, and opportunity. Explore and learn this new constellation of knowledge."
+    "message": "Cardanoは5つの原則を結びつけます：人、目的、テクノロジー、研究、機会。この新しい知の星座を探索し、学びましょう。"
   },
   "discoverCardano.meta.title": {
-    "message": "What Is Cardano, Blockchain Built for Sustainability"
+    "message": "Discover Cardano | cardano.org"
   },
   "discoverCardano.meta.description": {
-    "message": "Discover what makes Cardano different. Built on peer-reviewed science, powered by a global community, and designed for a sustainable, decentralized future."
+    "message": "Cardano is the nexus of five principles: People, purpose, technology, research, and opportunity. Explore and learn this new constellation of knowledge."
   },
   "discoverCardano.people.title": {
-    "message": "People"
+    "message": "人"
   },
   "discoverCardano.people.subtitle": {
-    "message": "Working together, we achieve more for the many."
+    "message": "共に歩めば、より多くの人のために、より多くを実現できる。"
   },
   "discoverCardano.people.text1": {
-    "message": "Cardano is built by a decentralized community of scientists, engineers, and thought leaders united in a common purpose: to create a technology platform that will ignite the positive change the world needs. We believe the future should not be defined by the past, and that more is possible - and, through technology, can be made possible for all. We measure the worth of a task not by its challenge, but by its results."
+    "message": "Cardanoは、科学者、エンジニア、思想的リーダーの分散型コミュニティによって構築されています。共通の目的のもとに集結した彼らは、世界が必要とするポジティブな変化を起こすテクノロジープラットフォームを創造しています。未来は過去に縛られるべきではなく、テクノロジーを通じてすべての人により多くの可能性を開くことができると信じています。"
   },
   "discoverCardano.people.text2": {
-    "message": "Every ada holder also holds a stake in the Cardano network. Ada stored in a wallet can be delegated to a stake pool to earn rewards – to participate in the successful running of the network – or pledged to a stake pool to increase the pool's likelihood of receiving rewards. In time, ada will also be usable for a variety of applications and services on the Cardano platform."
+    "message": "すべてのADA保有者はCardanoネットワークにステークを持っています。ウォレットに保管されたADAは、ステークプールに委任して報酬を得たり、ステークプールに誓約して報酬獲得の確率を高めたりできます。将来的には、Cardanoプラットフォーム上のさまざまなアプリケーションやサービスにもADAが利用できるようになります。"
   },
   "discoverCardano.purpose.title": {
-    "message": "Purpose"
+    "message": "目的"
   },
   "discoverCardano.purpose.subtitle": {
-    "message": "A platform built for a sustainable future, to help people work better together, trust one another, and build global solutions to global problems."
+    "message": "持続可能な未来のために構築されたプラットフォーム。人々がより良く協力し、互いを信頼し、グローバルな課題にグローバルな解決策を生み出すために。"
   },
   "discoverCardano.purpose.text1": {
-    "message": "Cardano is a fork in the road. It takes us from where we've been to where we're destined to go: a global society that is secure, transparent, and fair, and which serves the many as well as the few. Like the technological revolutions that have come before, it offers a new template for how we work, interact, and create, as individuals, businesses, and societies."
+    "message": "Cardanoは分岐点です。私たちがいた場所から、向かうべき場所へと導きます。それは安全で透明、公正なグローバル社会であり、少数だけでなく多くの人に奉仕する社会です。かつての技術革命と同様に、個人、企業、社会として働き、交流し、創造する方法の新たなテンプレートを提示します。"
   },
   "discoverCardano.purpose.text2": {
-    "message": "Cardano began with a vision of a world without intermediaries, in which power is not controlled by an accountable few, but by the empowered many. In this world, individuals have control over their data and how they interact and transact. Businesses have the opportunity to grow independent of monopolistic and bureaucratic power structures. Societies are able to pursue true democracy: self-governing, fair, and accountable. It is a world made possible by Cardano."
+    "message": "Cardanoは仲介者のいない世界というビジョンから始まりました。権力が説明責任を負わない少数者に集中するのではなく、力を与えられた多数が持つ世界です。個人が自分のデータとやり取りの方法をコントロールし、企業が独占的で官僚的な権力構造から独立して成長でき、社会が真の民主主義を追求できる世界です。それがCardanoによって可能になる世界です。"
   },
   "discoverCardano.technology.title": {
-    "message": "Technology"
+    "message": "テクノロジー"
   },
   "discoverCardano.technology.subtitle": {
-    "message": "Cardano brings a new standard in technology - open and inclusive – to challenge the old and activate a new age of sustainable, globally-distributed innovation."
+    "message": "Cardanoはテクノロジーに新しい基準をもたらします。オープンで包括的な基準が旧来のものに挑戦し、持続可能でグローバルに分散されたイノベーションの新時代を切り開きます。"
   },
   "discoverCardano.technology.text1": {
-    "message": "From the incremental to global, Cardano improves how we interact, transact, and create - and ultimately operate as a global society."
+    "message": "小さなことからグローバルなことまで、Cardanoは私たちのやり取り、取引、創造の方法を改善し、最終的にはグローバル社会としての運営方法を変革します。"
   },
   "discoverCardano.technology.text2": {
-    "message": "Cardano is a blockchain platform built on the groundbreaking Ouroboros proof-of-stake consensus protocol, and developed using the Haskell programming language: a functional programming language that enables Cardano to pursue evidence-based development, for unparalleled security and stability."
+    "message": "Cardanoは、画期的なOuroboros プルーフ・オブ・ステーク・コンセンサスプロトコル上に構築され、Haskellプログラミング言語で開発されたブロックチェーンプラットフォームです。関数型プログラミング言語であるHaskellにより、Cardanoはエビデンスに基づく開発を追求し、比類のないセキュリティと安定性を実現しています。"
   },
   "discoverCardano.technology.text3": {
-    "message": "Our technology is underpinned by [research](/research). We have redefined what it means to create a global software platform through scientific methods. We have not compromised on our belief, or in our approach. To build a better future - secure, sustainable, and governable by the many - we have taken the road less traveled. The result of our efforts is a blockchain platform unparalleled in its capability and performance, and which is truly able to support global applications, systems, and real-life business use cases."
+    "message": "私たちのテクノロジーは[研究](/research)に支えられています。科学的手法によるグローバルソフトウェアプラットフォームの構築において、その意味を再定義してきました。安全で持続可能で多くの人が統治できる、より良い未来を築くために、私たちはあえて困難な道を選びました。その結果、能力とパフォーマンスにおいて比類のないブロックチェーンプラットフォームが誕生し、真にグローバルなアプリケーション、システム、実際のビジネスユースケースをサポートできるようになりました。"
   },
   "discoverCardano.research.title": {
-    "message": "Research"
+    "message": "研究"
   },
   "discoverCardano.research.subtitle": {
-    "message": "Pioneering tech begins with groundbreaking research."
+    "message": "先駆的なテクノロジーは、画期的な研究から始まる。"
   },
   "discoverCardano.research.text1": {
-    "message": "Cardano began with and has grown through [research](/research). Before any technology we integrate is developed, it is specified. And before it is specified, it is researched. That [research](/research) is peer-reviewed - a unique achievement for a blockchain platform - so that our ideas may be challenged before they are validated."
+    "message": "Cardanoは[研究](/research)から始まり、研究を通じて成長してきました。統合するすべてのテクノロジーは、開発される前に仕様化されます。そして仕様化される前に研究されます。その[研究](/research)はピアレビュー（査読）を受けています。これはブロックチェーンプラットフォームとしてユニークな成果であり、アイデアが検証される前に検証が行われます。"
   },
   "discoverCardano.research.text2": {
-    "message": "[Our research](/research) - led by leading academics - explores philosophy, sociology, behavior, and game theory. To achieve each outcome, we consider the minutiae of possibilities: the variables that often go unconsidered, but which may ultimately impact the integrity and sustainability of a global, decentralized platform. We take nothing for granted."
+    "message": "一流の学者が率いる[研究](/research)は、哲学、社会学、行動科学、ゲーム理論を探究しています。各成果を達成するために、私たちは見落とされがちな変数まで考慮します。それはグローバルで分散型のプラットフォームの整合性と持続可能性に最終的に影響を及ぼす可能性があるからです。"
   },
   "discoverCardano.opportunity.title": {
-    "message": "Opportunity"
+    "message": "機会"
   },
   "discoverCardano.opportunity.subtitle": {
-    "message": "The staging point for every new opportunity. Empower your business through Cardano, and discover the future of technology."
+    "message": "あらゆる新しい機会の出発点。Cardanoでビジネスを強化し、テクノロジーの未来を発見しましょう。"
   },
   "discoverCardano.opportunity.text1": {
-    "message": "Cardano provides the template and toolset to a new age of innovation. It introduces leading-edge technologies, models, and methodologies to help individuals, developers, and enterprises discover a new possible, realize change, and enrich their lives.."
+    "message": "Cardanoは新しいイノベーション時代のテンプレートとツールセットを提供します。個人、開発者、企業が新しい可能性を発見し、変化を実現し、生活を豊かにするための最先端のテクノロジー、モデル、方法論を導入します。"
   },
   "discoverCardano.opportunity.text2": {
-    "message": "Blockchain technology holds the answer to a number of legacy challenges, whether financial, societal, or technological. It disintermediates essential relationships, and redistributes power to alleviate costly dependencies, restrictive paradigms, and inefficient systems of transaction and exchange. Cardano is a realization of this potential. It is a platform with the security, privacy sustainability, and performance standards required to accelerate the mass adoption of the technology, and support a lasting ecosystem."
+    "message": "ブロックチェーン技術は、金融、社会、テクノロジーを問わず、多くのレガシーな課題に対する答えを持っています。本質的な関係から仲介者を排除し、高コストな依存関係、制約的なパラダイム、非効率な取引・交換システムを軽減するために権力を再分配します。Cardanoはこの可能性の実現です。大規模な技術採用を加速し、持続的なエコシステムをサポートするために必要なセキュリティ、プライバシー、持続可能性、パフォーマンス基準を備えたプラットフォームです。"
   },
   "discoverCardano.opportunity.text3": {
-    "message": "Cardano powers new, more secure, and globally scalable solutions. Its technology is continuously improved upon through evidence-based development methods, and guided by a democratic voting system, in which every member has a voice. The opportunity of Cardano is adaptable to your use case. It is an opportunity that creates other opportunities, continuously."
+    "message": "Cardanoは新しく、よりセキュアで、グローバルにスケーラブルなソリューションを提供します。テクノロジーはエビデンスに基づく開発手法によって継続的に改善され、すべてのメンバーが発言権を持つ民主的な投票システムによって導かれています。Cardanoの可能性はあなたのユースケースに適応できます。それは新たな機会を絶えず生み出す機会です。"
   },
   "entities.hero.title": {
-    "message": "Entities building on Cardano"
+    "message": "Cardanoを構築する組織"
   },
   "entities.hero.description": {
-    "message": "Numerous independent entities, including companies actively building on Cardano, collaborate to advance the platform and ensure it remains aligned with its mission."
+    "message": "Cardano上で活発に開発を行う企業を含む多数の独立した組織が連携し、プラットフォームの発展とミッションとの整合性を維持しています。"
   },
   "entities.meta.title": {
-    "message": "Organizations Building on Cardano"
+    "message": "Entities building on Cardano | cardano.org"
   },
   "entities.meta.description": {
-    "message": "Numerous independent entities, including companies actively building on Cardano, collaborate to advance the platform and ensure it remains aligned with its mission."
+    "message": "Cardano上で活発に開発を行う企業を含む多数の独立した組織が連携し、プラットフォームの発展とミッションとの整合性を維持しています。"
   },
   "entities.entitiesSection.divider": {
-    "message": "Entities advancing Cardano"
+    "message": "Cardanoを推進する組織"
   },
   "entities.companiesSection.divider": {
-    "message": "Companies, associations, and collaborations building on Cardano"
+    "message": "Cardano上で開発する企業・団体・コラボレーション"
   },
   "entities.companiesSection.description": {
-    "message": "There is a growing number of entities that build on Cardano. Below are a few of them:"
+    "message": "Cardano上で開発を行う組織は増え続けています。以下はその一部です："
   },
   "entities.companiesSection.addCompanyLink": {
-    "message": "add your company"
+    "message": "あなたの会社を追加"
   },
   "events.hero.title": {
-    "message": "Cardano Events"
+    "message": "Cardanoイベント"
   },
   "events.hero.description": {
-    "message": "Upcoming Cardano events in one place, so you never miss a chance to connect, learn, and grow with the Cardano Community."
+    "message": "今後のCardanoイベントをまとめてチェック。コミュニティとつながり、学び、共に成長するチャンスを見逃さないで。"
   },
   "events.pagination.previous": {
-    "message": "Previous"
+    "message": "前へ"
   },
   "events.pagination.next": {
-    "message": "Next"
+    "message": "次へ"
   },
   "events.meta.title": {
-    "message": "Cardano Events, Conferences and Meetups"
+    "message": "Cardano Events | cardano.org"
   },
   "events.meta.description": {
-    "message": "Upcoming Cardano events in one place, so you never miss a chance to connect, learn, and grow with the Cardano Community."
+    "message": "今後のCardanoイベントをまとめてチェック。コミュニティとつながり、学び、共に成長するチャンスを見逃さないで。"
   },
   "events.divider.discoverWorldwide": {
-    "message": "Discover Cardano Events Worldwide"
+    "message": "世界中のCardanoイベントを発見"
   },
   "events.platforms.luma": {
-    "message": "Events on Luma.com"
+    "message": "Luma.comのイベント"
   },
   "events.platforms.meetup": {
-    "message": "Events on Meetup.com"
+    "message": "Meetup.comのイベント"
   },
   "events.divider.upcomingHighlighted": {
-    "message": "Upcoming highlighted Events"
+    "message": "今後の注目イベント"
   },
   "events.divider.pastHighlighted": {
-    "message": "Past Highlighted Events"
+    "message": "過去の注目イベント"
   },
   "events.recapAvailable": {
-    "message": "Recap available:"
+    "message": "まとめあり："
   },
   "events.watchHere": {
-    "message": "Watch here"
+    "message": "こちらで視聴"
   },
   "exchanges.hero.title": {
-    "message": "Integrate Cardano"
+    "message": "Cardanoを統合する"
   },
   "exchanges.hero.description": {
-    "message": "Easy integration with Cardano. All of the upgrades. None of the maintenance."
+    "message": "Cardanoとの簡単な統合。すべてのアップグレード。メンテナンス不要。"
   },
   "exchanges.layout.title": {
-    "message": "Integrate Cardano, Exchange and Wallet Partnerships"
+    "message": "Integrate Cardano | cardano.org"
   },
   "exchanges.layout.description": {
-    "message": "Integrate Cardano into your exchange, wallet, or payment platform. Access documentation, resources, and partnership opportunities for ada support."
+    "message": "Easy integration with Cardano. All of the upgrades. None of the maintenance."
   },
   "exchanges.intro.description": {
-    "message": "There are various [ways to integrate Cardano](https://developers.cardano.org), one of which is Adrestia. The Adrestia team focuses on supporting exchange and developer integrations by providing a wallet SDK and set of APIs that make it easier for developers and exchanges to integrate and interact with Cardano across releases."
+    "message": "Cardanoを[統合する方法](https://developers.cardano.org)はさまざまで、その一つがAdrestiaです。Adrestiaチームは、開発者と取引所がCardanoをリリースをまたいで簡単に統合・操作できるよう、ウォレットSDKとAPIセットを提供し、取引所と開発者の統合をサポートしています。"
   },
   "exchanges.whyAdrestia.divider": {
-    "message": "Why Adrestia?"
+    "message": "なぜAdrestia？"
   },
   "exchanges.whyAdrestia.leftText": {
-    "message": "Blockchains - and especially Cardano - are fast developing. Staying up to date with releases can become a maintenance challenge. We're committed to making it as easy as possible to develop and integrate with Cardano. Through Adrestia, Cardano is adaptable to your systems and requirements."
+    "message": "ブロックチェーン、特にCardanoは急速に進化しています。リリースに追従し続けることはメンテナンスの課題になりえます。Cardanoとの開発と統合をできるだけ簡単にすることに尽力しています。Adrestiaを通じて、Cardanoはあなたのシステムと要件に適応します。"
   },
   "exchanges.whyAdrestia.rightText": {
-    "message": "Improvements to Cardano should not mean greater complexity or resource overhead. We want to innovate and deploy improvements as they're available, and as they become necessary. This might mean a few updates one month, and many the next. Adrestia is a consistent SDK and set of GraphQL APIs that make it easy for developers to create applications and maintain core compatibility and functionality with the Cardano network across releases."
+    "message": "Cardanoの改善が複雑さやリソースオーバーヘッドの増加を意味すべきではありません。利用可能になった改善はすぐに、必要に応じてイノベーションとデプロイを行いたいと考えています。ある月は少数のアップデート、次の月は多数ということもあるでしょう。Adrestiaは一貫したSDKとGraphQL APIセットで、開発者がアプリケーションを作成し、リリースをまたいでCardanoネットワークとのコア互換性と機能性を維持するのを容易にします。"
   },
   "exchanges.cta1.title": {
-    "message": "Focus On What Matters. Leave The Rest To Us."
+    "message": "重要なことに集中を。残りは私たちにお任せください。"
   },
   "exchanges.cta1.buttonLabel": {
-    "message": "Access Adrestia"
+    "message": "Adrestiaにアクセス"
   },
   "exchanges.accessAdrestia.divider": {
-    "message": "Access Adrestia"
+    "message": "Adrestiaにアクセス"
   },
   "exchanges.whatMakesDifferent.title": {
-    "message": "What makes Adrestia different?"
+    "message": "Adrestiaの違いとは？"
   },
   "exchanges.whatMakesDifferent.description1": {
-    "message": "Cardano's architecture is built for modularity and adaptability. Through Adrestia, we're able to save developers and exchanges significant maintenance overhead and, most importantly, time."
+    "message": "Cardanoのアーキテクチャはモジュール性と適応性のために構築されています。Adrestiaを通じて、開発者と取引所のメンテナンスオーバーヘッドを大幅に削減し、最も重要な時間を節約できます。"
   },
   "exchanges.whatMakesDifferent.description2": {
-    "message": "Unlike most blockchain API suites, Adrestia decouples and splits out key services from the core Cardano node. The new SDK and APIs are consistent across releases, which means developers are not required to re-learn the platform with each release. Adrestia offers a host of self-contained services and ways to query, transact, and extract information."
+    "message": "ほとんどのブロックチェーンAPIスイートとは異なり、Adrestiaは主要なサービスをCardanoコアノードから分離・分割します。新しいSDKとAPIはリリース間で一貫しており、開発者は各リリースごとにプラットフォームを学び直す必要がありません。Adrestiaは自己完結型のサービスと、クエリ、トランザクション、情報抽出のさまざまな方法を提供します。"
   },
   "exchanges.benefits.reduceTime.title": {
-    "message": "Reduce Time To Market"
+    "message": "市場投入時間を短縮"
   },
   "exchanges.benefits.reduceTime.text": {
-    "message": "Develop applications for Cardano without worrying about new releases breaking your code."
+    "message": "新しいリリースでコードが壊れる心配なく、Cardano向けアプリケーションを開発できます。"
   },
   "exchanges.benefits.reduceDowntime.title": {
-    "message": "Reduce Downtime"
+    "message": "ダウンタイムを削減"
   },
   "exchanges.benefits.reduceDowntime.text": {
-    "message": "Fewer backward compatibility issues mean significantly reduced downtime."
+    "message": "下位互換性の問題が少ないため、ダウンタイムが大幅に削減されます。"
   },
   "exchanges.benefits.reduceMaintenance.title": {
-    "message": "Reduce Maintenance Costs"
+    "message": "メンテナンスコストを削減"
   },
   "exchanges.benefits.reduceMaintenance.text": {
-    "message": "Spend less time and resources on maintaining application compatibility across releases."
+    "message": "リリース間のアプリケーション互換性の維持にかかる時間とリソースを節約できます。"
   },
   "exchanges.benefits.increaseProductivity.title": {
-    "message": "Increase Productivity"
+    "message": "生産性を向上"
   },
   "exchanges.benefits.increaseProductivity.text": {
-    "message": "Focus on what matters - application and wallet development - and leave the updates to us."
+    "message": "重要なこと（アプリケーションとウォレットの開発）に集中し、アップデートは私たちにお任せください。"
   },
   "exchanges.cta2.title": {
-    "message": "Discover how components work and interact with the Cardano core node, and choose the right component to suit your requirements."
+    "message": "コンポーネントがCardanoコアノードとどのように連携するかを理解し、要件に合った最適なコンポーネントを選びましょう。"
   },
   "exchanges.cta2.buttonLabel": {
-    "message": "Learn the Core Node Architecture"
+    "message": "コアノードアーキテクチャを学ぶ"
   },
   "exchanges.learnArchitecture.divider": {
-    "message": "Learn the Core Node Architecture"
+    "message": "コアノードアーキテクチャを学ぶ"
   },
   "exchanges.howDoesItWork.title": {
-    "message": "How Does It Work?"
+    "message": "仕組み"
   },
   "exchanges.howDoesItWork.description": {
-    "message": "Cardano introduces an additional layer between users and developers and the core node. Within this layer, our code node team tracks and manages complex changes, potential issues, and hard forks that arise from protocol improvements. We implement necessary updates across Adrestia libraries and APIs, and take care of the maintenance so you don't have to."
+    "message": "Cardanoはユーザーと開発者とコアノードの間に追加レイヤーを導入します。このレイヤー内で、コードノードチームがプロトコル改善から生じる複雑な変更、潜在的な問題、ハードフォークを追跡・管理します。AdrestiaライブラリとAPI全体に必要なアップデートを実装し、メンテナンスを代行します。"
   },
   "exchanges.ctaTwoColumn.leftTitle": {
-    "message": "Adrestia User Guide"
+    "message": "Adrestiaユーザーガイド"
   },
   "exchanges.ctaTwoColumn.leftText": {
-    "message": "Find out more about Adrestia and what it could mean for you. Our user guide is a handy, straight-forward resource to help you determine which actions to take and when."
+    "message": "Adrestiaとその可能性について詳しく学びましょう。ユーザーガイドは、いつどのアクションを取るべきかを判断するのに役立つ、わかりやすいリソースです。"
   },
   "exchanges.ctaTwoColumn.leftButtonLabel": {
-    "message": "Access Adrestia"
+    "message": "Adrestiaにアクセス"
   },
   "exchanges.ctaTwoColumn.rightTitle": {
-    "message": "Adrestia Component Overview & Flow Chart Guide"
+    "message": "Adrestiaコンポーネント概要＆フローチャートガイド"
   },
   "exchanges.ctaTwoColumn.rightText": {
-    "message": "Discover our new, self-contained set of libraries and APIs to decide which is right for you."
+    "message": "自己完結型のライブラリとAPIセットを確認し、最適なものを見つけましょう。"
   },
   "exchanges.ctaTwoColumn.rightButtonLabel": {
-    "message": "Find out more"
+    "message": "詳しく見る"
   },
   "genesis.hero.title": {
-    "message": "Genesis"
+    "message": "ジェネシス"
   },
   "genesis.hero.description": {
-    "message": "Distribution of ada token vouchers, which are part of the Cardano settlement layer, took place in Asia in four stages between October 2015 and the start of January 2017."
+    "message": "Cardano決済レイヤーの一部であるADAトークンバウチャーの配布は、2015年10月から2017年1月にかけてアジアで4段階にわたって行われました。"
   },
   "genesis.layout.title": {
-    "message": "Cardano Genesis Distribution, Initial ada Allocation"
+    "message": "Genesis Distribution | cardano.org"
   },
   "genesis.layout.description": {
-    "message": "Distribution of ada token vouchers, which are part of the Cardano settlement layer, took place in Asia in four stages between October 2015 and the start of January 2017."
+    "message": "Cardano決済レイヤーの一部であるADAトークンバウチャーの配布は、2015年10月から2017年1月にかけてアジアで4段階にわたって行われました。"
   },
   "genesis.divider.distribution": {
-    "message": "Genesis Distribution"
+    "message": "ジェネシス配布"
   },
   "genesis.distribution.title": {
-    "message": "Distribution"
+    "message": "配布"
   },
   "genesis.distribution.paragraph1": {
-    "message": "The initial distribution of ada, essentially a pre-launch sales event, was the first in the cryptocurrency industry to set Know Your Customer guidelines, and an audit was performed on the distribution process. Information and statistics about the voucher distribution are detailed below in the Ada Voucher Distribution Stats section."
+    "message": "ADAの初期配布（実質的にはプレローンチ販売イベント）は、暗号資産業界で初めてKYC（本人確認）ガイドラインを設定し、配布プロセスの監査が実施されました。バウチャー配布の情報と統計は、以下のADAバウチャー配布統計セクションに詳述されています。"
   },
   "genesis.distribution.paragraph2": {
-    "message": "In addition to these ada, the Genesis Block Distribution includes an amount equal to 20% of the ada vouchers sold during the Sale period, or **5,185,414,108 ada**. These have been generated and distributed to three groups of entities of the Cardano ecosystem that are part of the Technical and Business Development Pool; IOHK, EMURGO, and the Cardano Foundation, as follows:"
+    "message": "これらのADAに加えて、ジェネシスブロック配布には販売期間中に販売されたADAバウチャーの20%に相当する**5,185,414,108 ADA**が含まれています。これらは技術・ビジネス開発プールの一部であるCardanoエコシステムの3つのグループに生成・配布されました。IOHK、EMURGO、Cardano Foundationへの配布は以下の通りです："
   },
   "genesis.distribution.cardanoFoundation": {
-    "message": "The Cardano Foundation, Switzerland: **648,176,761 ada**"
+    "message": "Cardano Foundation（スイス）：**648,176,761 ADA**"
   },
   "genesis.distribution.emurgo": {
-    "message": "EMURGO: **2,074,165,644 ada**"
+    "message": "EMURGO：**2,074,165,644 ADA**"
   },
   "genesis.distribution.iohk": {
-    "message": "IOHK: **2,463,071,701 ada**"
+    "message": "IOHK：**2,463,071,701 ADA**"
   },
   "genesis.distribution.totalAmount": {
-    "message": "The public sales distribution accounts for **25,927,070,538 ada**. The total amount of ada available at launch was therefore equal to **31,112,484,646 ada**."
+    "message": "公開販売の配布は**25,927,070,538 ADA**です。そのため、ローンチ時に利用可能なADAの総量は**31,112,484,646 ADA**でした。"
   },
   "genesis.distribution.supplyTracking": {
-    "message": "Since the Genesis Block, and especially since the Shelley phase with staking rewards, Cardano token distribution and supply have been continuously expanding. This can be tracked epoch by epoch on the [Supply Insight page](/insights/supply)."
+    "message": "ジェネシスブロック以降、特にステーキング報酬のあるShelleyフェーズ以降、Cardanoトークンの配布と供給は継続的に拡大しています。これは[Supply Insightページ](/insights/supply)でエポックごとに追跡できます。"
   },
   "genesis.divider.proceeds": {
-    "message": "Genesis Proceeds"
+    "message": "ジェネシス収益"
   },
   "genesis.proceeds.title": {
-    "message": "Proceeds"
+    "message": "収益"
   },
   "genesis.proceeds.paragraph1": {
-    "message": "The ada vouchers were sold by a Japanese corporation and its sales force in Japan with total gross sales of 108,844.5 BTC. Further information on the sale can be found here."
+    "message": "ADAバウチャーは日本の企業とその営業チームによって日本で販売され、総売上額は108,844.5 BTCでした。販売に関する詳細情報はこちらで確認できます。"
   },
   "genesis.proceeds.paragraph2": {
-    "message": "A part of the total sales proceeds were donated to the Cardano Foundation as follows:"
+    "message": "総売上収益の一部はCardano Foundationに以下の通り寄付されました："
   },
   "genesis.proceeds.isleOfMan": {
-    "message": "Cardano Foundation, Isle of Man (predecessor): **1,090.00 BTC**"
+    "message": "Cardano Foundation（マン島、前身）：**1,090.00 BTC**"
   },
   "genesis.proceeds.switzerland": {
-    "message": "Cardano Foundation, Switzerland: **7,168.00 BTC**"
+    "message": "Cardano Foundation（スイス）：**7,168.00 BTC**"
   },
   "governance.hero.title": {
-    "message": "Governance on Cardano"
+    "message": "Cardanoのガバナンス"
   },
   "governance.hero.description": {
-    "message": "Cardano runs on a secure, decentralized system where ada holders shape the platform's development and influence the ecosystem's direction."
+    "message": "Cardanoは安全な分散型システムで運営されており、ADA保有者がプラットフォームの開発を形作り、エコシステムの方向性に影響を与えます。"
   },
   "governance.meta.title": {
-    "message": "Cardano Governance, Community-Driven Decision Making"
+    "message": "Governance on Cardano | cardano.org"
   },
   "governance.meta.description": {
-    "message": "Cardano governance gives every ada holder a voice. Delegate to a DRep, vote on proposals, or register as a delegate representative to shape the network."
+    "message": "Cardano now runs on a secure, decentralized governance system that gives every ada holder a voice. The community collectively steers the platform's development, influencing the direction of core upgrades, applications, and services built on Cardano."
   },
   "governance.divider.withinCardano": {
-    "message": "Governance Within Cardano"
+    "message": "Cardanoにおけるガバナンス"
   },
   "governance.withinCardano.text1": {
-    "message": "Cardano is defined by its community. Its governance model shows that true democracy - in which individuals are incentivized to play a role and votes are immutably recorded - is possible. It is a way for token holders to decide the future of a platform, and for the community to dictate the use of Cardano's treasury funds."
+    "message": "Cardanoはコミュニティによって定義されています。そのガバナンスモデルは、個人が役割を果たすインセンティブを持ち、投票が不変に記録される真の民主主義が可能であることを示しています。トークン保有者がプラットフォームの未来を決定し、コミュニティがCardanoトレジャリー資金の使途を決定する方法です。"
   },
   "governance.withinCardano.text2": {
-    "message": "This model and the pioneering technology that underpins it can be applied to any application, system, or even society. It is a blueprint for change that is decided by the many, as well as the few, and which will redistribute power, eliminating intermediaries, to improve the lives of all."
+    "message": "このモデルとそれを支える先駆的なテクノロジーは、あらゆるアプリケーション、システム、さらには社会にも適用できます。少数だけでなく多くの人によって決定される変化の設計図であり、仲介者を排除して権力を再分配し、すべての人の生活を改善します。"
   },
   "governance.withinCardano.quote": {
-    "message": "Change begins with one voice. But is realized through the Combination of many."
+    "message": "変化は一つの声から始まる。しかし、多くの声の組み合わせで実現する。"
   },
   "governance.withinCardano.buttonText": {
-    "message": "Stay up to date"
+    "message": "最新情報を受け取る"
   },
   "governance.divider.delegateVoting": {
-    "message": "Delegate your voting power"
+    "message": "投票権を委任する"
   },
   "governance.delegateVoting.text": {
-    "message": "Delegation is the act of lending your voting power—equal to the ada balance in your wallet—to a Delegate Representative (DRep), who votes on your behalf like a parliamentary representative. Alternatively, you can use automatic voting options to abstain or signal \"No Confidence\" in all proposals."
+    "message": "委任とは、ウォレット内のADA残高に相当する投票権を、あなたの代わりに投票するDRep（委任代表者）に貸し出す行為です。議会の代表者のように機能します。または、自動投票オプションを使って、すべての提案に棄権や「不信任」を表明することもできます。"
   },
   "governance.delegateVoting.buttonText": {
-    "message": "Find a DRep"
+    "message": "DRepを見つける"
   },
   "governance.divider.becomeDRep": {
-    "message": "Become a DRep on Cardano"
+    "message": "CardanoのDRepになる"
   },
   "governance.becomeDRep.text1": {
-    "message": "DReps are key participants in governing the Cardano network. They actively engage in governance and represent other Cardano members. DReps must stay informed on governance actions to make wise decisions."
+    "message": "DRepはCardanoネットワークのガバナンスにおける重要な参加者です。ガバナンスに積極的に関与し、他のCardanoメンバーを代表します。DRepは賢明な判断を下すために、ガバナンスアクションについて常に情報を得ている必要があります。"
   },
   "governance.becomeDRep.text2": {
-    "message": "If you have the time and commitment to contribute to Cardano's governance, register as a DRep. A refundable deposit of 500 ada is required and will be returned upon retirement."
+    "message": "Cardanoのガバナンスに貢献する時間と意欲があるなら、DRepとして登録しましょう。500 ADAの返金可能なデポジットが必要で、退任時に返還されます。"
   },
   "governance.becomeDRep.buttonText": {
-    "message": "Become a DRep"
+    "message": "DRepになる"
   },
   "governance.divider.viewActions": {
-    "message": "View Governance Actions on Cardano"
+    "message": "Cardanoのガバナンスアクションを見る"
   },
   "governance.viewActions.text": {
-    "message": "Stay informed and participate in Cardano's decentralized governance. View all on-chain actions, including those recently submitted, ratified, enacted, expired, or dropped. Engage with ongoing proposals, track their progress, and understand their impact on the network. Your involvement helps shape the future of Cardano. Click below to see all current and past governance actions and make your voice heard."
+    "message": "Cardanoの分散型ガバナンスについて情報を得て参加しましょう。最近提出、承認、制定、期限切れ、却下されたものを含む、すべてのオンチェーンアクションを確認できます。進行中の提案に参加し、進捗を追跡し、ネットワークへの影響を理解しましょう。あなたの参加がCardanoの未来を形作ります。"
   },
   "governance.viewActions.buttonText": {
-    "message": "Governance Actions"
+    "message": "ガバナンスアクション"
   },
   "governance.divider.whyVoltaire": {
-    "message": "Why Voltaire"
+    "message": "なぜVoltaire"
   },
   "governance.divider.actionCharts": {
-    "message": "Governance Action Charts"
+    "message": "ガバナンスアクションチャート"
   },
   "governance.actionCharts.text": {
-    "message": "Discover how Cardano governance works with an interactive set of charts that illuminate each governance action. Navigate processes, rules, and thresholds at a glance, with visual explanations that make exploration fast and practical."
+    "message": "各ガバナンスアクションを図解するインタラクティブなチャートセットで、Cardanoガバナンスの仕組みを理解しましょう。プロセス、ルール、閾値を一目で把握でき、ビジュアルな説明で素早く実用的に探索できます。"
   },
   "governance.actionCharts.buttonText": {
-    "message": "Governance Action Charts"
+    "message": "ガバナンスアクションチャート"
   },
   "hardforks.timeline.byron.description": {
-    "message": "The launch of the Cardano mainnet and introduction of the ada cryptocurrency."
+    "message": "Cardanoメインネットの立ち上げとADA暗号資産の導入。"
   },
   "hardforks.timeline.label.epoch": {
-    "message": "Epoch"
+    "message": "エポック"
   },
   "hardforks.timeline.label.protocolVersion": {
-    "message": "Protocol Version"
+    "message": "プロトコルバージョン"
   },
   "hardforks.timeline.label.transactionId": {
-    "message": "Transaction ID"
+    "message": "トランザクションID"
   },
   "hardforks.timeline.shelley.description": {
-    "message": "Introduced staking and decentralization features, transitioning from a federated to a decentralized system."
+    "message": "ステーキングと分散化機能を導入し、フェデレーテッドシステムから分散型システムへの移行を実現。"
   },
   "hardforks.timeline.allegra.description": {
-    "message": "Added token locking capabilities, which was a prerequisite for the smart contract functionality."
+    "message": "スマートコントラクト機能の前提条件となるトークンロック機能を追加。"
   },
   "hardforks.timeline.mary.description": {
-    "message": "Brought native token functionality to Cardano, allowing users to create and transact with custom tokens."
+    "message": "Cardanoにネイティブトークン機能を導入し、カスタムトークンの作成と取引を可能に。"
   },
   "hardforks.timeline.alonzo.description": {
-    "message": "Introduced smart contract capabilities using Plutus, enabling the deployment of decentralized applications (dApps)."
+    "message": "Plutusを使用したスマートコントラクト機能を導入し、分散型アプリケーション（dApps）のデプロイを可能に。"
   },
   "hardforks.timeline.vasil.description": {
-    "message": "Improved the scalability and performance of the network, named after Vasil Dabov, a Cardano community member."
+    "message": "ネットワークのスケーラビリティとパフォーマンスを向上。Cardanoコミュニティメンバーのヴァシル・ダボフにちなんで命名。"
   },
   "hardforks.timeline.label.transactionIds": {
-    "message": "Transaction IDs"
+    "message": "トランザクションID"
   },
   "hardforks.timeline.valentine.description": {
-    "message": "Introduced further improvements to Plutus smart contract functionality and overall network performance."
+    "message": "Plutusスマートコントラクト機能とネットワーク全体のパフォーマンスにさらなる改善を導入。"
   },
   "hardforks.timeline.chang1.description": {
-    "message": "Introducing the first batch of decentralized governance features of CIP-1694. Enabling only parameter changes and hard fork initiations."
+    "message": "CIP-1694の分散型ガバナンス機能の第一弾を導入。パラメータ変更とハードフォーク開始のみを有効化。"
   },
   "hardforks.timeline.plomin.description": {
-    "message": "Introducing the second batch of decentralized governance features of CIP-1694. Enabling the full set of governance actions and the DRep role."
+    "message": "CIP-1694の分散型ガバナンス機能の第二弾を導入。ガバナンスアクションの全セットとDRepロールを有効化。"
   },
   "hardforks.hero.title": {
-    "message": "Hard forks"
+    "message": "ハードフォーク"
   },
   "hardforks.hero.description": {
-    "message": "What hard forks were implemented, and what functionalities did they introduce?"
+    "message": "どのようなハードフォークが実施され、どのような機能が導入されたのか？"
   },
   "hardforks.layout.title": {
-    "message": "Cardano Hard Forks, Network Upgrade History"
+    "message": "Which hard forks have occurred? | cardano.org"
   },
   "hardforks.layout.description": {
-    "message": "A complete timeline of Cardano hard forks from Byron to Chang. Explore each network upgrade, what changed, and how the protocol has evolved."
+    "message": "An environmentally sustainable, verifiably secure proof-of-stake protocol with rigorous security guarantees."
   },
   "hardforks.content.title": {
-    "message": "Cardano Hard Forks"
+    "message": "Cardanoのハードフォーク"
   },
   "hardforks.content.description": {
-    "message": "Hard forks in Cardano do not signify division and differences within the ecosystem. On the contrary, they define a specific and collectively agreed-upon exact time (slot) when all nodes switch from the current era to a new one, applying new functions, validation rules, or parameter values. All stake pool operators need to install the upgrade, and they also have a say and must agree to it. A Cardano hard fork is, therefore, not a separation but a precise collective evolution."
+    "message": "Cardanoのハードフォークは、エコシステム内の分裂や不一致を意味しません。むしろ、すべてのノードが現在のエラから新しいエラに切り替わり、新しい機能、検証ルール、パラメータ値を適用する特定の集合的に合意された正確な時間（スロット）を定義します。すべてのステークプールオペレーターはアップグレードをインストールする必要があり、同意する必要もあります。Cardanoのハードフォークは分離ではなく、正確な集合的進化です。"
   },
   "hardforks.divider.timeline": {
-    "message": "Timeline"
+    "message": "タイムライン"
   },
   "hardforks.loading": {
-    "message": "Loading..."
+    "message": "読み込み中..."
   },
   "hardforks.divider.transactionIds": {
-    "message": "hard fork transaction ids"
+    "message": "ハードフォーク トランザクションID"
   },
   "hardforks.transactionIds.description": {
-    "message": "Note that some hard forks, particularly Byron and Shelley, transitioned through a series of updates and may not have a single specific transaction id associated with them. For the others, the provided transaction ids correspond to significant parameter updates leading to the hard forks."
+    "message": "一部のハードフォーク（特にByronとShelley）は一連のアップデートを経て移行したため、単一の特定のトランザクションIDが関連付けられていない場合があります。その他については、提供されたトランザクションIDはハードフォークにつながる重要なパラメータ更新に対応しています。"
   },
   "learn.hero.title": {
-    "message": "Learn"
+    "message": "学ぶ"
   },
   "learn.hero.description": {
-    "message": "Empowering the digital architects of the future."
+    "message": "未来のデジタルアーキテクトを育てる"
   },
   "learn.layout.title": {
-    "message": "Learn About Cardano, Guides, Tutorials and Resources"
+    "message": "Learn | cardano.org"
   },
   "learn.layout.description": {
-    "message": "Learn how Cardano works, from proof-of-stake consensus and smart contracts to staking, governance, and building decentralized applications."
+    "message": "An open platform designed to empower billions without economic identity by offering decentralized applications for managing identity, value, and governance."
   },
   "newsletter.hero.title": {
-    "message": "Stay Informed"
+    "message": "最新情報を入手"
   },
   "newsletter.hero.description": {
-    "message": "Get access to the latest Cardano news and content, and the hottest topics happening around the Cardano ecosystem."
+    "message": "Cardanoの最新ニュースとコンテンツ、エコシステムで話題のトピックにアクセスしましょう。"
   },
   "newsletter.layout.title": {
-    "message": "Cardano Community Digest, Weekly News and Updates"
+    "message": "Cardano Community Digest | cardano.org"
   },
   "newsletter.layout.description": {
-    "message": "Get access to the latest Cardano news and content, and the hottest topics happening around the Cardano ecosystem."
+    "message": "Cardanoの最新ニュースとコンテンツ、エコシステムで話題のトピックにアクセスしましょう。"
   },
   "newsletter.divider.text": {
-    "message": "Stay informed"
+    "message": "最新情報を入手"
   },
   "newsletter.content.title": {
-    "message": "Cardano Community Digest"
+    "message": "Cardanoコミュニティダイジェスト"
   },
   "newsletter.content.description": {
-    "message": "Get your bi-weekly dose of the latest hot topics, development updates, a list of upcoming meetups, delegation strategy updates, what our Cardano Ambassadors are up to, and much more."
+    "message": "隔週で最新の注目トピック、開発アップデート、今後のミートアップ一覧、委任戦略の更新、Cardanoアンバサダーの活動などをお届けします。"
   },
   "ouroboros.hero.title": {
     "message": "Ouroboros"
   },
   "ouroboros.hero.description": {
-    "message": "An environmentally sustainable, verifiably secure proof-of-stake protocol with rigorous security guarantees."
+    "message": "環境に配慮し、検証可能なセキュリティを備えた、厳格なセキュリティ保証を持つプルーフ・オブ・ステーク・プロトコル。"
   },
   "ouroboros.meta.title": {
-    "message": "Ouroboros, Cardano's Proof-of-Stake Protocol"
+    "message": "What is Ouroboros? | cardano.org"
   },
   "ouroboros.meta.description": {
-    "message": "Ouroboros is the first peer-reviewed, provably secure proof-of-stake consensus protocol. Learn how it powers the Cardano blockchain with minimal energy usage."
+    "message": "An environmentally sustainable, verifiably secure proof-of-stake protocol with rigorous security guarantees."
   },
   "ouroboros.divider.vision": {
-    "message": "Vision"
+    "message": "ビジョン"
   },
   "ouroboros.vision.title": {
-    "message": "The Blockchain Revolution Started With Bitcoin. It Continues Now With Ouroboros:"
+    "message": "ブロックチェーン革命はBitcoinで始まった。今、Ouroborosで続く："
   },
   "ouroboros.vision.description": {
-    "message": "A proof-of-stake protocol that provides and improves the security guarantees of proof-of-work at a fraction of the energy cost. Ouroboros applies cryptography, combinatorics, and mathematical game theory to guarantee the protocol's integrity, longevity, and performance, and that of the distributed networks that depend upon it."
+    "message": "プルーフ・オブ・ワークのセキュリティ保証を維持しながら、そのエネルギーコストのごく一部で改善を実現するプルーフ・オブ・ステーク・プロトコルです。Ouroborosは暗号学、組合せ論、数学的ゲーム理論を適用して、プロトコルとそれに依存する分散型ネットワークの整合性、長寿、パフォーマンスを保証します。"
   },
   "ouroboros.whatIs.title": {
-    "message": "What Is Ouroboros?"
+    "message": "Ouroborosとは？"
   },
   "ouroboros.whatIs.description1": {
-    "message": "Ouroboros is the first provably secure proof-of-stake protocol, and the first blockchain protocol to be based on peer-reviewed research. Ouroboros combines unique technology and mathematically-verified mechanisms - which, in turn, combine behavioral psychology and economic philosophy - to ensure the security and sustainability of the blockchains that depend upon it. The result is a protocol with proven security guarantees able to facilitate the propagation of global, permissionless networks with minimal energy requirements - of which Cardano is the first."
+    "message": "Ouroborosは、初の証明可能に安全なプルーフ・オブ・ステーク・プロトコルであり、査読済み研究に基づく初のブロックチェーンプロトコルです。独自のテクノロジーと数学的に検証されたメカニズム（行動心理学と経済哲学を組み合わせた）を統合し、それに依存するブロックチェーンのセキュリティと持続可能性を保証します。その結果、最小限のエネルギー要件でグローバルなパーミッションレスネットワークの伝播を促進できる、証明されたセキュリティ保証を持つプロトコルが生まれました。Cardanoがその最初の例です。"
   },
   "ouroboros.whatIs.description2": {
-    "message": "At the heart of Ouroboros is the concept of infinity. Global networks must be able to grow sustainably and ethically: to provide greater opportunities to the world while also preserving it. This becomes possible with Ouroboros."
+    "message": "Ouroborosの中核には無限の概念があります。グローバルネットワークは持続的かつ倫理的に成長できなければなりません。世界を守りながら、より大きな機会を提供する必要があります。これがOuroborosで可能になります。"
   },
   "ouroboros.whatIs.description3": {
-    "message": "Ouroboros facilitates the creation and fruition of distributed, permissionless networks capable of sustainably supporting new markets."
+    "message": "Ouroborosは、新しい市場を持続的にサポートできる、分散型でパーミッションレスなネットワークの構築と実現を促進します。"
   },
   "ouroboros.whatIs.quote": {
-    "message": "Ouroboros exists to define the parameters of the new world: a protocol more secure, scalable, and energy-efficient than anything that has come before."
+    "message": "Ouroborosは新しい世界のパラメータを定義するために存在します。これまでのどれよりも安全で、スケーラブルで、エネルギー効率の高いプロトコルです。"
   },
   "ouroboros.whatIs.buttonLabel": {
-    "message": "Explore the research"
+    "message": "研究を探索"
   },
   "ouroboros.divider.features": {
-    "message": "Features"
+    "message": "特徴"
   },
   "ouroboros.features.provablySecure.title": {
-    "message": "Provably Secure"
+    "message": "証明可能なセキュリティ"
   },
   "ouroboros.features.provablySecure.text1": {
-    "message": "Ouroboros features mathematically verifiable security against attackers."
+    "message": "Ouroborosは攻撃者に対する数学的に検証可能なセキュリティを備えています。"
   },
   "ouroboros.features.provablySecure.text2": {
-    "message": "The protocol is guaranteed to be secure so long as 51% of the stake – in the case of Cardano, ada – is held by honest participants, which, in addition to other novel concepts, is achieved through random leader selection. The protocol continues to evolve through new iterations and rigorous security analysis."
+    "message": "プロトコルは、ステークの51%（Cardanoの場合はADA）が正直な参加者によって保持されている限り、安全であることが保証されています。これはランダムなリーダー選出などの新しい概念によって達成されます。プロトコルは新しいイテレーションと厳格なセキュリティ分析を通じて継続的に進化しています。"
   },
   "ouroboros.features.incentivesRewards.title": {
-    "message": "Incentives & Rewards"
+    "message": "インセンティブと報酬"
   },
   "ouroboros.features.incentivesRewards.text1": {
-    "message": "To ensure the sustainability of the blockchain networks using Ouroboros, the protocol features an incentive mechanism that rewards network participants for their participation."
+    "message": "Ouroborosを使用するブロックチェーンネットワークの持続可能性を確保するために、プロトコルにはネットワーク参加者の参加に報いるインセンティブメカニズムが組み込まれています。"
   },
   "ouroboros.features.incentivesRewards.text2": {
-    "message": "This can either be operating a stake pool or delegating a stake in ada to a stake pool. Rewards (in the form of ada) can be earned by completing either of these activities."
+    "message": "これはステークプールの運営、またはADAのステークをステークプールに委任することで可能です。いずれの活動を行っても、報酬（ADAの形で）を得ることができます。"
   },
   "ouroboros.features.stakeDelegation.title": {
-    "message": "Stake Delegation And Stake Pools"
+    "message": "ステーク委任とステークプール"
   },
   "ouroboros.features.stakeDelegation.text1": {
-    "message": "Ouroboros is a proof-of-stake protocol. It distributes network control across stake pools: node operators with the infrastructure required to ensure a consistent and reliable connection to the network."
+    "message": "Ouroborosはプルーフ・オブ・ステーク・プロトコルです。ネットワークの安定した信頼性の高い接続を確保するために必要なインフラを持つノードオペレーターであるステークプールにネットワーク制御を分配します。"
   },
   "ouroboros.features.stakeDelegation.text2": {
-    "message": "For each slot, a stake pool is assigned as the slot leader, and is rewarded for adding a block to the chain. Ada holders may delegate their stake to a specific stake pool, increasing its chance of being selected as the slot leader, and share in the stake pool's rewards."
+    "message": "各スロットでステークプールがスロットリーダーとして割り当てられ、チェーンにブロックを追加することで報酬が与えられます。ADA保有者は特定のステークプールにステークを委任して、スロットリーダーに選ばれる確率を高め、ステークプールの報酬を分配できます。"
   },
   "ouroboros.features.energyEfficient.title": {
-    "message": "Energy Efficient"
+    "message": "エネルギー効率"
   },
   "ouroboros.features.energyEfficient.text1": {
-    "message": "Ouroboros solves the greatest challenge faced by existing blockchains: the need for more and more energy to achieve consensus. Using Ouroboros, Cardano is able to securely, sustainably, and ethically scale, with up to [four million times the energy efficiency of bitcoin](https://iohk.io/en/blog/posts/2020/03/23/from-classic-to-hydra-the-implementations-of-ouroboros-explained/)."
+    "message": "Ouroborosは既存のブロックチェーンが直面する最大の課題を解決します。コンセンサスを達成するためにますます多くのエネルギーが必要になるという問題です。Ouroborosにより、Cardanoは[Bitcoinの最大400万倍のエネルギー効率](https://iohk.io/en/blog/posts/2020/03/23/from-classic-to-hydra-the-implementations-of-ouroboros-explained/)で、安全かつ持続的、倫理的にスケールできます。"
   },
   "ouroboros.cta.title": {
-    "message": "Attack the protocol, fork the blockchain - or not. Explore the Ouroboros protocol firsthand in this interactive simulation."
+    "message": "プロトコルを攻撃するか、ブロックチェーンをフォークするか。このインタラクティブシミュレーションでOuroborosプロトコルを直接体験しましょう。"
   },
   "ouroboros.cta.buttonLabel": {
-    "message": "Play the game"
+    "message": "ゲームをプレイ"
   },
   "research.hero.title": {
-    "message": "Research"
+    "message": "リサーチ"
   },
   "research.hero.description": {
-    "message": "Cardano relevant research papers and specifications."
+    "message": "Cardanoに関連する研究論文と仕様。"
   },
   "research.meta.title": {
-    "message": "Cardano Research, Peer-Reviewed Blockchain Science"
+    "message": "Cardano Research | cardano.org"
   },
   "research.meta.description": {
-    "message": "Explore the peer-reviewed papers and formal specifications behind the Cardano blockchain, spanning cryptography, consensus, smart contracts, and governance."
+    "message": "Cardano relevant research papers and specifications."
   },
   "signalGovernance.layout.title": {
-    "message": "Signal your interest in Cardano Governance"
+    "message": "Signal your interest in Governance"
   },
   "signalGovernance.layout.description": {
-    "message": "We'll keep you updated on DReps, proposals and how to get involved."
+    "message": "DRep、提案、参加方法について最新情報をお届けします。"
   },
   "signalGovernance.openGraph.title": {
-    "message": "Signal your interest in Governance"
+    "message": "ガバナンスへの関心を表明する"
   },
   "signalGovernance.openGraph.description": {
-    "message": "We'll keep you updated on DReps, proposals and how to get involved."
+    "message": "DRep、提案、参加方法について最新情報をお届けします。"
   },
   "signalGovernance.hero.title": {
-    "message": "Signal your interest in Governance"
+    "message": "ガバナンスへの関心を表明する"
   },
   "signalGovernance.hero.description": {
-    "message": "We'll keep you updated on DReps, proposals and how to get involved."
+    "message": "DRep、提案、参加方法について最新情報をお届けします。"
   },
   "signalGovernance.divider.text": {
-    "message": "governance"
+    "message": "ガバナンス"
   },
   "signalOperator.layout.title": {
-    "message": "Signal your interest in Cardano Stake Pool Operations"
+    "message": "Signal your interest in Stake Pool Operations"
   },
   "signalOperator.layout.description": {
-    "message": "Stay informed about everything related to running a Stake Pool and technical updates."
+    "message": "ステークプール運営と技術アップデートに関するすべての最新情報をお届けします。"
   },
   "signalOperator.openGraph.title": {
-    "message": "Signal your interest in Stake Pool Operations"
+    "message": "ステークプール運営への関心を表明する"
   },
   "signalOperator.openGraph.description": {
-    "message": "Stay informed about everything related to running a Stake Pool and technical updates."
+    "message": "ステークプール運営と技術アップデートに関するすべての最新情報をお届けします。"
   },
   "signalOperator.hero.title": {
-    "message": "Signal your interest in Stake Pool Operations"
+    "message": "ステークプール運営への関心を表明する"
   },
   "signalOperator.hero.description": {
-    "message": "Stay informed about everything related to running a Stake Pool and technical updates."
+    "message": "ステークプール運営と技術アップデートに関するすべての最新情報をお届けします。"
   },
   "signalOperator.divider.text": {
-    "message": "operator"
+    "message": "オペレーター"
   },
   "signal.layout.title": {
-    "message": "Signal Your Interest in Cardano"
+    "message": "Signal your interest"
   },
   "signal.layout.description": {
-    "message": "Sign up to receive Cardano updates on governance, stake pool operations, or development. Stay informed about what matters to you."
-  },
-  "signal.openGraph.title": {
-    "message": "Signal your interest"
-  },
-  "signal.openGraph.description": {
     "message": "Get just the information you want"
   },
+  "signal.openGraph.title": {
+    "message": "関心を表明する"
+  },
+  "signal.openGraph.description": {
+    "message": "必要な情報だけを受け取る"
+  },
   "signal.hero.title": {
-    "message": "Signal your interest"
+    "message": "関心を表明する"
   },
   "signal.hero.description": {
-    "message": "Look at the available topics and get just the information you want"
+    "message": "利用可能なトピックを見て、必要な情報だけを受け取りましょう"
   },
   "signal.topics.title": {
-    "message": "Available Topics"
+    "message": "利用可能なトピック"
   },
   "solutions.hero.title": {
-    "message": "Enterprise Solutions"
+    "message": "エンタープライズソリューション"
   },
   "solutions.hero.description": {
-    "message": "Proven blockchain solutions for supply chain, identity, and beyond."
+    "message": "サプライチェーン、アイデンティティなどの実証済みブロックチェーンソリューション。"
   },
   "solutions.layout.title": {
-    "message": "Cardano Enterprise Solutions, Blockchain for Business"
+    "message": "Enterprise Solutions | cardano.org"
   },
   "solutions.layout.description": {
-    "message": "Discover proven enterprise blockchain solutions built on Cardano. From supply chain traceability to digital product passports, explore real-world implementations."
+    "message": "Cardano上に構築された実証済みエンタープライズブロックチェーンソリューションを発見しましょう。サプライチェーンのトレーサビリティからデジタルプロダクトパスポートまで、実際の導入事例を探索できます。"
   },
   "solutions.intro.description": {
-    "message": "Cardano powers enterprise solutions across industries, combining the security and transparency of blockchain with practical business applications. Our proven deployments demonstrate how organizations can leverage decentralized technology for supply chain management, product authentication, and sustainability tracking."
+    "message": "Cardanoは業界をまたいだエンタープライズソリューションを提供し、ブロックチェーンのセキュリティと透明性を実用的なビジネスアプリケーションと組み合わせています。実証済みの導入により、組織がサプライチェーン管理、製品認証、サステナビリティトラッキングに分散型テクノロジーを活用する方法を示しています。"
   },
   "solutions.divider.explore": {
-    "message": "Explore Use Cases"
+    "message": "ユースケースを探索"
   },
   "solutions.explore.description": {
-    "message": "Looking for specific blockchain applications? Explore our comprehensive use case library covering identity, finance, supply chain, and more."
+    "message": "特定のブロックチェーンアプリケーションをお探しですか？アイデンティティ、金融、サプライチェーンなどを網羅するユースケースライブラリを探索しましょう。"
   },
   "solutions.explore.button": {
-    "message": "View All Use Cases"
+    "message": "すべてのユースケースを見る"
   },
   "solutions.cta.title": {
-    "message": "Ready to build on Cardano? Connect with the Cardano Foundation to explore partnership opportunities."
+    "message": "Cardanoで開発する準備はできましたか？Cardano Foundationに連絡してパートナーシップの機会を探りましょう。"
   },
   "solutions.cta.button": {
-    "message": "Contact Us"
+    "message": "お問い合わせ"
   },
   "delegation.faq.q1": {
-    "message": "What is a stake pool?"
+    "message": "ステークプールとは？"
   },
   "delegation.faq.a1.p1": {
-    "message": "Stake pools are run by stake pool operators. These are network participants with the skills to reliably ensure consistent uptime of a node, which is essential in ensuring the success of the Ouroboros protocol and the Cardano network as a whole."
+    "message": "ステークプールはステークプールオペレーターによって運営されています。オペレーターは、ノードの安定した稼働を確保するスキルを持つネットワーク参加者で、Ouroborosプロトコルとネットワーク全体の成功に不可欠です。"
   },
   "delegation.faq.a1.p2": {
-    "message": "The protocol uses a probabilistic mechanism to select a leader for each slot, who will be expected to create the next block in the chain. The chance of a stake pool node being selected as slot leader increases proportionately to the amount of stake delegated to that node. Each time a stake pool node is selected as a slot leader and successfully creates a block, it receives a reward, which is shared with the pool proportionate to the amount each member has delegated. Stake pool operators can deduct their running costs from the awarded ada, as well as specify a profit margin for providing the service."
+    "message": "プロトコルは確率的なメカニズムを使って各スロットのリーダーを選出します。選ばれたリーダーはチェーンに次のブロックを作成します。ステークプールがスロットリーダーに選ばれる確率は、そのノードに委任されたステーク量に比例して高くなります。ステークプールが選ばれてブロックを正常に作成すると報酬を受け取り、その報酬は各メンバーの委任量に応じてプール内で分配されます。ステークプールオペレーターは、報酬のADAから運営費を差し引き、サービス提供のための利益率を設定できます。"
   },
   "delegation.faq.q2": {
-    "message": "Can I re-delegate my stake to another pool?"
+    "message": "別のプールにステークを再委任できますか？"
   },
   "delegation.faq.a2.p1": {
-    "message": "Delegated stake can be re-delegated to another pool at any time. Re-delegated stake will remain in the current pool until the epoch after next (from the point of re-delegation), after which your delegation preferences will be updated on the chain and your stake moved to the new stake pool. Rewards are distributed from the end of each epoch, so you'll continue to receive rewards from your original stake pool for two epochs before your new delegation preferences are applied."
+    "message": "委任したステークはいつでも別のプールに再委任できます。再委任されたステークは、再委任のポイントから次の次のエポックの終わりまで現在のプールに残ります。その後、委任の設定がチェーン上で更新され、ステークが新しいステークプールに移動します。報酬は各エポック終了時に分配されるため、新しい委任設定が適用されるまでの2エポック間は、元のステークプールからの報酬を受け続けます。"
   },
   "delegation.faq.q3": {
-    "message": "Can I delegate to multiple stake pools?"
+    "message": "複数のステークプールに委任できますか？"
   },
   "delegation.faq.a3.p1": {
-    "message": "Some wallets offer different solutions for delegating to different stake pools at the same time. [Discover wallets](/what-is-ada#wallets)."
+    "message": "一部のウォレットでは、複数のステークプールに同時に委任するためのソリューションを提供しています。[ウォレットを見る](/what-is-ada#wallets)。"
   },
   "delegation.faq.q4": {
-    "message": "What is stake pool performance?"
+    "message": "ステークプールのパフォーマンスとは？"
   },
   "delegation.faq.a4.p1": {
-    "message": "The performance metric is an indicator of how well a stake pool is performing. Considering that the slot leader election process is private, it is only possible to estimate how often the stake pool should be elected based on the number of actually produced blocks. A pool can be nominated more often than expected based on its stake. For example, if a pool only produces half the number of blocks that it was nominated for, its performance rating is 50%. This could happen because the pool has a poor network connection, or has been turned off by its operator."
+    "message": "パフォーマンス指標は、ステークプールの動作がどれだけ良好かを示します。スロットリーダーの選出プロセスは非公開のため、実際に生成されたブロック数に基づいて、ステークプールがどの程度の頻度で選ばれるべきかを推定することしかできません。ステーク量に基づいて期待より多く指名されるプールもあります。例えば、指名されたブロック数の半分しか生成しないプールのパフォーマンス評価は50%になります。これは、ネットワーク接続が不安定であったり、オペレーターがオフにしている場合に起こりえます。"
   },
   "delegation.faq.a4.p2": {
-    "message": "Performance ratings make more sense over a longer period of time. If a pool has not yet been selected to produce a block in the current epoch, its performance rating will be 0%, even if it is likely to produce blocks later in the epoch. Performance ratings of over 100% are possible if a pool creates more blocks than it was nominated to produce."
+    "message": "パフォーマンス評価は、より長い期間で見ると意味があります。プールが現在のエポックでまだブロック生成に選ばれていない場合、後でブロックを生成する可能性があっても、パフォーマンスは0%になります。プールが指名された数よりも多くのブロックを生成した場合、100%を超えるパフォーマンス評価も可能です。"
   },
   "delegation.faq.q5": {
-    "message": "What is stake pool saturation?"
+    "message": "ステークプールの飽和とは？"
   },
   "delegation.faq.a5.p1": {
-    "message": "Saturation is a term used to indicate that a particular stake pool has more stake delegated to it than is ideal for the network, and once a pool reaches the point of saturation it will offer diminishing rewards. The saturation mechanism was designed to prevent centralization by encouraging delegators to delegate to different stake pools, and operators to set up alternative pools so that they can continue earning maximum rewards. Saturation, therefore, exists to preserve the interests of both ada holders delegating their stake and stake pool operators."
+    "message": "飽和とは、特定のステークプールにネットワークにとって理想的な量以上のステークが委任されている状態を示す用語です。プールが飽和点に達すると、報酬が減少します。飽和メカニズムは、委任者が異なるプールに委任し、オペレーターが代替プールを設立して最大報酬を獲得し続けるインセンティブを与えることで、中央集権化を防ぐために設計されました。"
   },
   "delegation.faq.a5.p2": {
-    "message": "The goal is to avoid any single pool becoming too large – thereby disincentivizing delegation to other pools – and receiving a disproportionate amount of the rewards. The health of the network is partly determined by having a high number of active stake pools with a balanced amount of stake delegated to them. The more numerous and geographically diverse the network's pools, the better. Each stake pool's saturation percentage is shown within the Daedalus stake pool selection menu."
+    "message": "目標は、単一のプールが大きくなりすぎて他のプールへの委任を阻害し、報酬の不均衡な分配を受けることを回避することです。ネットワークの健全性は、多数のアクティブなステークプールにバランスの取れたステークが委任されていることで部分的に決まります。プールの数が多く地理的に多様であるほど良いです。"
   },
   "delegation.faq.q6": {
-    "message": "What is stake pool desirability?"
+    "message": "ステークプールのデザイラビリティとは？"
   },
   "delegation.faq.a6.p1": {
-    "message": "Desirability measures how desirable a stake pool is to an ada holder seeking to delegate their stake. It is influenced by a number of factors – including a stake pool's margin, fee, performance, the total reward available in the current epoch, and saturation percentage – and contributes to determining a stake pool's ranking."
+    "message": "デザイラビリティは、ステークを委任したいADA保有者にとってステークプールがどれだけ魅力的かを測定します。マージン、手数料、パフォーマンス、現在のエポックの利用可能な報酬総額、飽和率など、多くの要因に影響され、ステークプールのランキング決定に寄与します。"
   },
   "delegation.faq.q7": {
-    "message": "How are stake pools ranked?"
+    "message": "ステークプールはどのようにランク付けされますか？"
   },
   "delegation.faq.a7.p1": {
-    "message": "Stake pools are ranked mainly through a combination of their desirability and performance, in addition to other factors. It is worth mentioning here that the wallet developers make this decision for their wallet. [Discover wallets](/what-is-ada#wallets)."
+    "message": "ステークプールのランク付けは、デザイラビリティとパフォーマンスの組み合わせに加えて、その他の要因を考慮して行われます。なお、ウォレット開発者がそれぞれのウォレットでこの決定を行います。[ウォレットを見る](/what-is-ada#wallets)。"
   },
   "delegation.faq.q8": {
-    "message": "How should I choose a stake pool?"
+    "message": "ステークプールの選び方は？"
   },
   "delegation.faq.a8.p1": {
-    "message": "Choosing a stake pool involves several factors to consider to ensure you make a well-informed decision. So-called [pool tools](/apps?tags=pooltool) can help you choose a stake pool. Points to consider:"
+    "message": "ステークプールの選択には、十分な情報に基づいた判断をするためにいくつかの要素を考慮する必要があります。いわゆる[プールツール](/apps?tags=pooltool)がステークプール選びに役立ちます。考慮すべきポイント："
   },
   "delegation.faq.a8.p2": {
-    "message": "**Performance:** Look at the pool's historical performance, which reflects its success rate in producing blocks. A consistently high performance is a good indicator of the pool's reliability and effective operation."
+    "message": "**パフォーマンス：** プールの過去のパフォーマンスを確認しましょう。ブロック生成の成功率を反映しています。一貫して高いパフォーマンスは、プールの信頼性と効果的な運営の良い指標です。"
   },
   "delegation.faq.a8.p3": {
-    "message": "**Uptime:** Ensure the pool has high uptime. This means the pool's servers are running without interruption, increasing the chances of being selected to produce a block."
+    "message": "**稼働率：** プールが高い稼働率を持っていることを確認しましょう。プールのサーバーが中断なく稼働していることを意味し、ブロック生成に選ばれる確率が高まります。"
   },
   "delegation.faq.a8.p4": {
-    "message": "**Margin Fees:** Stake pools charge a percentage fee on the rewards earned. Lower fees can mean more rewards, but consider the balance between low fees and high pool performance."
+    "message": "**マージン手数料：** ステークプールは獲得した報酬に対してパーセンテージの手数料を課します。手数料が低いほど報酬が多くなる可能性がありますが、低手数料と高パフォーマンスのバランスを考慮してください。"
   },
   "delegation.faq.a8.p5": {
-    "message": "**Fixed Fees:** There is often a minimum fixed fee (set by the protocol) that pools will charge. Check what fixed fee the pool charges."
+    "message": "**固定手数料：** プロトコルによって設定された最低固定手数料があります。プールが課す固定手数料を確認しましょう。"
   },
   "delegation.faq.a8.p6": {
-    "message": "**Saturation Point:** A pool becomes saturated when it has more stake than an optimal amount set by the protocol. Staking with a saturated pool can decrease your rewards, so it's advisable to choose a pool below this threshold."
+    "message": "**飽和点：** プールがプロトコルの定める最適なステーク量を超えると飽和状態になります。飽和したプールでステーキングすると報酬が減少する可能性があるため、この閾値以下のプールを選ぶことをお勧めします。"
   },
   "delegation.faq.a8.p7": {
-    "message": "**Community Engagement:** Look for pools that actively engage with the Cardano community. This can be through educational content, community support, or contributions to the Cardano ecosystem."
+    "message": "**コミュニティへの参加：** Cardanoコミュニティに積極的に参加しているプールを探しましょう。教育コンテンツ、コミュニティサポート、Cardanoエコシステムへの貢献を通じてその姿勢が見えるでしょう。"
   },
   "delegation.faq.a8.p8": {
-    "message": "**Mission-Driven Pools:** Some pools donate a portion of their fees to charitable causes or are dedicated to specific missions like environmental sustainability or education. If this aligns with your values, it might influence your choice."
+    "message": "**ミッション駆動型プール：** 一部のプールは手数料の一部を慈善活動に寄付したり、環境の持続可能性や教育などの特定のミッションに特化しています。これがあなたの価値観に合うなら、選択の参考にしてみてください。"
   },
   "delegation.faq.q9": {
-    "message": "How much will I earn in rewards?"
+    "message": "報酬はどのくらい得られますか？"
   },
   "delegation.faq.a9.p1": {
-    "message": "You can use the [rewards calculator](/calculator) to get an idea of how much you will earn in rewards. It's important to note that the calculator produces only reward estimates and shouldn't be considered definitive or a guarantee of reward amounts. In the future, we will likely test different parameters that may affect reward margins. Amounts calculated are therefore subject to change, but represent a realistic and sensible level of return."
+    "message": "[報酬計算機](/calculator)を使って、獲得できる報酬の目安を確認できます。計算機は推定値のみを提供するものであり、報酬額を保証するものではないことに注意してください。将来的には、報酬マージンに影響を与える異なるパラメータのテストを行う可能性があります。"
   },
   "delegation.faq.q10": {
-    "message": "What wallets are supported and where do I find them?"
+    "message": "対応しているウォレットとその入手先は？"
   },
   "delegation.faq.a10.p1": {
-    "message": "There are various wallets to choose from. Please make sure that you only download wallets from trustworthy sites. [Discover wallets](/what-is-ada#wallets)."
+    "message": "選択できるウォレットはさまざまです。信頼できるサイトからのみダウンロードしてください。[ウォレットを見る](/what-is-ada#wallets)。"
   },
   "delegation.faq.q11": {
-    "message": "Can I restore an ada balance from a hardware wallet?"
+    "message": "ハードウェアウォレットからADA残高を復元できますか？"
   },
   "delegation.faq.a11.p1": {
-    "message": "Yes. You can use Daedalus to restore an ada balance from a hardware wallet. However, we advise caution doing so. Entering your hardware wallet recovery phrase in Daedalus can expose your hardware wallet private keys to additional security risks. Recommendations to minimize security issues are available via Daedalus during the hardware wallet recovery process."
+    "message": "はい。Daedalusを使用してハードウェアウォレットからADA残高を復元できます。ただし、注意が必要です。Daedalusにハードウェアウォレットのリカバリーフレーズを入力すると、秘密鍵がセキュリティリスクにさらされる可能性があります。セキュリティ上の問題を最小限に抑えるための推奨事項は、ハードウェアウォレットの復元プロセス中にDaedalus内で案内されます。"
   },
   "delegation.faq.q12": {
-    "message": "Will the ada rewards I earn be added to my delegated stake?"
+    "message": "獲得したADA報酬は委任中のステークに加算されますか？"
   },
   "delegation.faq.a12.p1": {
-    "message": "Yes. Rewards earned accrue with your original stake. When rewards are received, the balance of your reward account increases – and, consequently, the delegated stake is increased."
+    "message": "はい。獲得した報酬は元のステークに加算されます。報酬を受け取ると、報酬アカウントの残高が増加し、それに伴い委任されたステークも増加します。"
   },
   "stakePoolDelegation.hero.title": {
-    "message": "Delegate Your Stake"
+    "message": "ステークを委任する"
   },
   "stakePoolDelegation.hero.description": {
-    "message": "To build the network, earn rewards, and become part of the Cardano journey."
+    "message": "ネットワークを構築し、報酬を獲得し、Cardanoの旅に参加しましょう。"
   },
   "stakePoolDelegation.meta.title": {
-    "message": "Delegate ada, Cardano Staking Made Simple"
+    "message": "Delegate your stake | cardano.org"
   },
   "stakePoolDelegation.meta.description": {
-    "message": "Delegate your stake to build the network, earn rewards, and become part of the Cardano journey."
+    "message": "ステークを委任して、ネットワークを構築し、報酬を獲得し、Cardanoの旅に参加しましょう。"
   },
   "stakePoolDelegation.whatIsStake.divider": {
-    "message": "What is stake?"
+    "message": "ステークとは？"
   },
   "stakePoolDelegation.whatIsStake.text1": {
-    "message": "Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to delegate or pledge a stake is fundamental to how Cardano works."
+    "message": "Cardanoネットワーク上で保有されるADAはネットワークにおけるステークを表し、ステークのサイズは保有するADAの量に比例します。ステークを委任または誓約する能力は、Cardanoの仕組みの基本です。"
   },
   "stakePoolDelegation.whatIsStake.text2": {
-    "message": "There are two ways an ada holder can earn rewards: by delegating their stake to a stake pool run by someone else, or running their own stake pool. The amount of stake delegated to a given stake pool is the primary way the Ouroboros protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so."
+    "message": "ADA保有者が報酬を得る方法は2つあります。他者が運営するステークプールにステークを委任する方法と、自分でステークプールを運営する方法です。特定のステークプールに委任されたステーク量は、Ouroborosプロトコルがブロックチェーンに次のブロックを追加し金銭的報酬を受け取るべきノードを選択する主な基準です。"
   },
   "stakePoolDelegation.whatIsStake.text3": {
-    "message": "The more stake is delegated to a stake pool (up to a certain point), the more likely it is to make the next block – and the rewards are shared between everyone who delegated their stake to that stake pool."
+    "message": "ステークプールに委任されたステークが多いほど（一定のポイントまで）、次のブロックを作成する可能性が高くなり、報酬はそのプールにステークを委任した全員で分配されます。"
   },
   "stakePoolDelegation.whatIsDelegation.divider": {
-    "message": "What is stake delegation?"
+    "message": "ステーク委任とは？"
   },
   "stakePoolDelegation.whatIsDelegation.text": {
-    "message": "Delegation is the process by which ada holders delegate the stake associated with their ada to a stake pool. It allows ada holders that do not have the skills or desire to run a node to participate in the network and be rewarded in proportion to the amount of stake delegated."
+    "message": "委任とは、ADA保有者がADAに関連するステークをステークプールに委任するプロセスです。ノードを運営するスキルや意欲のないADA保有者がプロトコルに参加し、委任量に応じた報酬を得ることを可能にします。"
   },
   "stakePoolDelegation.whyIncentives.divider": {
-    "message": "Why incentives?"
+    "message": "なぜインセンティブ？"
   },
   "stakePoolDelegation.whyIncentives.text": {
-    "message": "Incentives are used to ensure the longevity and health of the Cardano network and ecosystem. The incentive mechanism is underpinned by scientific research that combines mathematics, economic theory, and game theory."
+    "message": "インセンティブは、Cardanoネットワークとエコシステムの長寿と健全性を確保するために使用されます。インセンティブメカニズムは、数学、経済理論、ゲーム理論を組み合わせた科学的研究に基づいています。"
   },
   "stakePoolDelegation.walletsCta.title": {
-    "message": "Cardano Wallets"
+    "message": "Cardanoウォレット"
   },
   "stakePoolDelegation.walletsCta.text": {
-    "message": "Discover a wide variety of wallets designed to facilitate your interaction with the Cardano ecosystem."
+    "message": "Cardanoエコシステムとのやり取りを容易にする多様なウォレットを見つけましょう。"
   },
   "stakePoolDelegation.walletsCta.buttonLabel": {
-    "message": "Discover Now"
+    "message": "今すぐ見る"
   },
   "stakePoolDelegation.calculatorCta.title": {
-    "message": "Try our staking calculator to see how much ada you could be rewarded for delegating to a stake pool."
+    "message": "ステーキング計算機を使って、ステークプールに委任した場合にどのくらいのADAが獲得できるか確認してみましょう。"
   },
   "stakePoolDelegation.calculatorCta.buttonLabel": {
-    "message": "Try Out"
+    "message": "試してみる"
   },
   "stakePoolOperation.hero.title1": {
-    "message": "Designed For Mass Participation"
+    "message": "大規模参加のために設計"
   },
   "stakePoolOperation.hero.title2": {
-    "message": "Built For Secure Decentralization"
+    "message": "安全な分散化のために構築"
   },
   "stakePoolOperation.hero.description": {
-    "message": "Become a stake pool operator, earn ada, and contribute to the decentralization of the Cardano network."
+    "message": "ステークプールオペレーターになり、ADAを獲得し、Cardanoネットワークの分散化に貢献しましょう。"
   },
   "stakePoolOperation.meta.title": {
-    "message": "Run a Cardano Stake Pool, Setup and Requirements"
+    "message": "Operate a stake pool | cardano.org"
   },
   "stakePoolOperation.meta.description": {
-    "message": "Become a stake pool operator, earn ada, and contribute to the decentralization of the Cardano network."
+    "message": "ステークプールオペレーターになり、ADAを獲得し、Cardanoネットワークの分散化に貢献しましょう。"
   },
   "stakePoolOperation.whatIsStaking.divider": {
-    "message": "What is staking?"
+    "message": "ステーキングとは？"
   },
   "stakePoolOperation.whatIsStaking.leftText": {
-    "message": "Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to delegate or pledge a stake is fundamental to how Cardano works."
+    "message": "Cardanoネットワーク上で保有されるADAはネットワークにおけるステークを表し、ステークのサイズは保有するADAの量に比例します。ステークを委任または誓約する能力は、Cardanoの仕組みの基本です。"
   },
   "stakePoolOperation.whatIsStaking.rightText1": {
-    "message": "There are two ways an ada holder can earn rewards: by delegating their stake to a stake pool run by someone else, or by running their own stake pool."
+    "message": "ADA保有者が報酬を得る方法は2つあります。他者が運営するステークプールにステークを委任する方法と、自分でステークプールを運営する方法です。"
   },
   "stakePoolOperation.whatIsStaking.rightText2": {
-    "message": "The amount of stake delegated to a given stake pool is the primary way the Ouroboros protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so."
+    "message": "特定のステークプールに委任されたステーク量は、Ouroborosプロトコルがブロックチェーンに次のブロックを追加し金銭的報酬を受け取るべきノードを選択する主な基準です。"
   },
   "stakePoolOperation.whatIsStaking.rightText3": {
-    "message": "The more stake is delegated to a stake pool (up to a certain point), the more likely it is to make the next block – and the rewards that it earns are shared between everyone who delegated their stake to that stake pool."
+    "message": "ステークプールに委任されたステークが多いほど（一定のポイントまで）、次のブロックを作成する可能性が高くなり、報酬はそのプールにステークを委任した全員で分配されます。"
   },
   "stakePoolOperation.whatIsStakePool.divider": {
-    "message": "What is stake pool?"
+    "message": "ステークプールとは？"
   },
   "stakePoolOperation.whatIsStakePool.text1": {
-    "message": "Stake pools may be either public or private. A public stake pool is a Cardano network node with a public address that other users can delegate to, and receive rewards. Private stake pools only deliver rewards to their owners."
+    "message": "ステークプールにはパブリックとプライベートがあります。パブリックステークプールは公開アドレスを持つCardanoネットワークノードで、他のユーザーが委任して報酬を受け取れます。プライベートステークプールはオーナーのみに報酬を配布します。"
   },
   "stakePoolOperation.whatIsStakePool.text2": {
-    "message": "Stake pools are run by a reliable operator: an individual or business with the knowledge and resources to run the node on a consistent basis. Ada holders can delegate to public stake pools if they wish to participate in the protocol and receive rewards, but do not wish to operate a Cardano network node themselves."
+    "message": "ステークプールは信頼できるオペレーター（ノードを安定的に稼働させる知識とリソースを持つ個人または企業）によって運営されます。ADA保有者はプロトコルに参加して報酬を得たいが、自分でCardanoネットワークノードを運営したくない場合、パブリックステークプールに委任できます。"
   },
   "stakePoolOperation.whatIsStakePool.text3": {
-    "message": "The more stake that is delegated to a stake pool, the greater chance it has of being selected as a slot leader. Each time it is selected and produces a block that is accepted onto the blockchain, it is rewarded, and these rewards are shared between the stake pool operator and stake pool delegators."
+    "message": "ステークプールに委任されたステークが多いほど、スロットリーダーに選ばれる可能性が高くなります。選ばれてブロックを生成しブロックチェーンに承認されるたびに報酬を受け取り、その報酬はステークプールオペレーターと委任者の間で分配されます。"
   },
   "stakePoolOperation.whatIsStakePool.text4": {
-    "message": "Extensive research and development has gone into ensuring a fair, competitive marketplace that proportionately incentivizes participation, and rewards the investment of time, energy, and resources. The key technical parameters influencing stake pools and the rewards received are:"
+    "message": "公平で競争力のある市場を確保し、参加を比例的にインセンティブ化し、時間・エネルギー・リソースの投資に報いるために、広範な研究開発が行われてきました。ステークプールと受け取る報酬に影響を与える主な技術パラメータは以下の通りです："
   },
   "stakePoolOperation.pledging.title": {
-    "message": "Pledging Mechanism"
+    "message": "誓約メカニズム"
   },
   "stakePoolOperation.pledging.text": {
-    "message": "While there is no required minimum pledge amount, pool operators can optionally pledge some or all of their stake to their pool to make their pool more attractive. The higher the amount of ada pledged, the more rewards the pool will receive, which will attract more delegation. The a0 protocol parameter defines the influence of the pledge on the pool reward."
+    "message": "必須の最低誓約額はありませんが、プールオペレーターは任意で自分のステークの一部または全部をプールに誓約し、プールの魅力を高めることができます。誓約するADAの額が多いほど、プールが受け取る報酬が増え、より多くの委任を引き付けます。a0プロトコルパラメータが、プール報酬に対する誓約の影響度を定義します。"
   },
   "stakePoolOperation.desirability.title": {
-    "message": "Desirability Index"
+    "message": "デザイラビリティインデックス"
   },
   "stakePoolOperation.desirability.text": {
-    "message": "The desirability of a pool is calculated by taking the pledged owner's stake, costs, and margin, and combining them with an influence from saturation and pool performance. This number will be used to rank pools in wallets, and indicates how 'desirable' or 'attractive' the pool is to potential delegators."
+    "message": "プールのデザイラビリティは、誓約されたオーナーのステーク、コスト、マージンを考慮し、飽和度とプールパフォーマンスの影響を組み合わせて計算されます。この数値はウォレット内でプールをランク付けするために使用され、潜在的な委任者にとってプールがどれだけ「望ましい」または「魅力的」かを示します。"
   },
   "stakePoolOperation.saturation.title": {
-    "message": "Saturation Parameter (K)"
+    "message": "飽和パラメータ（K）"
   },
   "stakePoolOperation.saturation.text": {
-    "message": "Saturation is a term used to indicate that a particular stake pool has more stake delegated to it than is ideal for the network, while k is the targeted number of desired pools. Once a pool reaches the point of saturation, it will offer diminishing rewards. The saturation mechanism was designed to prevent centralization by encouraging delegators to delegate to different stake pools, and to incentivize operators to set up alternative pools so that they can continue earning maximum rewards. Saturation, therefore, exists to preserve the interests of both ada holders delegating their stake and stake pool operators, and to prevent any single pool from becoming too large."
+    "message": "飽和とは、特定のステークプールにネットワークにとって理想的な量以上のステークが委任されている状態を示す用語であり、kは目標とする望ましいプール数です。プールが飽和点に達すると、報酬は減少します。飽和メカニズムは、委任者が異なるプールに委任するよう促し、オペレーターが最大報酬を獲得し続けるために代替プールを設立するインセンティブを与えることで、中央集権化を防ぐために設計されました。したがって、飽和はADA保有者とオペレーターの双方の利益を保護し、単一のプールが大きくなりすぎるのを防ぐために存在します。"
   },
   "stakePoolOperation.setupCta.title": {
-    "message": "How do I set up a stake pool?"
+    "message": "ステークプールの設定方法は？"
   },
   "stakePoolOperation.setupCta.text1": {
-    "message": "It's important to remember the role of a stake pool operator: to ensure reliable, 24/7 operation of a network node. As a stake pool operator, you have a responsibility to the ada holders who delegate to you but also to the health of the network itself. This requires a stable and reliable network infrastructure and, ideally, system operation and server administration skills along with experience in development and operations."
+    "message": "ステークプールオペレーターの役割を忘れないでください。ネットワークノードの24時間365日の信頼性の高い稼働を保証することです。ステークプールオペレーターとして、委任者であるADA保有者に対してだけでなく、ネットワーク自体の健全性に対しても責任があります。これには安定した信頼性の高いネットワークインフラが必要であり、システム運用やサーバー管理のスキルに加え、開発と運用の経験があることが理想的です。"
   },
   "stakePoolOperation.setupCta.text2": {
-    "message": "Anybody can learn how to operate a stake pool, but a degree of technical familiarity and knowledge is required."
+    "message": "誰でもステークプールの運営方法を学べますが、ある程度の技術的な知識が必要です。"
   },
   "stakePoolOperation.setupCta.buttonLabel": {
-    "message": "Learn how"
+    "message": "方法を学ぶ"
   },
   "stakePoolOperation.calculatorCta.title": {
-    "message": "Try our staking calculator to see how much ada you could receive by running a stake pool."
+    "message": "ステーキング計算機を使って、ステークプールを運営した場合にどのくらいのADAが獲得できるか確認してみましょう。"
   },
   "stakePoolOperation.calculatorCta.buttonLabel": {
-    "message": "Try Out"
+    "message": "試してみる"
   },
   "useCases.hero.title": {
-    "message": "Use Cases"
+    "message": "ユースケース"
   },
   "useCases.hero.description": {
-    "message": "How Cardano blockchain solves real-world problems across industries."
+    "message": "Cardanoブロックチェーンが業界をまたいで現実世界の問題を解決する方法。"
   },
   "useCases.layout.title": {
-    "message": "Cardano Enterprise Solutions and Real-World Use Cases"
+    "message": "Use cases for enterprise | cardano.org"
   },
   "useCases.layout.description": {
-    "message": "Explore real-world Cardano use cases across supply chain, identity, finance, and education. See how enterprises leverage blockchain for transparency and efficiency."
+    "message": "An open platform designed to empower billions without economic identity by offering decentralized applications for managing identity, value, and governance."
   },
   "useCases.intro.description": {
-    "message": "Explore blockchain applications across industries. From identity verification to supply chain tracking, Cardano provides secure, scalable solutions for real-world challenges."
+    "message": "アイデンティティ検証からサプライチェーントラッキングまで、業界をまたいだブロックチェーンアプリケーションを探索しましょう。Cardanoは現実世界の課題に対する安全でスケーラブルなソリューションを提供します。"
   },
   "useCases.divider.enterprise": {
-    "message": "Enterprise Solutions"
+    "message": "エンタープライズソリューション"
   },
   "useCases.enterprise.description": {
-    "message": "Looking for proven enterprise deployments? Explore case studies and real-world implementations by the Cardano Foundation and partners."
+    "message": "実証済みのエンタープライズ導入をお探しですか？Cardano Foundationとパートナーによる導入事例と実際の実装を探索しましょう。"
   },
   "useCases.enterprise.button": {
-    "message": "View Enterprise Solutions"
+    "message": "エンタープライズソリューションを見る"
   },
   "why.hero.title": {
-    "message": "Why Cardano?"
+    "message": "なぜCardano？"
   },
   "why.hero.description": {
-    "message": "Wondering about Cardano's motiviation?"
+    "message": "Cardanoの動機について知りたいですか？"
   },
   "why.meta.title": {
-    "message": "Why Cardano, What Makes It Different"
+    "message": "Why Cardano? | cardano.org"
   },
   "why.meta.description": {
-    "message": "Cardano combines peer-reviewed research, formal verification, and a proof-of-stake protocol to deliver a secure, sustainable, and scalable blockchain platform."
+    "message": "Wondering about Cardano's motiviation?"
   },
   "why.divider.howItAllBegan": {
-    "message": "How it all began"
+    "message": "すべてはここから始まった"
   },
   "why.whatIsCardano.title": {
-    "message": "What is Cardano?"
+    "message": "Cardanoとは？"
   },
   "why.whatIsCardano.text1": {
-    "message": "Cardano is a blockchain platform and cryptocurrency project that began in 2015. It was created to rethink how cryptocurrencies are designed and developed, with the goal of providing a more balanced and sustainable ecosystem for users and for other systems that might integrate with it. The [cryptocurrency of the Cardano platform is called ada](/what-is-ada). In simple terms, Cardano is a technology that allows people to manage and exhange value, identity and governance over the internet."
+    "message": "Cardanoは2015年に始まったブロックチェーンプラットフォームであり暗号資産プロジェクトです。暗号資産の設計と開発の方法を見直し、利用者と連携するシステムにとってより均衡のとれた持続可能なエコシステムを提供することを目標に創られました。[Cardanoプラットフォームの暗号資産はADA](/what-is-ada)と呼ばれます。簡単に言えば、Cardanoはインターネット上で価値、アイデンティティ、ガバナンスを管理・交換できる技術です。"
   },
   "why.whatIsCardano.text2": {
-    "message": "Cardano is often called a third-generation blockchain. Bitcoin was the first generation (focusing on digital money), Ethereum the second (adding smart contracts - programs that run on the blockchain), and Cardano aims to be the next step by solving issues of scalability, interoperability, and sustainability that earlier networks face. It's an open-source project, meaning its code is public and it's developed by a broad community of engineers and researchers rather than a single company."
+    "message": "Cardanoは第三世代ブロックチェーンと呼ばれることがあります。Bitcoinが第一世代（デジタルマネーに焦点）、Ethereumが第二世代（スマートコントラクトを追加）であるのに対し、Cardanoは以前のネットワークが直面するスケーラビリティ、相互運用性、持続可能性の課題を解決する次のステップを目指しています。オープンソースプロジェクトであり、コードは公開されていて、単一企業ではなく幅広いエンジニアと研究者のコミュニティによって開発されています。"
   },
   "why.whyCreated.title": {
-    "message": "Why was Cardano created?"
+    "message": "なぜCardanoが作られたのか？"
   },
   "why.whyCreated.intro": {
-    "message": "The creators of Cardano saw that despite the success of Bitcoin and other cryptocurrencies, there were major challenges preventing mainstream adoption and long-term utility. Cardano's development started by identifying these problems and setting principles to solve them."
+    "message": "Cardanoの創設者たちは、Bitcoinや他の暗号資産の成功にもかかわらず、主流への普及と長期的な実用性を妨げる大きな課題があることを認識していました。Cardanoの開発は、これらの問題を特定し、それを解決するための原則を設定することから始まりました。"
   },
   "why.whyCreated.list.sustainability": {
-    "message": "**Lack of Sustainability:** Many crypto projects rely on initial funding (like ICOs) and have no built-in way to fund future improvements. This can lead to stagnation. The goal was to establish a sustainable funding mechanism to support long-term development. This led to the idea of a treasury system – a community-controlled fund designed to finance network upgrades and ongoing maintenance."
+    "message": "**持続可能性の欠如：** 多くの暗号プロジェクトは初期資金（ICOなど）に依存し、将来の改善を資金化する仕組みを持っていません。これは停滞につながる可能性があります。長期的な開発を支援する持続可能な資金メカニズムを確立することが目標でした。これがトレジャリーシステム（コミュニティが管理する、ネットワークのアップグレードと継続的なメンテナンスに資金を提供するファンド）のアイデアにつながりました。"
   },
   "why.whyCreated.list.governance": {
-    "message": "**Governance and Evolution:** Early blockchains had no clear way for users to agree on changes or upgrades (leading to disputes and splits like Bitcoin vs. Bitcoin Cash, or Ethereum vs. Ethereum Classic). Cardano's vision is to enable the community of ada holders to vote on proposals and changes, so the system can upgrade itself over time without breaking. This makes Cardano a self-evolving system that can adapt as needs change."
+    "message": "**ガバナンスと進化：** 初期のブロックチェーンには、変更やアップグレードについてユーザーが合意する明確な方法がありませんでした（Bitcoin対Bitcoin Cash、Ethereum対Ethereum Classicのような紛争や分裂につながりました）。Cardanoのビジョンは、ADA保有者が提案や変更に投票でき、システムが壊れることなく自らアップグレードできるようにすることです。これにより、ニーズの変化に適応できる自己進化型のシステムになります。"
   },
   "why.whyCreated.list.scalability": {
-    "message": "**Scalability:** Bitcoin and Ethereum become slow and expensive as more people use them because they were not designed to scale globally. For example, adding more computers (nodes) to those networks doesn't make them faster; every node still has to process every transaction. Cardano aims to scale to millions or even billions of users."
+    "message": "**スケーラビリティ：** BitcoinとEthereumは、グローバルなスケールを想定して設計されていなかったため、利用者が増えると遅く高コストになります。例えば、ノードを追加しても処理速度は上がりません。すべてのノードがすべてのトランザクションを処理する必要があるためです。Cardanoは数百万、さらには数十億のユーザーにスケールすることを目指しています。"
   },
   "why.whyCreated.list.security": {
-    "message": "**Security and Academic Rigor:** The crypto space sometimes saw new features added without fully studying past research or potential flaws. Cardano's team took a different approach: study the science (cryptography, distributed systems) and use peer-reviewed research before building. In fact, Cardano is built on [a collection of peer-reviewed papers](/research) and formal methods. By involving expert cryptographers and scientists, Cardano tries to ensure its technology is secure and based on evidence rather than only on quick experimentation."
+    "message": "**セキュリティと学術的厳密さ：** 暗号空間では、過去の研究や潜在的な欠陥を十分に調べないまま新機能を追加することがありました。Cardanoのチームは異なるアプローチを取りました：科学（暗号学、分散システム）を研究し、構築する前にピアレビュー済みの研究を活用します。Cardanoは[査読済みの論文集](/research)と形式手法に基づいて構築されています。"
   },
   "why.whyCreated.list.interoperability": {
-    "message": "**Interoperability:** There are thousands of cryptocurrencies, but they often exist in isolation, unable to interact with each other or with legacy systems. Cardano's goal is to make it easier for different blockchains and the traditional financial system to connect. For example, Cardano is exploring sidechains technology to allow value and data to move between Cardano and other blockchains. It's also building in support for standards (similar to how internet protocols work) so it can communicate with banks and regulators if needed, without compromising the core principles of a blockchain."
+    "message": "**相互運用性：** 何千もの暗号資産が存在しますが、互いにまたはレガシーシステムとやり取りできないことが多いです。Cardanoの目標は、異なるブロックチェーンと従来の金融システムの接続を容易にすることです。例えば、Cardanoはサイドチェーン技術を探求し、Cardanoと他のブロックチェーン間で価値とデータの移動を可能にしています。また、銀行や規制当局と通信できるよう標準のサポートも構築していますが、ブロックチェーンの核となる原則は損なわれません。"
   },
   "why.whyCreated.list.realWorld": {
-    "message": "**Addressing Real-World Needs:** Ultimately, Cardano's mission is not just about advancing technology for its own sake. It poses a deeper question: \"What is the point of all of it?\" The answer lies in providing financial services to those who lack access. In many developing countries, people are without banks, legal identity, credit, or insurance. The goal is to bundle these essential services – money transfers, property records, identity, credit, and more – into one secure platform that can operate on a basic smartphone. In regions where traditional banking is unavailable or unaffordable, a blockchain like Cardano has the potential to be transformative, offering people powerful digital financial tools."
+    "message": "**現実世界のニーズへの対応：** Cardanoのミッションは技術の進歩そのものだけではありません。「これがすべて何のためにあるのか？」というより深い問いを投げかけます。その答えは、金融サービスへのアクセスがない人々にサービスを提供することにあります。多くの途上国では、銀行、法的身分証明、信用、保険なしに生活しています。送金、不動産記録、身分証明、信用などの基本的なサービスを、基本的なスマートフォンで動作する一つのセキュアなプラットフォームに統合することが目標です。"
   },
   "why.cta.title": {
-    "message": "The original essay from 2017 outlining the background, philosophy and inspiration behind the Cardano blockchain. By Charles Hoskinson."
+    "message": "Cardanoブロックチェーンの背景、哲学、インスピレーションをまとめた2017年のオリジナルエッセイ。Charles Hoskinson著。"
   },
   "why.cta.buttonLabel": {
-    "message": "Read the essay"
+    "message": "エッセイを読む"
   },
   "apps.hero.title": {
     "message": "Cardano Apps and dApps"
@@ -3074,28 +3074,28 @@
     "message": "Browse {count} curated Cardano apps live on mainnet. Wallets, DEXes, NFT marketplaces, lending, governance, and games. Filter by category or activity."
   },
   "apps.cta": {
-    "message": "₳dd your project"
+    "message": "₳プロジェクトを追加"
   },
   "apps.filters.title": {
-    "message": "Filters"
+    "message": "フィルター"
   },
   "apps.filters.projectCount.singular": {
-    "message": "1 project"
+    "message": "1件のプロジェクト"
   },
   "apps.filters.projectCount.plural": {
-    "message": "{count} projects"
+    "message": "{count}件のプロジェクト"
   },
   "apps.filters.clearButton": {
-    "message": "Clear filters"
+    "message": "フィルターをクリア"
   },
   "apps.filters.showLess": {
-    "message": "Show less filters"
+    "message": "フィルターを表示を減らす"
   },
   "apps.filters.showMore": {
-    "message": "Show {count} more filters"
+    "message": "さらに{count}件のフィルターを表示"
   },
   "apps.noResult": {
-    "message": "No result"
+    "message": "結果なし"
   },
   "apps.maintainerPicks": {
     "message": "Maintainer picks"
@@ -3104,10 +3104,10 @@
     "message": "Curated by page maintainers as strong starting points. Selection criteria: see /docs/get-involved/maintainer-picks."
   },
   "apps.allProjects": {
-    "message": "All Projects"
+    "message": "すべてのプロジェクト"
   },
   "apps.searchPlaceholder": {
-    "message": "Search apps..."
+    "message": "アプリを検索..."
   },
   "apps.intent.title": {
     "message": "Find apps for"
@@ -3122,7 +3122,7 @@
     "message": "Vote"
   },
   "apps.intent.build": {
-    "message": "Build"
+    "message": "開発する"
   },
   "apps.intent.mintNfts": {
     "message": "Mint NFTs"
@@ -3245,10 +3245,10 @@
     "message": "The newest apps in the showcase"
   },
   "apps.carousel.prev": {
-    "message": "Previous"
+    "message": "前へ"
   },
   "apps.carousel.next": {
-    "message": "Next"
+    "message": "次へ"
   },
   "apps.mostActive.leaderboardLink": {
     "message": "Live from the transaction leaderboard"
@@ -3281,7 +3281,7 @@
     "message": "Have a say in Cardano"
   },
   "apps.guidedPaths.developers": {
-    "message": "Build on Cardano"
+    "message": "Cardanoでビルド"
   },
   "apps.submit.enableTracking": {
     "message": "Enable tracking"
@@ -3293,52 +3293,52 @@
     "message": "tx"
   },
   "insights.card.openInsight": {
-    "message": "Open insight"
+    "message": "インサイトを開く"
   },
   "insights.layout.title": {
-    "message": "Cardano Insights, Data and Analytics"
-  },
-  "insights.layout.description": {
-    "message": "Explore interactive Cardano insights across governance, staking, consensus, economics, and more."
-  },
-  "insights.hero.title": {
     "message": "Insights"
   },
+  "insights.layout.description": {
+    "message": "ガバナンス、ステーキング、コンセンサス、経済などのインタラクティブなCardanoインサイトを探索。"
+  },
+  "insights.hero.title": {
+    "message": "インサイト"
+  },
   "insights.hero.description": {
-    "message": "Explore Cardano topics through on-chain data and visual charts."
+    "message": "オンチェーンデータとビジュアルチャートでCardanoのトピックを探索。"
   },
   "insights.search.placeholder": {
-    "message": "Search or filter by tags below..."
+    "message": "検索またはタグでフィルター..."
   },
   "insights.search.ariaLabel": {
-    "message": "Search insights"
+    "message": "インサイトを検索"
   },
   "insights.filter.label": {
-    "message": "Filter by topic"
+    "message": "トピックでフィルター"
   },
   "insights.filter.clear": {
-    "message": "Clear"
+    "message": "クリア"
   },
   "insights.pagination.prevAriaLabel": {
-    "message": "Previous page"
+    "message": "前のページ"
   },
   "insights.pagination.prev": {
-    "message": "Prev"
+    "message": "前へ"
   },
   "insights.pagination.pageOf": {
-    "message": "Page {current} of {total}"
+    "message": "{total}ページ中{current}ページ"
   },
   "insights.pagination.nextAriaLabel": {
-    "message": "Next page"
+    "message": "次のページ"
   },
   "insights.pagination.next": {
-    "message": "Next"
+    "message": "次へ"
   },
   "insights.noResults": {
-    "message": "No insights matched your filters."
+    "message": "フィルター条件に一致するインサイトがありません。"
   },
   "ambassadors.roles.contentCreation.title": {
-    "message": "Content Creation"
+    "message": "コンテンツ制作"
   },
   "ambassadors.roles.contentCreation.description": {
     "message": "Articles, videos, podcasts and translations across languages."
@@ -3350,13 +3350,13 @@
     "message": "Organizing local meetups, workshops, hackathons and conferences."
   },
   "ambassadors.roles.education.title": {
-    "message": "Education & Advocacy"
+    "message": "教育＆アドボカシー"
   },
   "ambassadors.roles.education.description": {
     "message": "Teaching, onboarding new users and raising awareness."
   },
   "ambassadors.roles.business.title": {
-    "message": "Business Development"
+    "message": "ビジネス開発"
   },
   "ambassadors.roles.business.description": {
     "message": "Growing partnerships and real-world adoption."
@@ -3368,7 +3368,7 @@
     "message": "Building tools, contributing to open source and technical docs."
   },
   "ambassadors.roles.moderation.title": {
-    "message": "Moderation"
+    "message": "モデレーション"
   },
   "ambassadors.roles.moderation.description": {
     "message": "Creating safe, welcoming and informative spaces."
@@ -3691,6 +3691,9 @@
   "ambassadors.directory.socialAria.youtube": {
     "message": "YouTube channel"
   },
+  "ambassadors.directory.socialAria.github": {
+    "message": "GitHub profile"
+  },
   "ambassadors.stories.divider": {
     "message": "Impact Stories"
   },
@@ -3740,91 +3743,91 @@
     "message": "Open-source contributions that make Cardano easier to use for developers everywhere."
   },
   "enterprise.label.solutions": {
-    "message": "Solutions"
+    "message": "ソリューション"
   },
   "enterprise.label.products": {
-    "message": "Products"
+    "message": "プロダクト"
   },
   "enterprise.learnMore": {
-    "message": "Learn more"
+    "message": "詳しく見る"
   },
   "governance.blue.title": {
-    "message": "A Model To Marginalize None, And Give Power To All."
+    "message": "誰も排除せず、すべての人に力を与えるモデル。"
   },
   "governance.blue.text": {
-    "message": "Our current systems do not work for everyone. A better, more positive future is possible. If the world is to serve the many, it must be agreed to by the many. Consensus must drive progress and where disagreement occurs, it must drive creative solutions."
+    "message": "現在のシステムは誰にとっても機能しているわけではありません。より良い、よりポジティブな未来は可能です。世界が多くの人に奉仕するためには、多くの人の合意が必要です。コンセンサスが進歩を推進し、意見の相違がある場合には、創造的な解決策を生み出す原動力となるべきです。"
   },
   "governanceCharts.searchPlaceholder": {
-    "message": "Search for charts or parameters..."
+    "message": "チャートやパラメータを検索..."
   },
   "governanceCharts.parametersButton": {
-    "message": "Parameters ▼"
+    "message": "パラメータ ▼"
   },
   "governanceCharts.availableParameters": {
-    "message": "Available Parameters:"
+    "message": "利用可能なパラメータ："
   },
   "governanceCharts.clearAll": {
-    "message": "Clear All"
+    "message": "すべてクリア"
   },
   "governanceCharts.selectCategory": {
-    "message": "Select a category:"
+    "message": "カテゴリを選択："
   },
   "governanceCharts.searchAndParamResults": {
-    "message": "Search Results & Parameter Filtered Charts:"
+    "message": "検索結果＆パラメータフィルターチャート："
   },
   "governanceCharts.searchResults": {
-    "message": "Search Results:"
+    "message": "検索結果："
   },
   "governanceCharts.paramFilteredCharts": {
-    "message": "Parameter Filtered Charts:"
+    "message": "パラメータフィルターチャート："
   },
   "governanceCharts.parameterDetails": {
-    "message": "Parameter Details"
+    "message": "パラメータ詳細"
   },
   "governanceCharts.noResults.searchAndParams": {
-    "message": "No charts found matching \"{searchTerm}\" with the selected parameters."
+    "message": "「{searchTerm}」と選択したパラメータに一致するチャートが見つかりません。"
   },
   "governanceCharts.noResults.search": {
-    "message": "No charts found matching \"{searchTerm}\""
+    "message": "「{searchTerm}」に一致するチャートが見つかりません"
   },
   "governanceCharts.noResults.params": {
-    "message": "No charts found with the selected parameters."
+    "message": "選択したパラメータに一致するチャートが見つかりません。"
   },
   "governanceCharts.selectChart": {
-    "message": "Select a chart:"
+    "message": "チャートを選択："
   },
   "governanceCharts.emptyState": {
-    "message": "No charts available for this category yet."
+    "message": "このカテゴリにはまだチャートがありません。"
   },
   "governanceCharts.initialPrompt": {
-    "message": "Please select a category to view available governance charts, or use the search to find specific charts."
+    "message": "カテゴリを選択してガバナンスチャートを表示するか、検索を使って特定のチャートを探してください。"
   },
   "governanceGraphs.fallback.unavailable": {
-    "message": "Graph visualization unavailable"
+    "message": "グラフの可視化は利用できません"
   },
   "governanceGraphs.fallback.preview": {
-    "message": "Data preview:"
+    "message": "データプレビュー："
   },
   "governanceGraphs.downloading": {
-    "message": "Downloading..."
+    "message": "ダウンロード中..."
   },
   "governanceGraphs.downloadImage": {
-    "message": "Download Image"
+    "message": "画像をダウンロード"
   },
   "governance.voltaire.text1": {
-    "message": "Decentralization begins with the technology - with Shelley - but is only truly achieved when no single entity is in control. The governing principle of decentralization is the redistribution of control: global networks that are defined not from the middle, but by every participant. This is the purpose of Voltaire."
+    "message": "分散化はテクノロジー（Shelley）から始まりますが、単一の組織がコントロールしない状態になって初めて真に達成されます。分散化の基本原則は、コントロールの再分配です。中央からではなく、すべての参加者によって定義されるグローバルネットワーク。これがVoltaireの目的です。"
   },
   "governance.voltaire.text2": {
-    "message": "Voltaire adds the ability for the Cardano community to make impactful decisions about software updates, technical improvements and funding decisions. Known as"
+    "message": "Voltaireは、Cardanoコミュニティがソフトウェアアップデート、技術的改善、資金決定について影響力のある決定を行う能力を加えます。"
   },
   "governance.voltaire.text2b": {
-    "message": ", these allow the future of Cardano to be determined by its community and funded from the platform's treasury."
+    "message": "により、Cardanoの未来はコミュニティによって決定され、プラットフォームのトレジャリーから資金が提供されます。"
   },
   "governance.voltaire.text3": {
-    "message": "The era will also play host to a series of experiments, as we discuss topics such as decentralised governance, the dynamics of democracy and consent, evolving Voltaire from research to reality. If Shelley was the foundation of a globally coordinated network without a central authority, then Voltaire will explore the apparatus for shared decision making: the language of decentralization."
+    "message": "このエラでは、分散型ガバナンス、民主主義と同意のダイナミクスなどのトピックについて一連の実験も行われ、Voltaireを研究から現実へと進化させます。Shelleyが中央権限のないグローバルに調整されたネットワークの基盤であったなら、Voltaireは共同意思決定の仕組み、つまり分散化の言語を探求します。"
   },
   "governance.voltaire.buttonText": {
-    "message": "Read the research"
+    "message": "研究を読む"
   },
   "governance.delegate.layout.title": {
     "message": "Delegate to a DRep — Cardano Governance"
@@ -3965,450 +3968,450 @@
     "message": "Dashboard to monitor DReps and governance actions."
   },
   "quiz.ui.noQuestions": {
-    "message": "No quiz questions available."
+    "message": "クイズの質問がありません。"
   },
   "quiz.ui.greatJob": {
-    "message": "Great job!"
+    "message": "よくできました！"
   },
   "quiz.ui.keepLearning": {
-    "message": "Keep learning!"
+    "message": "学び続けましょう！"
   },
   "quiz.ui.scoreText": {
-    "message": "You scored {score} out of {totalQuestions}"
+    "message": "{totalQuestions}問中{score}問正解"
   },
   "quiz.ui.tryAgain": {
-    "message": "Try again"
+    "message": "もう一度挑戦"
   },
   "quiz.ui.correct": {
-    "message": "Correct!"
+    "message": "正解！"
   },
   "quiz.ui.incorrect": {
-    "message": "Incorrect"
+    "message": "不正解"
   },
   "quiz.ui.explanation": {
-    "message": "Explanation"
+    "message": "解説"
   },
   "quiz.ui.checkAnswer": {
-    "message": "Check answer"
+    "message": "回答を確認"
   },
   "quiz.ui.nextQuestion": {
-    "message": "Next question"
+    "message": "次の質問"
   },
   "quiz.ui.finishQuiz": {
-    "message": "Finish quiz"
+    "message": "クイズ完了"
   },
   "research.headings.papers": {
-    "message": "Papers"
+    "message": "論文"
   },
   "research.headings.specifications": {
-    "message": "Specifications"
+    "message": "仕様"
   },
   "research.byron.subtitle": {
-    "message": "Foundation"
+    "message": "基盤"
   },
   "research.byron.description": {
-    "message": "A period dedicated to building a foundational federated network that enabled the purchase and sale of ada. The network ran the proof-of-stake Ouroboros consensus protocol."
+    "message": "フェデレーテッドネットワークの基盤を構築し、ADAの購入・売却を可能にした期間。ネットワークはプルーフ・オブ・ステークのOuroborosコンセンサスプロトコルで稼働しました。"
   },
   "research.shelley.subtitle": {
-    "message": "Decentralization"
+    "message": "分散化"
   },
   "research.shelley.description": {
-    "message": "A period of growth and development occurred for the network, focusing on ensuring greater decentralization. This phase led to enhanced security and a more robust environment, following the transition where the majority of nodes became operated by network participants."
+    "message": "ネットワークの成長と発展が進み、より大きな分散化に焦点を当てた期間。このフェーズでは、ノードの大部分がネットワーク参加者によって運営されるようになり、セキュリティが強化され、より堅牢な環境が実現しました。"
   },
   "research.goguen.subtitle": {
-    "message": "Smart Contracts"
+    "message": "スマートコントラクト"
   },
   "research.goguen.description": {
-    "message": "The Goguen era introduced smart-contract functionality, enabling the construction of decentralized applications while supporting multifunctional assets, fungible, and non-fungible token standards."
+    "message": "Goguenエラではスマートコントラクト機能が導入され、分散型アプリケーションの構築が可能になり、多機能資産、ファンジブルトークン、非代替性トークン（NFT）規格がサポートされました。"
   },
   "research.basho.subtitle": {
-    "message": "Scaling"
+    "message": "スケーリング"
   },
   "research.basho.description": {
-    "message": "An era of optimization, improving the scalability and interoperability of the network. Enhancing the network performance, Basho will introduce sidechains, new blockchains, interoperable with the main Cardano chain, with immense potential to extend the network's capabilities."
+    "message": "最適化のエラ。ネットワークのスケーラビリティと相互運用性を向上させます。Bashoではサイドチェーン（メインのCardanoチェーンと相互運用可能な新しいブロックチェーン）が導入され、ネットワークの機能を拡張する大きな可能性を持っています。"
   },
   "research.voltaire.subtitle": {
-    "message": "Governance"
+    "message": "ガバナンス"
   },
   "research.voltaire.description": {
-    "message": "The development era is currently enabling the Cardano network to become a self-sustaining system. Voltaire is introducing a voting and treasury system that allows network participants to use their stake and voting rights to influence the future development of the blockchain."
+    "message": "現在の開発エラは、Cardanoネットワークを自立型システムにすることを目指しています。Voltaireでは、ネットワーク参加者がステークと投票権を使ってブロックチェーンの将来の開発に影響を与えることができる投票・トレジャリーシステムが導入されています。"
   },
   "solutions.card.learnMore": {
-    "message": "Learn more"
+    "message": "詳しく見る"
   },
   "solutions.section.title": {
-    "message": "Enterprise Solutions"
+    "message": "エンタープライズソリューション"
   },
   "termExplainer.divider": {
-    "message": "{category} Terms you should know"
+    "message": "{category}の知っておくべき用語"
   },
   "apps.stickyButton": {
-    "message": "ADD YOUR APP"
+    "message": "アプリを追加"
   },
   "insightsGovernance.meta.pageTitle": {
-    "message": "Cardano Governance Action Charts"
+    "message": "Cardanoガバナンスアクションチャート"
   },
   "insightsGovernance.meta.pageDescription": {
-    "message": "Visual representation of Cardano Governance Action process flows."
+    "message": "Cardanoガバナンスアクションプロセスフローのビジュアル表示。"
   },
   "insightsGovernance.meta.title": {
-    "message": "Cardano Governance Actions"
+    "message": "Cardanoガバナンスアクション"
   },
   "insightsGovernance.og.title": {
-    "message": "Cardano Governance Actions"
+    "message": "Cardanoガバナンスアクション"
   },
   "insightsGovernance.og.description": {
-    "message": "Explore the Cardano Governance Action flow logic."
+    "message": "Cardanoガバナンスアクションのフローロジックを探索。"
   },
   "insightsGovernance.page.title": {
-    "message": "Cardano Governance Action Charts"
+    "message": "Cardanoガバナンスアクションチャート"
   },
   "insightsGovernance.page.description": {
-    "message": "Explore the Cardano Governance Action Flows in a visual chart visualization"
+    "message": "Cardanoガバナンスアクションフローをビジュアルチャートで探索"
   },
   "insightsGovernance.page.keywords": {
-    "message": "Cardano, governance, action, DRep, SPO, voting, threshold"
+    "message": "Cardano, ガバナンス, アクション, DRep, SPO, 投票, 閾値"
   },
   "insightsGovernance.intro.paragraph1": {
-    "message": "**Governance Actions Insights** visualizes the seven Cardano governance action types as flowcharts. Each chart shows the lifecycle (submission → ratification → enactment), who votes (DReps, SPOs, Constitutional Committee) and the thresholds. Most actions require approval from **at least two of the three** bodies; some require **all three**. For definitions and full thresholds, see the [Developer Portal: Governance Actions](https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/)."
+    "message": "**ガバナンスアクションインサイト**は、7つのCardanoガバナンスアクションタイプをフローチャートで可視化します。各チャートはライフサイクル（提出 → 批准 → 制定）、投票者（DRep、SPO、憲法委員会）、閾値を示します。ほとんどのアクションは**3つの機関のうち少なくとも2つ**の承認が必要です。一部は**3つすべて**が必要です。定義と完全な閾値については、[Developer Portal: Governance Actions](https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/)を参照してください。"
   },
   "insightsGovernance.intro.paragraph2": {
-    "message": "Pick a **category** (General, Info Actions, Protocol Parameter Changes, Critical Parameter Changes), then choose a **chart**. Follow the nodes; **purple boxes** indicate thresholds and enactment order. You can **download** the diagram or simply **share the URL**, the address bar updates to the chart you're viewing. For the formal basis, see the **Cardano Constitution – Appendix I: Guardrails** [constitution](/constitution)."
+    "message": "**カテゴリ**（一般、情報アクション、プロトコルパラメータ変更、重要パラメータ変更）を選び、**チャート**を選択してください。ノードをたどると、**紫のボックス**が閾値と制定順序を示します。図は**ダウンロード**できます。**URLを共有**するだけでもOKです。アドレスバーは表示中のチャートに更新されます。正式な根拠については、**Cardano憲法 – 付録I: ガードレール** [constitution](/constitution)を参照してください。"
   },
   "insightsGovernance.intro.paragraph3": {
-    "message": "For **Protocol Parameter Changes**, the charts separate routine updates (typically **DReps + CC**) from **security-critical parameters**, which also need **SPO approval**, i.e., all three bodies. Appendix I lists the critical parameters and their permitted ranges/scope."
+    "message": "**プロトコルパラメータ変更**のチャートは、通常の更新（通常は**DRep + CC**）と**セキュリティ上重要なパラメータ**を区別しています。後者は**SPOの承認**も必要、つまり3つの機関すべてが必要です。付録Iに重要なパラメータとその許容範囲が記載されています。"
   },
   "insightsGovernance.divider.charts": {
-    "message": "Governance Action Charts"
+    "message": "ガバナンスアクションチャート"
   },
   "insightsSupply.meta.pageTitle": {
-    "message": "Cardano Supply Overview"
+    "message": "Cardano供給概要"
   },
   "insightsSupply.meta.pageDescription": {
-    "message": "Visual representation of ada supply distribution across key categories in the Cardano network."
+    "message": "Cardanoネットワークの主要カテゴリにわたるADA供給分布のビジュアル表示。"
   },
   "insightsSupply.meta.title": {
-    "message": "Cardano Supply Overview"
+    "message": "Cardano供給概要"
   },
   "insightsSupply.og.title": {
-    "message": "Cardano Supply Distribution"
+    "message": "Cardano供給分布"
   },
   "insightsSupply.og.description": {
-    "message": "Explore how ada is distributed across reserves, circulation, treasury, and rewards."
+    "message": "リザーブ、流通、トレジャリー、報酬にわたるADAの分布を探索。"
   },
   "insightsSupply.error.configTitle": {
-    "message": "Missing configuration"
+    "message": "設定が見つかりません"
   },
   "insightsSupply.error.configMessage": {
-    "message": "API URL is missing."
+    "message": "API URLが不足しています。"
   },
   "insightsSupply.error.invalidEpochTitle": {
-    "message": "Invalid epoch"
+    "message": "無効なエポック"
   },
   "insightsSupply.error.invalidEpochMessage": {
-    "message": "Epoch must be ≥ {minEpoch}."
+    "message": "エポックは{minEpoch}以上である必要があります。"
   },
   "insightsSupply.error.retrying": {
-    "message": "Retrying…"
+    "message": "再試行中…"
   },
   "insightsSupply.error.retry": {
-    "message": "Retry"
+    "message": "再試行"
   },
   "insightsSupply.loading.preparing": {
-    "message": "Preparing…"
+    "message": "準備中…"
   },
   "insightsSupply.chart.circulation": {
-    "message": "Circulation"
+    "message": "流通量"
   },
   "insightsSupply.chart.circulationInfo": {
-    "message": "Sum of all circulating UTxOs"
+    "message": "すべての流通UTxOの合計"
   },
   "insightsSupply.chart.treasury": {
-    "message": "Treasury"
+    "message": "トレジャリー"
   },
   "insightsSupply.chart.treasuryInfo": {
-    "message": "All ada currently in the treasury pot"
+    "message": "現在トレジャリーポットにあるすべてのADA"
   },
   "insightsSupply.chart.rewards": {
-    "message": "Rewards"
+    "message": "報酬"
   },
   "insightsSupply.chart.rewardsInfo": {
-    "message": "All unclaimed rewards"
+    "message": "すべての未請求報酬"
   },
   "insightsSupply.chart.depositsStake": {
-    "message": "Deposits Stake"
+    "message": "ステークデポジット"
   },
   "insightsSupply.chart.depositsStakeInfo": {
-    "message": "Deposit pot for registered stake pools and staking accounts"
+    "message": "登録済みステークプールとステーキングアカウントのデポジットポット"
   },
   "insightsSupply.chart.depositsDRep": {
-    "message": "Deposits DRep"
+    "message": "DRepデポジット"
   },
   "insightsSupply.chart.depositsDRepInfo": {
-    "message": "Deposit pot for registered DReps"
+    "message": "登録済みDRepのデポジットポット"
   },
   "insightsSupply.chart.depositsProposal": {
-    "message": "Deposits Proposal"
+    "message": "提案デポジット"
   },
   "insightsSupply.chart.depositsProposalInfo": {
-    "message": "Deposit pot for active governance actions"
+    "message": "アクティブなガバナンスアクションのデポジットポット"
   },
   "insightsSupply.chart.fees": {
-    "message": "Fees"
+    "message": "手数料"
   },
   "insightsSupply.chart.feesInfo": {
-    "message": "Fees collected"
+    "message": "徴収された手数料"
   },
   "insightsSupply.chart.totalSupply": {
-    "message": "Total Supply"
+    "message": "総供給量"
   },
   "insightsSupply.chart.totalSupplyInfo": {
-    "message": "All ada in circulation + unclaimed rewards + deposits + fees + treasury"
+    "message": "流通中のすべてのADA + 未請求報酬 + デポジット + 手数料 + トレジャリー"
   },
   "insightsSupply.chart.reserves": {
-    "message": "Reserves"
+    "message": "リザーブ"
   },
   "insightsSupply.chart.reservesInfo": {
-    "message": "Difference between maximum and total supply"
+    "message": "最大供給量と総供給量の差"
   },
   "insightsSupply.chart.maximumSupply": {
-    "message": "Maximum supply"
+    "message": "最大供給量"
   },
   "insightsSupply.chart.maximumSupplyInfo": {
-    "message": "The maximum amount of ada that can ever exist, based on the genesis block definition."
+    "message": "ジェネシスブロックの定義に基づく、これまでに存在できるADAの最大量。"
   },
   "insightsSupply.table.category": {
-    "message": "Category"
+    "message": "カテゴリ"
   },
   "insightsSupply.table.ada": {
-    "message": "ada"
+    "message": "ADA"
   },
   "insightsSupply.table.description": {
-    "message": "Description"
+    "message": "説明"
   },
   "insightsSupply.faq.heading": {
-    "message": "Epoch {epoch} facts:"
+    "message": "エポック{epoch}のファクト："
   },
   "insightsSupply.faq.q1.question": {
-    "message": "Q: How did the values change compared to the previous Epoch?"
+    "message": "Q: 前のエポックと比較して、数値はどう変わりましたか？"
   },
   "insightsSupply.faq.q2.question": {
-    "message": "Q: How much ada was added to the treasury?"
+    "message": "Q: トレジャリーにどれだけのADAが追加されましたか？"
   },
   "insightsSupply.faq.q3.question": {
-    "message": "Q: How many fees were collected and distributed?"
+    "message": "Q: どれだけの手数料が徴収・分配されましたか？"
   },
   "insightsSupply.faq.q4.question": {
-    "message": "Q: Were there withdrawals from the treasury in epoch {epoch}?"
+    "message": "Q: エポック{epoch}でトレジャリーからの引き出しはありましたか？"
   },
   "insightsSupply.faq.q4.noWithdrawals": {
-    "message": "A: There were no treasury withdrawals during this epoch."
+    "message": "A: このエポック中のトレジャリー引き出しはありませんでした。"
   },
   "insightsSupply.faq.q5.question": {
-    "message": "Q: Where can I learn more about the Cardano Mainnet reward calculation?"
+    "message": "Q: Cardanoメインネットの報酬計算についてもっと詳しく知るには？"
   },
   "insightsSupplySummary.meta.pageTitle": {
-    "message": "Cardano Supply Summary"
+    "message": "Cardano供給サマリー"
   },
   "insightsSupplySummary.meta.pageDescription": {
-    "message": "Historical analysis of Cardano ada supply distribution across reserves, rewards, treasury, and deposits."
+    "message": "リザーブ、報酬、トレジャリー、デポジットにわたるCardano ADA供給分布の履歴分析。"
   },
   "insightsSupplySummary.meta.title": {
-    "message": "Cardano Supply Summary"
+    "message": "Cardano供給サマリー"
   },
   "insightsSupplySummary.og.title": {
-    "message": "Cardano Supply Summary"
+    "message": "Cardano供給サマリー"
   },
   "insightsSupplySummary.og.description": {
-    "message": "Explore historical trends in Cardano supply distribution, reserves, rewards, treasury, and deposits."
+    "message": "Cardano供給分布、リザーブ、報酬、トレジャリー、デポジットの履歴トレンドを探索。"
   },
   "insightsSupplySummary.intro.description": {
-    "message": "**Explore historical trends in Cardano ada supply distribution** across reserves, rewards, treasury, and deposits. Select an epoch range to analyze how these key metrics evolved over time."
+    "message": "**Cardano ADA供給分布の履歴トレンドを探索**しましょう。リザーブ、報酬、トレジャリー、デポジットの推移を分析できます。エポック範囲を選択して、主要指標の時間的な変化を確認しましょう。"
   },
   "insightsSupplySummary.epochSelect.title": {
-    "message": "Select Epoch Range"
+    "message": "エポック範囲を選択"
   },
   "insightsSupplySummary.epochSelect.start": {
-    "message": "Start:"
+    "message": "開始："
   },
   "insightsSupplySummary.epochSelect.end": {
-    "message": "End:"
+    "message": "終了："
   },
   "insightsSupplySummary.loading.initial": {
-    "message": "Loading all epoch data (this may take a moment)..."
+    "message": "全エポックデータを読み込み中（少々お待ちください）..."
   },
   "insightsSupplySummary.loading.data": {
-    "message": "Loading data..."
+    "message": "データを読み込み中..."
   },
   "insightsSupplySummary.loading.loaded": {
-    "message": "Loaded {count} epochs. Adjust the slider to filter the range."
+    "message": "{count}エポックを読み込みました。スライダーで範囲を調整できます。"
   },
   "insightsSupplySummary.loading.currentEpoch": {
-    "message": "Loading current epoch..."
+    "message": "現在のエポックを読み込み中..."
   },
   "insightsSupplySummary.toc.title": {
-    "message": "Contents"
+    "message": "目次"
   },
   "insightsSupplySummary.toc.reserves": {
-    "message": "Reserves Evolution"
+    "message": "リザーブの推移"
   },
   "insightsSupplySummary.toc.rewards": {
-    "message": "Distributed Rewards"
+    "message": "分配された報酬"
   },
   "insightsSupplySummary.toc.treasury": {
-    "message": "Treasury Evolution"
+    "message": "トレジャリーの推移"
   },
   "insightsSupplySummary.toc.deposits": {
-    "message": "Deposits"
+    "message": "デポジット"
   },
   "insightsSupplySummary.reserves.divider": {
-    "message": "Reserves Evolution"
+    "message": "リザーブの推移"
   },
   "insightsSupplySummary.rewards.divider": {
-    "message": "Distributed Rewards"
+    "message": "分配された報酬"
   },
   "insightsSupplySummary.treasury.divider": {
-    "message": "Treasury Evolution"
+    "message": "トレジャリーの推移"
   },
   "insightsSupplySummary.treasuryWithdrawals.divider": {
-    "message": "Treasury Withdrawals in Selected Range"
+    "message": "選択範囲内のトレジャリー引き出し"
   },
   "insightsSupplySummary.treasuryWithdrawals.table.epoch": {
-    "message": "Epoch"
+    "message": "エポック"
   },
   "insightsSupplySummary.treasuryWithdrawals.table.title": {
-    "message": "Title"
+    "message": "タイトル"
   },
   "insightsSupplySummary.treasuryWithdrawals.table.amount": {
-    "message": "Amount (ada)"
+    "message": "金額（ADA）"
   },
   "insightsSupplySummary.treasuryWithdrawals.table.explorer": {
-    "message": "Explorer"
+    "message": "エクスプローラー"
   },
   "insightsSupplySummary.treasuryWithdrawals.table.view": {
-    "message": "View"
+    "message": "表示"
   },
   "insightsSupplySummary.deposits.divider": {
-    "message": "Deposits"
+    "message": "デポジット"
   },
   "insightsTemplate.meta.pageTitle": {
-    "message": "Cardano Insights Template"
+    "message": "Insights Template | cardano.org"
   },
   "insightsTemplate.meta.pageDescription": {
-    "message": "Insights Template"
+    "message": "インサイトテンプレート"
   },
   "insightsTemplate.meta.title": {
-    "message": "This is just an insights template"
+    "message": "これはインサイトテンプレートです"
   },
   "insightsTemplate.og.title": {
-    "message": "This is just an insights template | Cardano.org"
+    "message": "これはインサイトテンプレートです | Cardano.org"
   },
   "insightsTemplate.og.description": {
-    "message": "Detailed description for open graph pages, and more."
+    "message": "Open Graphページの詳細な説明など。"
   },
   "insightsTemplate.page.keywords": {
-    "message": "Cardano, Insights, Template"
+    "message": "Cardano, インサイト, テンプレート"
   },
   "insightsTemplate.content.paragraph1": {
-    "message": "You don't need to use TitleWithText or similar components—plain HTML is fine."
+    "message": "TitleWithTextなどのコンポーネントを使う必要はありません。プレーンHTMLで構いません。"
   },
   "insightsTemplate.content.internalLinksLabel": {
-    "message": "For internal links use:"
+    "message": "内部リンクには以下を使用："
   },
   "insightsTemplate.content.internalLinkText": {
-    "message": "where to get ada?"
+    "message": "ADAの入手方法"
   },
   "insightsTemplate.content.externalLinksLabel": {
-    "message": "For external links use:"
+    "message": "外部リンクには以下を使用："
   },
   "insightsTransactions.meta.pageTitle": {
-    "message": "Cardano Transaction Trends"
+    "message": "Cardanoトランザクショントレンド"
   },
   "insightsTransactions.meta.pageDescription": {
-    "message": "Historical analysis of Cardano transaction counts, fees, and block production across epochs."
+    "message": "エポックごとのCardanoトランザクション数、手数料、ブロック生成の履歴分析。"
   },
   "insightsTransactions.meta.title": {
-    "message": "Cardano Transaction Trends"
+    "message": "Cardanoトランザクショントレンド"
   },
   "insightsTransactions.og.title": {
-    "message": "Cardano Transaction Trends"
+    "message": "Cardanoトランザクショントレンド"
   },
   "insightsTransactions.og.description": {
-    "message": "Explore historical trends in Cardano transactions, fees collected, and block production over time."
+    "message": "Cardanoトランザクション、徴収された手数料、ブロック生成の履歴トレンドを探索。"
   },
   "insightsTransactions.intro.description": {
-    "message": "**Explore historical trends in Cardano transactions** including transaction counts, fees collected, and block production. Select an epoch range to analyze how network activity evolved over time."
+    "message": "**Cardanoトランザクションの履歴トレンドを探索**しましょう。トランザクション数、徴収された手数料、ブロック生成などを含みます。エポック範囲を選択して、ネットワーク活動の時間的な変化を分析しましょう。"
   },
   "insightsTransactions.epochSelect.title": {
-    "message": "Select Epoch Range"
+    "message": "エポック範囲を選択"
   },
   "insightsTransactions.epochSelect.start": {
-    "message": "Start:"
+    "message": "開始："
   },
   "insightsTransactions.epochSelect.epoch": {
-    "message": "Epoch"
+    "message": "エポック"
   },
   "insightsTransactions.epochSelect.end": {
-    "message": "End:"
+    "message": "終了："
   },
   "insightsTransactions.loading.initial": {
-    "message": "Loading all epoch data (this may take a moment)..."
+    "message": "全エポックデータを読み込み中（少々お待ちください）..."
   },
   "insightsTransactions.loading.data": {
-    "message": "Loading data..."
+    "message": "データを読み込み中..."
   },
   "insightsTransactions.loading.loaded": {
-    "message": "Loaded {count} epochs. Adjust the slider to filter the range."
+    "message": "{count}エポックを読み込みました。スライダーで範囲を調整できます。"
   },
   "insightsTransactions.loading.currentEpoch": {
-    "message": "Loading current epoch..."
+    "message": "現在のエポックを読み込み中..."
   },
   "insightsTransactions.notice.inProgressTitle": {
-    "message": "Current Epoch In Progress"
+    "message": "現在のエポック進行中"
   },
   "insightsTransactions.notice.inProgressDescription": {
-    "message": "Epoch {epoch} is currently in progress. Data for this epoch is incomplete and will appear lower than completed epochs. The final values will be available once the epoch ends. In-progress data points are marked with an orange indicator on the charts."
+    "message": "エポック{epoch}は現在進行中です。このエポックのデータは不完全で、完了したエポックよりも低く表示されます。最終的な値はエポック終了後に利用可能になります。進行中のデータポイントはチャート上でオレンジのインジケーターでマークされます。"
   },
   "insightsTransactions.toc.title": {
-    "message": "Contents"
+    "message": "目次"
   },
   "insightsTransactions.toc.transactions": {
-    "message": "Transaction Volume"
+    "message": "トランザクション量"
   },
   "insightsTransactions.toc.fees": {
-    "message": "Transaction Fees"
+    "message": "トランザクション手数料"
   },
   "insightsTransactions.toc.avgFee": {
-    "message": "Average Fee per Transaction"
+    "message": "トランザクションあたりの平均手数料"
   },
   "insightsTransactions.toc.blocks": {
-    "message": "Block Production"
+    "message": "ブロック生成"
   },
   "insightsTransactions.toc.combined": {
-    "message": "Transactions & Fees Combined"
+    "message": "トランザクション＆手数料（統合）"
   },
   "insightsTransactions.transactions.divider": {
-    "message": "Transaction Volume"
+    "message": "トランザクション量"
   },
   "insightsTransactions.fees.divider": {
-    "message": "Transaction Fees"
+    "message": "トランザクション手数料"
   },
   "insightsTransactions.avgFee.divider": {
-    "message": "Average Fee per Transaction"
+    "message": "トランザクションあたりの平均手数料"
   },
   "insightsTransactions.blocks.divider": {
-    "message": "Block Production"
+    "message": "ブロック生成"
   },
   "insightsTransactions.combined.divider": {
-    "message": "Transactions & Fees Combined"
+    "message": "トランザクション＆手数料（統合）"
   },
   "insights.footer.text": {
-    "message": "Last updated: {lastUpdated}. Charts are using real time data."
+    "message": "最終更新：{lastUpdated}。チャートはリアルタイムデータを使用しています。"
   },
   "apps.card.getStarted": {
-    "message": "Get Started"
+    "message": "始める"
   },
   "apps.card.source": {
-    "message": "Source"
+    "message": "ソース"
   }
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ja/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "次へ",
     "description": "The label for version current"
   },
   "sidebar.getInvolvedSidebar.category.Site Components": {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/communities.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/communities.md
@@ -1,44 +1,44 @@
 ---
-title: Online Communities
+title: オンラインコミュニティ
 displayed_sidebar: null
-description: Cardano Online Communities
+description: Cardanoオンラインコミュニティ
 ---
 
-The Cardano community has many different social channels. They’re all different and unique in their own way. So here’s a list of all of our recommended community channels, join the ones you like and connect with fellow Cardano community members around the world!
+The Cardano community has many different social channels. They’re all different and unique in their own way. Cardanoコミュニティにはさまざまなソーシャルチャンネルがあります。それぞれに個性があり、ユニークな特徴を持っています。おすすめのコミュニティチャンネルをまとめましたので、気になるものに参加して、世界中のCardanoコミュニティメンバーとつながりましょう！
 
-## Forums
+## フォーラム
 
-Enjoy structured long-format discussions.
+体系的なロングフォーマットのディスカッションを楽しめます。
 
-- [r/Cardano](https://www.reddit.com/r/cardano/) - Cardano community on Reddit
-- [forum.cardano.org](https://forum.cardano.org) - the Cardano Forum
-- [Cardano Stackexchange](https://cardano.stackexchange.com) - help for Cardano developers
-- [Facebook Group](https://www.facebook.com/groups/CardanoCommunity/) - the Cardano Facebook Group
+- [r/Cardano](https://www.reddit.com/r/cardano/) - Reddit上のCardanoコミュニティ
+- [forum.cardano.org](https://forum.cardano.org) - Cardanoフォーラム
+- [Cardano Stackexchange](https://cardano.stackexchange.com) - Cardano開発者向けヘルプ
+- [Facebook Group](https://www.facebook.com/groups/CardanoCommunity/) - CardanoのFacebookグループ
 
-## Events and local gatherings
+## イベントとローカルミートアップ
 
-Connect with the Cardano community at in-person or virtual events.
+対面またはバーチャルイベントでCardanoコミュニティとつながりましょう。
 
-- [Cardano on Meetup](https://www.meetup.com/pro/cardano) - Cardano Meetup Groups around the world.
-- [Cardano on Luma](https://luma.com/CardanoEvents) - Cardano Luma Events around the world.
+- [Cardano on Meetup](https://www.meetup.com/pro/cardano) - 世界中のCardano Meetupグループ
+- [Cardano on Luma](https://luma.com/CardanoEvents) - 世界中のCardano Lumaイベント
 
 ## Cardano on Telegram
 
-Real time chat and quick discussions.
+リアルタイムチャットと素早いディスカッション。
 
 - Cardano Main: https://t.me/Cardano
 - Cardano Developers: https://t.me/CardanoDevelopersOfficial
-- Cardano Report to Admin: https://t.me/cardanoreporttoadmin is for when you have issues with other our rulings, users, admins, moderators, or something else that isn’t working for you in our Telegram channels.
+- Cardano Report to Admin: https://t.me/cardanoreporttoadmin は、Telegramチャンネルでの判定、ユーザー、管理者、モデレーターなどに問題がある場合にご利用ください。
 
 ## Cardano on Discord
 
-Real-time chat and quick discussions.
+リアルタイムチャットと素早いディスカッション。
 
 - [Cardano Foundation Discord](https://discord.gg/MmeqpAzKbp)
 - [Cardano Community Discord](https://discord.com/invite/2nPUa5d7DE)
 - [IOG Discord](https://discord.com/invite/w6TwW9bGA6)
 
-## Language specific discussions
+## 言語別のディスカッション
 
 - :vietnam: Cardano Vietnam: https://t.me/CardanoVNCommunity
 - :jp: Cardano Japan: https://t.me/CardanoJapanOfficial
@@ -63,8 +63,8 @@ Real-time chat and quick discussions.
 - 🇹🇷 Turkey: https://t.me/CardanoTurk
 - :uk: Cardano UK: https://t.me/CardanoUK
 
-## Add your community
+## コミュニティを追加する
 
-Want to see your community listed here? We'd love to include more great Cardano communities!
+Want to see your community listed here? あなたのコミュニティをここに掲載しませんか？素晴らしいCardanoコミュニティをもっと紹介したいです！
 
-Please read the [Add your Community](/docs/get-involved/add-community) guide to learn about the requirements and how to submit your community through a pull request.
+要件やプルリクエストによるコミュニティの申請方法については、[コミュニティの追加](/docs/get-involved/add-community)ガイドをお読みください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/agriculture.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/agriculture.md
@@ -1,40 +1,40 @@
 ---
-title: Agriculture
-description: Farm-to-table traceability using Cardano blockchain for food supply chain transparency
-sidebar_label: Agriculture
+title: 農業
+description: Cardanoブロックチェーンを活用した食品サプライチェーンの透明性と農場から食卓までのトレーサビリティ
+sidebar_label: 農業
 sidebar_position: 8
 ---
 
-# Agriculture
+# 農業
 
-## The Challenge
+## 課題
 
 Modern food supply chains are complex and opaque. Consumers increasingly want to know where their food comes from, how it was produced, and whether claims about organic, fair trade, or sustainable practices are genuine. Food fraud costs the global industry an estimated $40 billion annually.
 
 For farmers and producers, proving the quality and origin of their products is difficult and expensive. Intermediaries capture much of the value, while producers struggle to differentiate their products in the market.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
 Blockchain technology creates an immutable record of a product's journey from farm to table:
 
-- **Origin verification**: Prove exactly where products come from and how they were produced
-- **Quality assurance**: Record temperature, handling, and other quality metrics throughout the supply chain
-- **Certification tracking**: Verify organic, fair trade, and other certifications at every step
-- **Fraud prevention**: Immutable records make it difficult to substitute or mislabel products
-- **Consumer transparency**: End consumers can scan a product and see its complete history
+- **産地証明**: 製品がどこでどのように生産されたかを正確に証明
+- **品質保証**: サプライチェーン全体を通じて温度や取り扱いなどの品質指標を記録
+- **認証追跡**: オーガニック、フェアトレードなどの認証をあらゆる段階で検証
+- **偽装防止**: 改ざん不可能な記録により、製品のすり替えや偽表示を困難に
+- **消費者への透明性**: 消費者が製品をスキャンするだけで、完全な履歴を確認可能
 
-Smart contracts can automate payments to farmers when products meet quality standards, reducing delays and disputes while ensuring fair compensation.
+スマートコントラクトにより、製品が品質基準を満たした際に農家への支払いを自動化し、遅延や紛争を減らして公正な報酬を確保できます。
 
-## Why Cardano
+## Cardanoが選ばれる理由
 
-- **Low transaction costs** make tracking even low-value agricultural products economically viable
-- **Sustainability credentials** align with environmental claims in the agriculture sector
-- **Interoperability** enables integration with existing agricultural management systems
-- **Global accessibility** supports smallholder farmers in developing regions
-- **Proven deployments** demonstrate real-world agricultural traceability
+- **低い取引コスト**により、低価格の農産物でも経済的に追跡が可能
+- **サステナビリティへの取り組み**が農業分野の環境配慮と整合
+- **相互運用性**により既存の農業管理システムとの統合が可能
+- **グローバルなアクセシビリティ**が途上国の小規模農家をサポート
+- **実績のある導入事例**が農業トレーサビリティの実用性を実証
 
-## Get Started
+## はじめよう
 
-- [Explore supply chain solutions](/solutions)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [サプライチェーンソリューションを見る](/solutions)
+- [Cardano開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/data-storage.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/data-storage.md
@@ -1,40 +1,40 @@
 ---
-title: Data Storage
-description: Decentralized, secure data storage solutions on Cardano blockchain
-sidebar_label: Data Storage
+title: データストレージ
+description: Cardanoブロックチェーンによる分散型で安全なデータストレージソリューション
+sidebar_label: データストレージ
 sidebar_position: 12
 ---
 
-# Data Storage
+# データストレージ
 
-## The Challenge
+## 課題
 
 Centralized data storage creates single points of failure and concentrates control over sensitive information. Cloud providers can experience outages, change terms of service, or be compelled to provide access to stored data. For sensitive applications, this dependency on third parties creates unacceptable risks.
 
-Data integrity is another concern. How can users verify that stored data hasn't been tampered with, especially over long time periods? Traditional backup systems provide redundancy but not proof of integrity.
+Data integrity is another concern. How can users verify that stored data hasn't been tampered with, especially over long time periods? データの完全性も課題です。保存されたデータが改ざんされていないことを、特に長期間にわたってどう検証するのでしょうか。従来のバックアップシステムは冗長性を提供しますが、完全性の証明はできません。
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Blockchain-based storage solutions combine decentralization with cryptographic integrity guarantees:
+ブロックチェーンベースのストレージソリューションは、分散化と暗号学的な完全性保証を両立させます。
 
-- **Distributed redundancy**: Data is stored across multiple nodes, eliminating single points of failure
-- **Integrity verification**: Cryptographic proofs ensure data hasn't been altered
-- **Censorship resistance**: No single entity can block access to stored data
-- **Immutable timestamps**: Prove when data was stored with blockchain-based timestamps
-- **Access control**: Smart contracts can manage who can access stored data and under what conditions
+- **分散型の冗長性**: データが複数のノードに保存され、単一障害点を排除
+- **完全性の検証**: 暗号学的証明によりデータが改ざんされていないことを保証
+- **検閲耐性**: 特定の組織が保存データへのアクセスをブロックすることが不可能
+- **改ざん不可能なタイムスタンプ**: ブロックチェーンベースのタイムスタンプでデータの保存時刻を証明
+- **アクセス制御**: スマートコントラクトによって、誰がどのような条件でデータにアクセスできるかを管理
 
-While large files are typically stored off-chain, their cryptographic hashes recorded on Cardano provide proof of existence and integrity that is as permanent as the blockchain itself.
+大容量ファイルは通常オフチェーンに保存されますが、そのハッシュ値をCardano上に記録することで、ブロックチェーンと同等の永続性を持つ存在証明と完全性の証明が得られます。
 
-## Why Cardano
+## Cardanoが選ばれる理由
 
-- **Proven security** through rigorous cryptographic protocols
-- **Long-term sustainability** through proof of stake and community governance
-- **Interoperability** with decentralized storage networks
-- **Low costs** for storing hashes and access control logic
-- **Developer tools** for building storage applications
+- **実証済みのセキュリティ**：厳格な暗号プロトコルによる保護
+- **長期的な持続可能性**：プルーフ・オブ・ステークとコミュニティガバナンスによる運営
+- **相互運用性**：分散型ストレージネットワークとの連携
+- **低コスト**：ハッシュ値やアクセス制御ロジックの保存が安価
+- **開発者ツール**：ストレージアプリケーション構築のための充実したツール群
 
-## Get Started
+## はじめよう
 
-- [Explore decentralized storage solutions](/solutions)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [分散型ストレージソリューションを見る](/solutions)
+- [Cardano開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/defi.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/defi.md
@@ -1,41 +1,41 @@
 ---
 title: DeFi
-description: Decentralized finance applications on Cardano provide transparent, accessible financial services
+description: Cardano上の分散型金融アプリケーションは、透明性とアクセシビリティを備えた金融サービスを提供します
 sidebar_label: DeFi
 sidebar_position: 6
 ---
 
-# Decentralized Finance (DeFi)
+# 分散型金融（DeFi）
 
-## The Challenge
+## 課題
 
-Traditional financial systems exclude billions of people worldwide who lack access to banking services. Even for those with access, financial services often come with high fees, opaque terms, and centralized control that can freeze assets or deny services arbitrarily.
+従来の金融システムでは、世界中で数十億人が銀行サービスを利用できずにいます。利用できる人にとっても、高い手数料、不透明な条件、資産の凍結やサービス拒否を一方的に行える中央集権的な管理が問題となっています。 Even for those with access, financial services often come with high fees, opaque terms, and centralized control that can freeze assets or deny services arbitrarily.
 
 The 2008 financial crisis demonstrated the risks of centralized financial systems, where failures at major institutions can cascade through the entire economy. Users have little visibility into how their deposits are used or what risks they're exposed to.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Decentralized finance on Cardano provides open, transparent financial services accessible to anyone with an internet connection:
+Cardano上の分散型金融は、インターネット接続さえあれば誰でも利用できる、オープンで透明な金融サービスを提供します。
 
-- **Permissionless access**: Anyone can participate without approval from centralized gatekeepers
-- **Transparent operations**: All transactions and smart contract logic are publicly auditable
-- **User custody**: Users maintain control of their assets without relying on intermediaries
-- **Composability**: DeFi protocols can be combined to create new financial products
-- **24/7 availability**: Services operate continuously without downtime or business hours
+- **パーミッションレスなアクセス**: 中央管理者の承認なしに誰でも参加可能
+- **透明な運用**: すべての取引とスマートコントラクトのロジックを公開監査可能
+- **ユーザー自身による資産管理**: 仲介者に頼ることなく自分の資産を管理
+- **コンポーザビリティ**: DeFiプロトコルを組み合わせて新しい金融商品を構築可能
+- **24時間365日稼働**: 営業時間やダウンタイムなく常時サービスを提供
 
-Cardano's DeFi ecosystem includes decentralized exchanges (DEXs), lending and borrowing platforms, stablecoins, and yield optimization protocols, all operating on secure, audited smart contracts.
+CardanoのDeFiエコシステムには、分散型取引所（DEX）、レンディング・借入プラットフォーム、ステーブルコイン、イールド最適化プロトコルなどがあり、すべて安全で監査済みのスマートコントラクト上で稼働しています。
 
-## Why Cardano
+## Cardanoが選ばれる理由
 
-- **Predictable fees** through the extended UTXO model enable accurate cost planning
-- **Formal verification** provides mathematical guarantees about smart contract behavior
-- **Native assets** reduce complexity and attack surface for token operations
-- **Sustainability** through proof of stake aligns with long-term value creation
-- **Strong community** of developers building innovative financial applications
+- **予測可能な手数料**：拡張UTXOモデルにより正確なコスト計画が可能
+- **形式検証**：スマートコントラクトの動作に対する数学的な保証
+- **ネイティブアセット**：トークン操作の複雑さと攻撃対象を軽減
+- **サステナビリティ**：プルーフ・オブ・ステークによる長期的な価値創造
+- **強力なコミュニティ**：革新的な金融アプリケーションを構築する開発者の集まり
 
-## Get Started
+## はじめよう
 
-- [Explore DeFi applications on Cardano](/apps/?operator=OR&tags=lending&tags=dex)
-- [Get a Cardano wallet](/apps/?tags=wallet)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [CardanoのDeFiアプリを探す](/apps/?operator=OR&tags=lending&tags=dex)
+- [Cardanoウォレットを入手する](/apps/?tags=wallet)
+- [Cardano開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/digital-identity.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/digital-identity.md
@@ -1,40 +1,40 @@
 ---
-title: Digital Identity
-description: Self-sovereign identity solutions on Cardano give users control over their personal data
-sidebar_label: Digital Identity
+title: デジタルID
+description: Cardano上の自己主権型アイデンティティソリューションにより、ユーザーが自分の個人データを管理できます
+sidebar_label: デジタルID
 sidebar_position: 3
 ---
 
-# Digital Identity
+# デジタルID
 
-## The Challenge
+## 課題
 
-In today's digital world, our identities are fragmented across countless platforms, each holding pieces of our personal information. Users have little control over how their data is used, shared, or monetized. Data breaches expose millions of records, identity theft is rampant, and proving who you are online remains cumbersome and privacy-invasive.
+In today's digital world, our identities are fragmented across countless platforms, each holding pieces of our personal information. Users have little control over how their data is used, shared, or monetized. 今日のデジタル社会では、個人のアイデンティティが無数のプラットフォームに分散しており、それぞれが個人情報の一部を保持しています。ユーザーは自分のデータがどう使われ、共有され、収益化されているかをほとんどコントロールできません。データ漏洩により数百万件の記録が流出し、なりすまし犯罪は横行し、オンラインでの本人証明は依然として煩雑でプライバシーを侵害するものとなっています。
 
 Centralized identity systems create single points of failure and give disproportionate power to identity providers. Users must repeatedly share sensitive information, creating unnecessary exposure and friction in digital interactions.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Self-sovereign identity (SSI) on Cardano puts users in control of their digital identity. Key features include:
+Cardano上の自己主権型アイデンティティ（SSI）は、ユーザー自身がデジタルIDを管理できるようにします。主な特徴は以下の通りです。 Key features include:
 
-- **User ownership**: Individuals control their identity data and decide what to share
-- **Selective disclosure**: Share only the information needed for a specific transaction
-- **Verifiable credentials**: Third parties can cryptographically verify claims without accessing underlying data
-- **Decentralized identifiers (DIDs)**: Persistent identifiers that don't depend on any central authority
-- **Privacy preservation**: Zero-knowledge proofs can verify attributes without revealing them
+- **ユーザーによる所有権**: 個人が自分のID情報を管理し、何を共有するかを決定
+- **選択的開示**: 特定の取引に必要な情報のみを共有
+- **検証可能な資格情報**: 第三者が元データにアクセスすることなく、暗号学的に主張を検証可能
+- **分散型識別子（DID）**: 中央機関に依存しない永続的な識別子
+- **プライバシー保護**: ゼロ知識証明により、属性を明かさずに検証が可能
 
-With blockchain-based identity, users can prove they're over 18 without revealing their birthdate, or prove they live in a certain country without revealing their address.
+ブロックチェーンベースのIDにより、ユーザーは生年月日を明かさずに18歳以上であることを証明したり、住所を明かさずに特定の国に居住していることを証明したりできます。
 
-## Why Cardano
+## Cardanoが選ばれる理由
 
-- **Formal verification methods** ensure identity smart contracts behave as intended
-- **Extended UTXO model** provides predictable transaction costs for identity operations
-- **Interoperability focus** enables identity credentials to work across different systems
-- **Strong governance** ensures the platform evolves with community input
-- **Scalability roadmap** supports identity solutions at global scale
+- **形式検証手法**によりIDスマートコントラクトが意図通りに動作することを保証
+- **拡張UTXOモデル**によりID関連操作の取引コストが予測可能
+- **相互運用性の重視**により、異なるシステム間でID資格情報を利用可能
+- **強固なガバナンス**によりコミュニティの意見を反映したプラットフォームの進化を実現
+- **スケーラビリティのロードマップ**がグローバル規模のIDソリューションを支援
 
-## Get Started
+## はじめよう
 
-- [Explore identity applications on Cardano](/apps/?tags=identity)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [CardanoのIDアプリケーションを探す](/apps/?tags=identity)
+- [Cardano開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/education.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/education.md
@@ -1,39 +1,39 @@
 ---
-title: Education Credentials
-description: Blockchain-verified academic credentials on Cardano provide tamper-proof, instantly verifiable certifications
-sidebar_label: Education
+title: 教育資格証明
+description: Cardanoブロックチェーンによる改ざん不可能で即座に検証できる学術資格証明
+sidebar_label: 教育
 sidebar_position: 2
 ---
 
-# Education Credentials
+# 教育資格証明
 
-## The Challenge
+## 課題
 
 The issuance of academic certifications is heavily centralized and often opaque. Traditional paper-based credentials are easily forged, difficult to verify, and can be lost or damaged. Educational institutions face challenges in maintaining the integrity of their certifications, while employers struggle to verify the authenticity of candidates' qualifications.
 
 The verification process is slow and costly, often requiring direct contact with issuing institutions. This creates friction in hiring processes and can disadvantage qualified candidates who obtained credentials from institutions that are difficult to reach or no longer exist.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Cardano's blockchain-based identity and credentials solutions enable educational institutions to issue digital credentials that are:
+Cardanoのブロックチェーンベースのアイデンティティ・資格証明ソリューションにより、教育機関は以下のようなデジタル資格を発行できます。
 
-- **Tamper-proof**: Once recorded on the blockchain, credentials cannot be altered or forged
-- **Instantly verifiable**: Anyone can verify a credential's authenticity without contacting the issuing institution
-- **Portable**: Students own their credentials and can share them with any employer or institution
-- **Persistent**: Credentials remain valid and verifiable even if the issuing institution closes
+- **改ざん不可能**: ブロックチェーンに記録された資格は変更や偽造ができない
+- **即座に検証可能**: 発行機関に問い合わせることなく、誰でも資格の真正性を検証できる
+- **ポータブル**: 学生が自分の資格を所有し、どの雇用者や機関にも共有可能
+- **永続的**: 発行機関が閉鎖されても、資格は有効で検証可能であり続ける
 
 Smart contracts can automate the issuance process, ensuring credentials are only issued when specific requirements are met. This creates an auditable trail of academic achievements that benefits students, institutions, and employers alike.
 
-## Why Cardano
+## Cardanoが選ばれる理由
 
-- **Low transaction fees** make credential issuance economically viable at scale
-- **Energy-efficient proof of stake** aligns with educational institutions' sustainability goals
-- **Native token support** enables certification NFTs without additional smart contract complexity
-- **Aiken smart contracts** provide programmable verification logic
-- **Global accessibility** ensures credentials can be verified anywhere in the world
+- **低い取引手数料**により大規模な資格発行も経済的に実現可能
+- **省エネルギーなプルーフ・オブ・ステーク**が教育機関のサステナビリティ目標と整合
+- **ネイティブトークン対応**により追加のスマートコントラクトなしで資格NFTを発行可能
+- **Aikenスマートコントラクト**によるプログラマブルな検証ロジック
+- **グローバルなアクセシビリティ**により世界中どこでも資格の検証が可能
 
-## Get Started
+## はじめよう
 
-- [Explore identity applications on Cardano](/apps/?tags=identity)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [CardanoのIDアプリケーションを探す](/apps/?tags=identity)
+- [Cardano開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/finance-kyc.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/finance-kyc.md
@@ -1,40 +1,40 @@
 ---
-title: Finance KYC
-description: Streamlined Know Your Customer verification using blockchain technology on Cardano
-sidebar_label: Finance KYC
+title: 金融KYC
+description: Cardanoのブロックチェーン技術を活用した、効率的な本人確認（KYC）プロセス
+sidebar_label: 金融KYC
 sidebar_position: 4
 ---
 
-# Finance KYC
+# 金融KYC
 
-## The Challenge
+## 課題
 
 Know Your Customer (KYC) processes are essential for financial compliance but create significant friction for both institutions and customers. Users must repeatedly submit the same documents to different institutions, leading to duplicated effort and increased exposure of sensitive data. Financial institutions spend billions annually on KYC compliance, with much of that cost passed on to customers.
 
 The current system is also exclusionary. The estimated 1.4 billion adults worldwide without formal identity documents are effectively locked out of the financial system, unable to access basic services like bank accounts or loans.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Blockchain-based KYC solutions create a more efficient and inclusive verification system:
+ブロックチェーンを活用したKYCソリューションは、より効率的で包括的な本人確認の仕組みを実現します。
 
-- **Reusable verification**: Complete KYC once, use it across multiple institutions
-- **Reduced data exposure**: Share only verification status, not underlying documents
-- **Faster onboarding**: Instant verification of pre-validated credentials
-- **Cost reduction**: Shared verification infrastructure reduces compliance costs
-- **Inclusion**: Alternative identity verification methods can bring the unbanked into the financial system
+- **再利用可能な本人確認**: 一度のKYC完了で複数の金融機関に対応
+- **データ露出の最小化**: 元の書類ではなく、確認済みステータスのみを共有
+- **スピーディなオンボーディング**: 事前検証済みの資格情報による即時確認
+- **コスト削減**: 共有型の本人確認インフラにより、コンプライアンスコストを低減
+- **金融包摂**: 代替的な本人確認手段により、銀行口座を持たない人々も金融システムに参加可能
 
 Smart contracts can automate compliance checks, ensuring only verified users can access specific financial services while maintaining privacy and reducing manual review requirements.
 
-## Why Cardano
+## なぜCardanoなのか
 
-- **Regulatory awareness** built into platform development from the start
-- **Privacy features** enable compliant verification without unnecessary data exposure
-- **Global reach** supports financial inclusion across borders
-- **Low fees** make micro-transactions and small account verification economically viable
-- **Enterprise partnerships** demonstrate real-world financial sector adoption
+- **規制への対応力**: プラットフォーム開発の初期段階から規制を意識した設計
+- **プライバシー機能**: 不必要なデータ開示なしにコンプライアンスに準拠した本人確認が可能
+- **グローバルなリーチ**: 国境を越えた金融包摂を支援
+- **低い手数料**: 少額取引や小規模口座の本人確認も経済的に実現
+- **企業パートナーシップ**: 金融セクターでの実際の導入実績
 
-## Get Started
+## はじめる
 
-- [Explore identity applications on Cardano](/apps/?tags=identity)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Cardano上のIDアプリケーションを探す](/apps/?tags=identity)
+- [開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/government.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/government.md
@@ -1,40 +1,40 @@
 ---
-title: Government Documents
-description: Tamper-proof official documents and records using Cardano blockchain technology
-sidebar_label: Government
+title: 行政文書
+description: Cardanoブロックチェーン技術による改ざん不可能な公文書・記録管理
+sidebar_label: 行政
 sidebar_position: 5
 ---
 
-# Government Documents
+# 行政文書
 
-## The Challenge
+## 課題
 
-Government-issued documents form the foundation of civic identity, yet they remain vulnerable to forgery, loss, and bureaucratic inefficiency. Birth certificates, property deeds, business licenses, and other official records are often paper-based, creating challenges for verification and portability.
+政府が発行する文書は市民のアイデンティティの基盤ですが、偽造、紛失、行政の非効率性に対して依然として脆弱です。出生証明書、不動産登記、事業許可証などの公文書は紙ベースであることが多く、その確認や持ち運びに課題があります。 Birth certificates, property deeds, business licenses, and other official records are often paper-based, creating challenges for verification and portability.
 
-Citizens frequently face lengthy processes to obtain copies of their own documents, while government agencies struggle with record-keeping across jurisdictions. Document fraud undermines trust in institutions and creates real harm for individuals whose identities are misused.
+市民は自分自身の書類のコピーを取得するために長い手続きを強いられ、行政機関は管轄をまたぐ記録管理に苦労しています。文書の偽造は制度への信頼を損ない、不正利用された個人には深刻な被害をもたらします。 Document fraud undermines trust in institutions and creates real harm for individuals whose identities are misused.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Blockchain technology enables governments to issue and manage official documents with unprecedented security and efficiency:
+ブロックチェーン技術を活用することで、行政機関はかつてないセキュリティと効率性で公文書を発行・管理できます。
 
-- **Immutable records**: Once issued, documents cannot be altered without detection
-- **Instant verification**: Third parties can verify document authenticity without contacting issuing agencies
-- **Citizen control**: Individuals can access and share their documents securely
-- **Cross-border recognition**: Standardized digital documents facilitate international verification
-- **Audit trails**: Complete history of document issuance and verification
+- **改ざん不可能な記録**: 一度発行された文書は、改ざんがあれば即座に検知可能
+- **即時検証**: 第三者が発行機関に問い合わせることなく文書の真正性を確認
+- **市民による管理**: 個人が自らの文書に安全にアクセス・共有できる
+- **国境を越えた認証**: 標準化されたデジタル文書により国際的な検証が容易に
+- **監査証跡**: 文書の発行・検証の完全な履歴を記録
 
-Smart contracts can automate document issuance when conditions are met, reducing processing times and human error while maintaining security and compliance.
+スマートコントラクトにより、条件が満たされた際の文書発行を自動化でき、セキュリティとコンプライアンスを維持しながら処理時間とヒューマンエラーを削減できます。
 
-## Why Cardano
+## なぜCardanoなのか
 
-- **Proven security** through peer-reviewed cryptographic protocols
-- **Sustainability** aligns with government environmental commitments
-- **Transparency** supports public accountability requirements
-- **Scalability** handles document verification at national scale
-- **Interoperability** enables integration with existing government systems
+- **実証済みのセキュリティ**: 査読済みの暗号プロトコルによる高い安全性
+- **サステナビリティ**: 政府の環境目標と合致
+- **透明性**: 公的説明責任の要件に対応
+- **スケーラビリティ**: 国家規模の文書検証に対応可能
+- **相互運用性**: 既存の行政システムとの連携が可能
 
-## Get Started
+## はじめる
 
-- [Explore identity applications on Cardano](/apps/?tags=identity)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Cardano上のIDアプリケーションを探す](/apps/?tags=identity)
+- [開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/healthcare.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/healthcare.md
@@ -1,40 +1,40 @@
 ---
-title: Healthcare
-description: Portable, secure health records using Cardano blockchain technology
-sidebar_label: Healthcare
+title: ヘルスケア
+description: Cardanoブロックチェーン技術を活用した、ポータブルで安全な医療記録
+sidebar_label: ヘルスケア
 sidebar_position: 15
 ---
 
-# Healthcare
+# ヘルスケア
 
-## The Challenge
+## 課題
 
 Healthcare data is fragmented across providers, making it difficult for patients and doctors to access complete medical histories. This fragmentation leads to repeated tests, dangerous drug interactions, and delayed diagnoses. In emergencies, critical information may be unavailable.
 
 Current systems also create privacy and security risks. Centralized databases are attractive targets for hackers, and patients have limited control over who accesses their sensitive health information.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Blockchain-based health records give patients control over their complete medical history:
+ブロックチェーンベースの医療記録により、患者が自分自身の完全な病歴を管理できるようになります。
 
-- **Patient ownership**: Individuals control access to their health data
-- **Portability**: Access records from any provider, anywhere in the world
-- **Interoperability**: Standardized data formats enable information sharing
-- **Audit trails**: Track who accessed records and when
-- **Selective sharing**: Share only relevant information with each provider
+- **患者によるデータ所有**: 個人が自分の健康データへのアクセスを管理
+- **ポータビリティ**: 世界中のどの医療機関からでも記録にアクセス可能
+- **相互運用性**: 標準化されたデータ形式により情報共有がスムーズに
+- **監査証跡**: 誰がいつ記録にアクセスしたかを追跡
+- **選択的な情報共有**: 各医療機関に必要な情報のみを共有
 
-Smart contracts can automate consent management, ensuring providers only access data they're authorized to see while maintaining compliance with healthcare regulations.
+スマートコントラクトで同意管理を自動化すれば、医療規制に準拠しながら、許可された医療機関だけがデータにアクセスできる仕組みを実現できます。
 
-## Why Cardano
+## なぜCardanoなのか
 
-- **Privacy features** protect sensitive health information
-- **Security** through proven cryptographic protocols
-- **Interoperability focus** enables healthcare system integration
-- **Global accessibility** supports healthcare across borders
-- **Regulatory compliance** capabilities for HIPAA and similar requirements
+- **プライバシー機能**: 機密性の高い健康情報を保護
+- **セキュリティ**: 実証済みの暗号プロトコルによる安全性
+- **相互運用性を重視**: 医療システムとの統合が可能
+- **グローバルなアクセス性**: 国境を越えた医療を支援
+- **規制準拠**: HIPAAなどの規制要件への対応力
 
-## Get Started
+## はじめる
 
-- [Explore Cardano applications](/apps)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Cardanoのアプリケーションを探す](/apps)
+- [開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/index.md
@@ -1,61 +1,61 @@
 ---
-title: Use Cases Overview
-description: Explore how Cardano blockchain technology solves real-world problems across industries
-sidebar_label: Overview
+title: ユースケース概要
+description: Cardanoブロックチェーン技術がさまざまな業界の課題をどう解決するかをご紹介します
+sidebar_label: 概要
 sidebar_position: 1
 ---
 
-# Cardano Use Cases
+# Cardanoのユースケース
 
-Cardano is a public, permissionless Layer 1 blockchain, perfect for enterprises and individuals seeking secure, scalable, and transparent solutions. Whether it's streamlining supply chains, enabling global payments, or tokenizing assets, Cardano offers decentralized innovation with robust security and low energy usage.
+Cardanoはパブリックでパーミッションレスなレイヤー1ブロックチェーンであり、安全でスケーラブルかつ透明性の高いソリューションを求める企業や個人に最適です。サプライチェーンの効率化、グローバル決済、資産のトークン化など、堅牢なセキュリティと低消費電力で分散型イノベーションを提供します。 Whether it's streamlining supply chains, enabling global payments, or tokenizing assets, Cardano offers decentralized innovation with robust security and low energy usage.
 
-## Identity
+## アイデンティティ
 
-Blockchain-based identity solutions provide secure, verifiable credentials that users control.
+ブロックチェーンベースのID（アイデンティティ）ソリューションは、ユーザー自身が管理できる安全で検証可能な資格情報を提供します。
 
-- **[Education Credentials](./education)** - Blockchain-verified academic credentials
-- **[Digital Identity](./digital-identity)** - Self-sovereign identity solutions
-- **[Finance KYC](./finance-kyc)** - Streamlined identity verification for financial services
-- **[Government Documents](./government)** - Tamper-proof official documents
+- **[教育資格証明](./education)** - ブロックチェーンで検証可能な学術資格
+- **[デジタルID](./digital-identity)** - 自己主権型のアイデンティティソリューション
+- **[金融KYC](./finance-kyc)** - 金融サービスにおける効率的な本人確認
+- **[公的文書](./government)** - 改ざん不可能な公式文書
 
-## Finance
+## 金融
 
-Decentralized financial applications that provide transparency and accessibility.
+透明性とアクセシビリティを備えた分散型金融アプリケーション。
 
-- **[DeFi](./defi)** - Decentralized lending, borrowing, and exchanges
-- **[Payments](./payments)** - Fast, low-cost cross-border transfers
+- **[DeFi](./defi)** - 分散型レンディング、借入、取引所
+- **[決済](./payments)** - 高速・低コストの国際送金
 
-## Supply Chain
+## サプライチェーン
 
-End-to-end traceability and verification for products and goods.
+製品・商品のエンドツーエンドのトレーサビリティと検証。
 
-- **[Agriculture](./agriculture)** - Farm-to-table traceability
-- **[Retail](./retail)** - Combat counterfeiting with provenance tracking
-- **[Logistics](./logistics)** - Real-time tracking and verification
+- **[農業](./agriculture)** - 農場から食卓までのトレーサビリティ
+- **[小売](./retail)** - 来歴追跡による偽造品対策
+- **[物流](./logistics)** - リアルタイムの追跡と検証
 
-## Social Impact
+## ソーシャルインパクト
 
-Blockchain solutions for transparency and accountability in social programs.
+社会プログラムの透明性と説明責任を実現するブロックチェーンソリューション。
 
-- **[Social Programs](./social-programs)** - Transparent fund distribution
+- **[社会プログラム](./social-programs)** - 透明性のある資金分配
 
-## Data & Technology
+## データ＆テクノロジー
 
-Decentralized approaches to data management and asset ownership.
+データ管理と資産所有権への分散型アプローチ。
 
-- **[Data Storage](./data-storage)** - Decentralized, secure storage solutions
-- **[Tokenized Assets](./tokenized-assets)** - Fractional ownership of real-world assets
+- **[データストレージ](./data-storage)** - 分散型の安全なストレージソリューション
+- **[トークン化資産](./tokenized-assets)** - 現実世界の資産の分割所有
 
-## Emerging Applications
+## 新たなアプリケーション
 
-New and developing use cases for blockchain technology.
+ブロックチェーン技術の新しいユースケース。
 
-- **[Voting Systems](./voting-systems)** - Secure, transparent elections
-- **[Healthcare](./healthcare)** - Portable, secure health records
-- **[Music & IP](./music-ip)** - Direct royalty payments to artists
+- **[投票システム](./voting-systems)** - 安全で透明性の高い選挙
+- **[ヘルスケア](./healthcare)** - ポータブルで安全な医療記録
+- **[音楽＆知的財産](./music-ip)** - アーティストへのロイヤリティ直接支払い
 
 ---
 
-## Enterprise Solutions
+## エンタープライズソリューション
 
-Looking for proven enterprise deployments and case studies? Visit our [Enterprise Solutions](/solutions) page to explore real-world implementations by the Cardano Foundation and partners.
+Looking for proven enterprise deployments and case studies? 実績のあるエンタープライズ導入事例をお探しですか？[エンタープライズソリューション](/solutions)ページで、Cardano Foundationとパートナーによる実際の導入事例をご覧ください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/logistics.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/logistics.md
@@ -1,40 +1,40 @@
 ---
-title: Logistics
-description: Real-time tracking and verification for supply chain logistics on Cardano
-sidebar_label: Logistics
+title: 物流
+description: Cardano上でのサプライチェーン物流のリアルタイム追跡と検証
+sidebar_label: 物流
 sidebar_position: 10
 ---
 
-# Logistics
+# 物流
 
-## The Challenge
+## 課題
 
 Global logistics involves countless handoffs between carriers, warehouses, and customs authorities. Each handoff creates opportunities for errors, delays, disputes, and fraud. Paper-based documentation leads to inefficiencies and disputes that cost the industry billions annually.
 
-Lack of real-time visibility makes it difficult to optimize routes, predict delays, or respond quickly to disruptions. When problems occur, determining responsibility across multiple parties becomes contentious and time-consuming.
+リアルタイムの可視性が欠如しているため、ルートの最適化、遅延の予測、混乱への迅速な対応が困難です。問題が発生した場合、複数の関係者間で責任の所在を明らかにするのは時間がかかり、争いの種になりがちです。 When problems occur, determining responsibility across multiple parties becomes contentious and time-consuming.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Blockchain technology creates a shared, immutable record of logistics operations:
+ブロックチェーン技術により、物流オペレーションの共有された改ざん不可能な記録が作成されます。
 
-- **Real-time tracking**: All parties share a single source of truth about shipment status
-- **Smart documentation**: Bills of lading, customs forms, and other documents digitized and verified
-- **Automated compliance**: Smart contracts enforce terms and trigger payments on delivery
-- **Dispute resolution**: Immutable records provide clear evidence for resolving conflicts
-- **Multi-party coordination**: All stakeholders can access relevant information without intermediaries
+- **リアルタイム追跡**: すべての関係者が出荷状況に関する唯一の正確な情報源を共有
+- **スマートドキュメント**: 船荷証券、通関書類などをデジタル化し検証
+- **自動化されたコンプライアンス**: スマートコントラクトが契約条件を執行し、配送時に自動決済
+- **紛争解決**: 改ざん不可能な記録が紛争解決の明確な証拠に
+- **マルチパーティ連携**: 仲介者なしに、すべてのステークホルダーが関連情報にアクセス可能
 
-IoT devices can automatically record location, temperature, humidity, and other conditions, creating an unbroken chain of custody documentation.
+IoTデバイスにより、位置情報、温度、湿度などの環境条件を自動記録し、途切れのない管理チェーンのドキュメントを作成できます。
 
-## Why Cardano
+## なぜCardanoなのか
 
-- **Scalability** supports high-volume logistics operations
-- **Interoperability** enables connection with existing logistics management systems
-- **Global reach** facilitates cross-border trade
-- **Low latency** provides timely updates for operational decisions
-- **Enterprise-ready** security and reliability
+- **スケーラビリティ**: 大量の物流オペレーションに対応
+- **相互運用性**: 既存の物流管理システムとの接続が可能
+- **グローバルなリーチ**: 国境を越えた貿易を促進
+- **低レイテンシー**: 運用上の判断に必要なタイムリーな情報更新
+- **エンタープライズ対応**: 高いセキュリティと信頼性
 
-## Get Started
+## はじめる
 
-- [Explore traceability solutions](/solutions)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [トレーサビリティソリューションを探す](/solutions)
+- [開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/music-ip.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/music-ip.md
@@ -1,40 +1,40 @@
 ---
-title: Music & IP
-description: Direct royalty payments to artists through blockchain technology on Cardano
-sidebar_label: Music & IP
+title: 音楽と知的財産
+description: Cardanoのブロックチェーン技術を通じた、アーティストへの直接的なロイヤリティ支払い
+sidebar_label: 音楽と知的財産
 sidebar_position: 16
 ---
 
-# Music & Intellectual Property
+# 音楽と知的財産
 
-## The Challenge
+## 課題
 
-Artists and creators often receive a small fraction of the revenue their work generates. Complex licensing arrangements, opaque royalty calculations, and numerous intermediaries mean that payments are delayed and reduced at every step. Many creators struggle to make a living despite their work being widely consumed.
+アーティストやクリエイターは、自身の作品が生み出す収益のごく一部しか受け取れないことが少なくありません。複雑なライセンス契約、不透明なロイヤリティ計算、多数の仲介業者の存在により、支払いはあらゆる段階で遅延・減額されます。作品が広く消費されているにもかかわらず、生計を立てるのに苦労しているクリエイターは数多くいます。 Complex licensing arrangements, opaque royalty calculations, and numerous intermediaries mean that payments are delayed and reduced at every step. Many creators struggle to make a living despite their work being widely consumed.
 
-Intellectual property rights are difficult to track and enforce in the digital age. Piracy is rampant, and even legitimate uses often fail to compensate creators fairly.
+Intellectual property rights are difficult to track and enforce in the digital age. デジタル時代において、知的財産権の追跡と執行は非常に困難です。海賊版は横行しており、正規の利用であってもクリエイターに適正な対価が支払われないケースが多いのが現状です。
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
 Blockchain technology enables direct relationships between creators and consumers:
 
-- **Direct payments**: Fans can support artists without intermediaries taking large cuts
-- **Transparent royalties**: Smart contracts automatically distribute payments to all rights holders
-- **Immutable ownership**: Prove creation and ownership of intellectual property
-- **Fractional rights**: Enable investment in creative works through tokenization
-- **Programmable licenses**: Smart contracts can enforce usage terms automatically
+- **ダイレクトペイメント**: 仲介業者に大きなマージンを取られることなく、ファンがアーティストを直接支援
+- **透明なロイヤリティ**: スマートコントラクトがすべての権利者に自動的に収益を分配
+- **改ざん不可能な所有権記録**: 知的財産の創作と所有を証明
+- **権利の分割所有**: トークン化によりクリエイティブ作品への投資を可能に
+- **プログラマブルライセンス**: スマートコントラクトが利用条件を自動的に執行
 
-NFTs and native tokens on Cardano enable new models for music distribution, from limited edition releases to ongoing royalty streams that fairly compensate all contributors.
+CardanoのNFTとネイティブトークンにより、限定リリースから、すべての貢献者に公正に報いる継続的なロイヤリティストリームまで、音楽配信の新しいモデルが可能になります。
 
-## Why Cardano
+## なぜCardanoなのか
 
-- **Low transaction fees** make micropayments to artists economically viable
-- **Native tokens** enable efficient representation of rights and royalties
-- **Smart contracts** automate fair distribution to all collaborators
-- **Community focus** aligns with artists seeking alternatives to corporate control
-- **Sustainability** through proof of stake appeals to environmentally conscious creators
+- **低い取引手数料**: アーティストへのマイクロペイメントを経済的に実現
+- **ネイティブトークン**: 権利やロイヤリティを効率的に表現
+- **スマートコントラクト**: すべてのコラボレーターへの公正な分配を自動化
+- **コミュニティ重視**: 企業支配に代わる選択肢を求めるアーティストと方向性が一致
+- **サステナビリティ**: プルーフ・オブ・ステークによる環境配慮が、エコ意識の高いクリエイターに支持
 
-## Get Started
+## はじめる
 
-- [Explore NFT marketplaces on Cardano](/apps/?tags=nft)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [CardanoのNFTマーケットプレイスを探す](/apps/?tags=nft)
+- [開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/payments.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/payments.md
@@ -1,41 +1,41 @@
 ---
-title: Payments
-description: Fast, low-cost cross-border transfers using Cardano blockchain technology
-sidebar_label: Payments
+title: 決済
+description: Cardanoブロックチェーン技術による高速・低コストな国際送金
+sidebar_label: 決済
 sidebar_position: 7
 ---
 
-# Payments
+# 決済
 
-## The Challenge
+## 課題
 
 Cross-border payments remain slow, expensive, and opaque. Traditional remittance services charge fees averaging 6-7% globally, with some corridors exceeding 10%. Transactions can take days to settle, and recipients often have limited options for accessing funds.
 
 For the millions of migrant workers sending money home to support their families, these fees represent a significant burden. The World Bank estimates that reducing remittance fees to 3% could save senders over $20 billion annually.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Cardano enables fast, low-cost payments that settle in minutes rather than days:
+Cardanoは、数日ではなく数分で完了する高速・低コストな決済を実現します。
 
-- **Low fees**: Transaction costs of fractions of a cent make small payments viable
-- **Fast settlement**: Transactions confirm in minutes, not days
-- **Global reach**: Anyone with internet access can send or receive payments
-- **Transparent pricing**: No hidden fees or unfavorable exchange rates
-- **24/7 availability**: Payments process any time, regardless of banking hours or holidays
+- **低手数料**: 1円未満のトランザクションコストで少額決済も可能
+- **高速な決済処理**: 数日ではなく数分でトランザクションが確認
+- **グローバルな利用**: インターネット環境があれば誰でも送受金が可能
+- **透明な価格設定**: 隠れた手数料や不利な為替レートなし
+- **24時間365日対応**: 銀行の営業時間や祝日に関係なくいつでも送金可能
 
-Native tokens on Cardano enable stablecoins pegged to local currencies, reducing volatility concerns for everyday transactions while maintaining the benefits of blockchain settlement.
+Cardano上のネイティブトークンにより、各国の法定通貨に連動したステーブルコインが利用でき、ブロックチェーン決済のメリットを維持しながら、日常的な取引における価格変動リスクを抑えられます。
 
-## Why Cardano
+## なぜCardanoなのか
 
-- **Scalability** through Hydra and other Layer 2 solutions enables high transaction throughput
-- **Interoperability** allows connection with traditional payment systems
-- **Security** protects against fraud and unauthorized transactions
+- **スケーラビリティ**: HydraなどのLayer 2ソリューションにより高いトランザクション処理能力を実現
+- **相互運用性**: 従来の決済システムとの連携が可能
+- **セキュリティ**: 不正行為や不正な取引からの保護
 - **Low environmental impact** through proof of stake consensus
-- **Growing merchant adoption** expands real-world payment utility
+- **加盟店の増加**: 実世界での決済活用が広がっている
 
-## Get Started
+## はじめよう
 
-- [Get a Cardano wallet](/apps/?tags=wallet)
-- [Where to get ada](/where-to-get-ada)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Cardanoウォレットを入手する](/apps/?tags=wallet)
+- [ADAの入手方法](/where-to-get-ada)
+- [Cardano開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/retail.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/retail.md
@@ -1,40 +1,40 @@
 ---
-title: Retail
-description: Combat counterfeiting with blockchain-verified product provenance on Cardano
-sidebar_label: Retail
+title: 小売
+description: Cardanoブロックチェーンによる製品の真贋証明で偽造品に対抗
+sidebar_label: 小売
 sidebar_position: 9
 ---
 
-# Retail
+# 小売
 
-## The Challenge
+## 課題
 
 Counterfeiting costs legitimate businesses hundreds of billions of dollars annually and poses real risks to consumers. From luxury goods to electronics to pharmaceuticals, fake products flood markets worldwide. Traditional anti-counterfeiting measures like holograms and serial numbers are easily replicated.
 
 Consumers struggle to verify product authenticity, especially when purchasing through secondary markets or online platforms. Legitimate brands face reputational damage when counterfeits bearing their name cause harm or disappointment.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Blockchain-based product authentication provides unforgeable proof of origin and ownership:
+ブロックチェーンを活用した製品認証は、偽造不可能な出所と所有権の証明を提供します。
 
-- **Digital product passports**: Each product receives a unique, verifiable digital identity
-- **Ownership history**: Track the complete chain of custody from manufacturer to consumer
-- **Authentication**: Consumers can verify authenticity with a simple scan
-- **Secondary market trust**: Verified provenance supports resale markets
-- **Warranty and service**: Automatic warranty tracking and service history
+- **デジタル製品パスポート**: 各製品に固有の検証可能なデジタルIDを付与
+- **所有履歴**: メーカーから消費者までの管理チェーンを完全に追跡
+- **真贋認証**: 消費者がスキャン一つで真贋を確認可能
+- **中古市場での信頼性**: 検証済みの来歴がリセール市場を支える
+- **保証とサービス**: 保証の自動追跡とサービス履歴の管理
 
-Smart contracts can link physical products to digital twins, enabling automated warranty claims, loyalty rewards, and product registration.
+スマートコントラクトにより、物理的な製品をデジタルツインと紐付けることで、保証請求の自動化、ロイヤリティプログラム、製品登録などが実現します。
 
-## Why Cardano
+## なぜCardanoなのか
 
-- **Native tokens** enable efficient product tokenization without complex smart contracts
-- **Low fees** make tracking individual items economically viable
-- **Immutable records** provide trustworthy provenance that cannot be falsified
-- **Consumer-friendly verification** through mobile applications
-- **Enterprise solutions** proven in real-world retail deployments
+- **ネイティブトークン**: 複雑なスマートコントラクトなしで効率的な製品トークン化が可能
+- **低手数料**: 個々の製品の追跡も経済的に実現可能
+- **改ざん不可能な記録**: 偽造できない信頼性の高い来歴情報を提供
+- **消費者にやさしい認証**: モバイルアプリで簡単に確認
+- **エンタープライズソリューション**: 実際のリテール環境で実証済み
 
-## Get Started
+## はじめよう
 
-- [Explore authenticity solutions](/solutions)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [真贋認証ソリューションを探す](/solutions)
+- [Cardano開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/social-programs.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/social-programs.md
@@ -1,40 +1,40 @@
 ---
-title: Social Programs
-description: Transparent fund distribution for social programs using Cardano blockchain
-sidebar_label: Social Programs
+title: 社会プログラム
+description: Cardanoブロックチェーンを活用した社会プログラムにおける透明な資金配分
+sidebar_label: 社会プログラム
 sidebar_position: 11
 ---
 
-# Social Programs
+# 社会プログラム
 
-## The Challenge
+## 課題
 
 Social programs aimed at poverty reduction, disaster relief, and development face persistent challenges with fund distribution. Corruption siphons resources away from intended beneficiaries, while administrative inefficiencies add costs and delays. Donors and taxpayers often lack visibility into how funds are actually used.
 
 For beneficiaries, accessing aid can involve bureaucratic hurdles, intermediaries who extract fees, and delays that undermine the program's effectiveness. Proving eligibility and preventing duplicate claims adds further complexity.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Blockchain technology enables transparent, efficient distribution of social program funds:
+ブロックチェーン技術により、社会プログラムの資金を透明かつ効率的に配分できます。
 
-- **Transparent allocation**: Every transaction is publicly auditable, deterring corruption
-- **Direct distribution**: Funds can flow directly to beneficiaries without intermediaries
-- **Conditional payments**: Smart contracts release funds when specific conditions are verified
-- **Identity integration**: Blockchain identity solutions enable beneficiary verification while protecting privacy
-- **Real-time monitoring**: Program administrators and donors can track fund utilization
+- **透明な資金配分**: すべてのトランザクションが公開監査可能で、汚職を抑止
+- **直接配分**: 仲介者を介さず、資金を受益者に直接届けられる
+- **条件付き支払い**: スマートコントラクトにより、特定の条件が満たされた場合にのみ資金をリリース
+- **アイデンティティとの統合**: ブロックチェーンベースのID技術でプライバシーを守りつつ受益者を確認
+- **リアルタイム監視**: プログラム管理者や寄付者が資金の利用状況をリアルタイムで追跡可能
 
-Stablecoins and digital wallets enable beneficiaries to receive and use funds even without traditional bank accounts, increasing financial inclusion.
+ステーブルコインとデジタルウォレットにより、従来の銀行口座を持たない受益者でも資金を受け取り、利用することが可能となり、金融包摂が促進されます。
 
-## Why Cardano
+## なぜCardanoなのか
 
-- **Low transaction fees** maximize the percentage of funds reaching beneficiaries
-- **Sustainability** through proof of stake aligns with development goals
-- **Privacy features** protect vulnerable beneficiaries
-- **Accessibility** works in areas with limited banking infrastructure
-- **Governance** enables community participation in program design
+- **低トランザクション手数料**: 受益者に届く資金の割合を最大化
+- **持続可能性**: プルーフ・オブ・ステークは開発目標と整合
+- **プライバシー機能**: 脆弱な立場にある受益者を保護
+- **アクセシビリティ**: 銀行インフラが限られた地域でも機能
+- **ガバナンス**: コミュニティがプログラム設計に参加可能
 
-## Get Started
+## はじめよう
 
-- [Explore Cardano applications](/apps)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Cardanoアプリケーションを探す](/apps)
+- [Cardano開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/tokenized-assets.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/tokenized-assets.md
@@ -1,40 +1,40 @@
 ---
-title: Tokenized Assets
-description: Fractional ownership of real-world assets through tokenization on Cardano
-sidebar_label: Tokenized Assets
+title: トークン化資産
+description: Cardano上のトークン化による実物資産の分割所有
+sidebar_label: トークン化資産
 sidebar_position: 13
 ---
 
-# Tokenized Assets
+# トークン化資産
 
-## The Challenge
+## 課題
 
 Traditional investment in real-world assets like real estate, art, or commodities requires significant capital and involves complex legal and administrative processes. This excludes most people from wealth-building opportunities that have historically been reserved for the wealthy.
 
 Even for those who can invest, assets are often illiquid, making it difficult to access funds when needed. The overhead of buying, selling, and managing these assets further reduces returns.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Asset tokenization divides ownership of real-world assets into digital tokens that can be easily traded:
+資産のトークン化は、実物資産の所有権をデジタルトークンに分割し、簡単に取引できるようにします。
 
-- **Fractional ownership**: Own a piece of a building, artwork, or other valuable asset
-- **Increased liquidity**: Trade tokens 24/7 on decentralized exchanges
-- **Reduced barriers**: Lower minimum investments open opportunities to more people
-- **Automated compliance**: Smart contracts can enforce regulatory requirements
-- **Transparent ownership**: All ownership records are publicly verifiable
+- **分割所有**: ビル、美術品、その他の価値ある資産の一部を所有可能
+- **流動性の向上**: 分散型取引所で24時間365日トークンを売買可能
+- **参入障壁の低減**: 最低投資額を下げ、より多くの人に機会を開放
+- **コンプライアンスの自動化**: スマートコントラクトにより規制要件を自動的に適用
+- **透明な所有記録**: すべての所有記録が公開検証可能
 
 Tokenization can apply to virtually any asset class: real estate, infrastructure, commodities, collectibles, intellectual property, and more.
 
-## Why Cardano
+## なぜCardanoなのか
 
-- **Native tokens** provide efficient, secure asset representation
-- **Low transaction fees** make small trades economically viable
-- **Regulatory awareness** supports compliant tokenization schemes
-- **Smart contract security** through formal verification methods
-- **Global accessibility** enables worldwide participation
+- **ネイティブトークン**: 効率的で安全な資産のデジタル表現を実現
+- **低トランザクション手数料**: 小口取引も経済的に成立
+- **規制への意識**: コンプライアンスに対応したトークン化スキームをサポート
+- **スマートコントラクトの安全性**: 形式検証手法による堅牢性の確保
+- **グローバルなアクセス**: 世界中から誰でも参加可能
 
-## Get Started
+## はじめよう
 
-- [Explore Cardano applications](/apps)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Cardanoアプリケーションを探す](/apps)
+- [Cardano開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/voting-systems.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use-cases/voting-systems.md
@@ -1,41 +1,41 @@
 ---
-title: Voting Systems
-description: Secure, transparent election systems using Cardano blockchain technology
-sidebar_label: Voting Systems
+title: 投票システム
+description: Cardanoブロックチェーン技術による安全で透明な選挙システム
+sidebar_label: 投票システム
 sidebar_position: 14
 ---
 
-# Voting Systems
+# 投票システム
 
-## The Challenge
+## 課題
 
-Election integrity is fundamental to democracy, yet voting systems face persistent challenges. Paper-based systems are slow and error-prone, while electronic systems raise concerns about security, auditability, and trust. Voters often cannot verify that their vote was counted correctly.
+選挙の公正性は民主主義の根幹ですが、投票システムには根強い課題があります。紙ベースの方式は時間がかかりミスが起きやすく、電子投票はセキュリティ、監査可能性、信頼性に対する懸念があります。有権者は自分の票が正しく集計されたかを確認できないことがほとんどです。 Paper-based systems are slow and error-prone, while electronic systems raise concerns about security, auditability, and trust. Voters often cannot verify that their vote was counted correctly.
 
 Beyond governmental elections, organizations of all types need secure voting mechanisms for governance decisions. Current solutions often lack transparency or are vulnerable to manipulation.
 
-## How Blockchain Solves This
+## ブロックチェーンによる解決策
 
-Blockchain voting systems provide security, transparency, and verifiability:
+ブロックチェーンベースの投票システムは、安全性、透明性、検証可能性を提供します。
 
-- **Voter verification**: Cryptographic identity ensures only eligible voters participate
-- **Vote integrity**: Once cast, votes cannot be altered or deleted
-- **Auditability**: Anyone can verify the vote count while maintaining ballot secrecy
-- **Transparency**: The entire process is publicly auditable
-- **Accessibility**: Secure remote voting can increase participation
+- **有権者の本人確認**: 暗号化されたIDにより、資格のある有権者のみが投票に参加
+- **投票の完全性**: 一度投じた票は改ざんも削除も不可能
+- **監査可能性**: 投票の秘密を保ちながら、誰でも集計結果を検証可能
+- **透明性**: プロセス全体が公開監査に対応
+- **アクセシビリティ**: 安全なリモート投票により参加率の向上が期待
 
-Cardano's own governance uses blockchain-based voting, demonstrating the technology's viability for high-stakes decisions affecting billions of dollars in value.
+Cardano自体のガバナンスでもブロックチェーンベースの投票が採用されており、数十億ドル規模の意思決定における技術の実用性を実証しています。
 
-## Why Cardano
+## なぜCardanoなのか
 
-- **Proven governance voting** through Catalyst and on-chain governance
-- **Privacy-preserving options** protect voter anonymity while ensuring integrity
-- **Scalability** supports large-scale elections
-- **Community governance experience** provides real-world insights
-- **Research-driven approach** addresses complex voting system requirements
+- **実績あるガバナンス投票**: CatalystやオンチェーンガバナンスでのADA実績
+- **プライバシー保護**: 公正性を確保しつつ投票者の匿名性を保護
+- **スケーラビリティ**: 大規模な選挙にも対応可能
+- **コミュニティガバナンスの経験**: 実運用から得られた知見を蓄積
+- **研究に基づくアプローチ**: 複雑な投票システム要件に対応
 
-## Get Started
+## はじめよう
 
-- [Learn about Cardano governance](/governance)
-- [Explore governance tools](/apps?tags=governance)
-- [Developer resources for building on Cardano](https://developers.cardano.org)
-- [View Enterprise Solutions](/solutions)
+- [Cardanoのガバナンスについて学ぶ](/governance)
+- [ガバナンスツールを探す](/apps?tags=governance)
+- [Cardano開発者向けリソース](https://developers.cardano.org)
+- [エンタープライズソリューションを見る](/solutions)

--- a/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/i18n/ja/docusaurus-theme-classic/footer.json
@@ -1,22 +1,22 @@
 {
   "link.title.Entities": {
-    "message": "Entities",
+    "message": "関連組織",
     "description": "The title of the footer links column with title=Entities in the footer"
   },
   "link.title.Support": {
-    "message": "Support",
+    "message": "サポート",
     "description": "The title of the footer links column with title=Support in the footer"
   },
   "link.title.Legal": {
-    "message": "Legal",
+    "message": "法的情報",
     "description": "The title of the footer links column with title=Legal in the footer"
   },
   "link.title.More": {
-    "message": "More",
+    "message": "その他",
     "description": "The title of the footer links column with title=More in the footer"
   },
   "link.item.label.Cardano Foundation": {
-    "message": "Cardano Foundation",
+    "message": "カルダノ財団",
     "description": "The label of footer link with label=Cardano Foundation linking to /entities?tab=cardanofoundation"
   },
   "link.item.label.EMURGO": {
@@ -36,15 +36,15 @@
     "description": "The label of footer link with label=PRAGMA linking to /entities?tab=pragma"
   },
   "link.item.label.More entities": {
-    "message": "More entities",
+    "message": "その他の組織",
     "description": "The label of footer link with label=More entities linking to /entities/#companies"
   },
   "link.item.label.Brand Assets": {
-    "message": "Brand Assets",
+    "message": "ブランドアセット",
     "description": "The label of footer link with label=Brand Assets linking to /brand-assets"
   },
   "link.item.label.Glossary": {
-    "message": "Glossary",
+    "message": "用語集",
     "description": "The label of footer link with label=Glossary linking to /glossary"
   },
   "link.item.label.Discord": {
@@ -52,31 +52,31 @@
     "description": "The label of footer link with label=Discord linking to /docs/communities/#cardano-on-discord"
   },
   "link.item.label.Newsletter": {
-    "message": "Newsletter",
+    "message": "ニュースレター",
     "description": "The label of footer link with label=Newsletter linking to /newsletter"
   },
   "link.item.label.Contact": {
-    "message": "Contact",
+    "message": "お問い合わせ",
     "description": "The label of footer link with label=Contact linking to /contact"
   },
   "link.item.label.Terms": {
-    "message": "Terms",
+    "message": "利用規約",
     "description": "The label of footer link with label=Terms linking to https://cardanofoundation.org/en/terms-and-conditions"
   },
   "link.item.label.Privacy Policy": {
-    "message": "Privacy Policy",
+    "message": "プライバシーポリシー",
     "description": "The label of footer link with label=Privacy Policy linking to https://cardanofoundation.org/en/privacy"
   },
   "link.item.label.Cardano News": {
-    "message": "Cardano News",
+    "message": "Cardanoニュース",
     "description": "The label of footer link with label=Cardano News linking to /news"
   },
   "link.item.label.Get Involved": {
-    "message": "Get Involved",
+    "message": "参加する",
     "description": "The label of footer link with label=Get Involved linking to /docs/get-involved"
   },
   "link.item.label.Contributors": {
-    "message": "Contributors",
+    "message": "コントリビューター",
     "description": "The label of footer link with label=Contributors linking to https://github.com/cardano-foundation/cardano-org/graphs/contributors"
   },
   "copyright": {

--- a/i18n/vi/code.json
+++ b/i18n/vi/code.json
@@ -92,7 +92,7 @@
     "description": "The label used to navigate to the previous doc"
   },
   "theme.docs.paginator.next": {
-    "message": "Next",
+    "message": "Tiếp theo",
     "description": "The label used to navigate to the next doc"
   },
   "theme.docs.tagDocListPageTitle.nDocsTagged": {
@@ -278,7 +278,7 @@
     "message": "See all {count} results"
   },
   "theme.SearchPage.documentsFound.plurals": {
-    "message": "One document found|{count} documents found",
+    "message": "Đã tìm thấy một tài liệu | {count} đã tìm thấy tài liệu",
     "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.SearchPage.existingResultsTitle": {
@@ -294,7 +294,7 @@
     "description": "The placeholder for search page input"
   },
   "theme.SearchPage.inputLabel": {
-    "message": "Search",
+    "message": "Tìm kiếm",
     "description": "The ARIA label for search page input"
   },
   "theme.SearchPage.algoliaLabel": {
@@ -310,7 +310,7 @@
     "description": "The paragraph for fetching new search results"
   },
   "theme.SearchBar.label": {
-    "message": "Search",
+    "message": "Tìm kiếm",
     "description": "The ARIA label and placeholder for search button"
   },
   "theme.SearchModal.searchBox.resetButtonTitle": {
@@ -318,7 +318,7 @@
     "description": "The label and ARIA label for search box reset button"
   },
   "theme.SearchModal.searchBox.cancelButtonText": {
-    "message": "Cancel",
+    "message": "Huỷ bỏ",
     "description": "The label and ARIA label for search box cancel button"
   },
   "theme.SearchModal.searchBox.placeholderText": {
@@ -334,7 +334,7 @@
     "description": "The placeholder text for search box when AI is streaming an answer"
   },
   "theme.SearchModal.searchBox.enterKeyHint": {
-    "message": "search",
+    "message": "tìm kiếm",
     "description": "The hint for the search box enter key text"
   },
   "theme.SearchModal.searchBox.enterKeyHintAskAi": {
@@ -342,7 +342,7 @@
     "description": "The hint for the Ask AI search box enter key text"
   },
   "theme.SearchModal.searchBox.searchInputLabel": {
-    "message": "Search",
+    "message": "Tìm kiếm",
     "description": "The ARIA label for search input"
   },
   "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
@@ -578,7 +578,7 @@
     "description": "The title of the tag list page"
   },
   "whatIsAda.hero.title": {
-    "message": "What is ada?"
+    "message": "Ada là gì?"
   },
   "whatIsAda.hero.description1": {
     "message": "A new type of currency. A new means of transaction."
@@ -593,7 +593,7 @@
     "message": "ada is the native cryptocurrency of the Cardano blockchain. Use it for transactions, staking, governance voting, and interacting with decentralized applications."
   },
   "whatIsAda.section.headline": {
-    "message": "What is ada?"
+    "message": "Ada là gì?"
   },
   "whatIsAda.section.title": {
     "message": "Ada Is The Native Token Of Cardano"
@@ -617,7 +617,7 @@
     "message": "There are many ways to obtain ada to use the Cardano blockchain. Find out on {whereToGetAdaLink}"
   },
   "howToBuyAda.whereToGetAdaLink": {
-    "message": "where to get ada?"
+    "message": "mua ada ở đâu?"
   },
   "howToBuyAda.description2": {
     "message": "As an ada holder, it is important to keep your funds secure, and that means you need to keep your private keys private. It is highly recommended to avoid keeping your cryptocurrency in an exchange longer than necessary, and instead to use a cryptocurrency wallet."
@@ -725,13 +725,13 @@
     "message": "A cold wallet is an offline wallet. It is not connected to the internet and is used for securing storing funds that do not have to be frequently accessed. Examples include hardware wallets - which is a secure hardware device that stores the wallet's private keys - and paper wallets. Cardano is supported by both Trezor and Ledger hardware wallets."
   },
   "whatIsAda.button.getStarted": {
-    "message": "Get started with Cardano"
+    "message": "Bắt đầu với Cardano"
   },
   "whatIsAda.button.whereToGetAda": {
-    "message": "Where to get ada?"
+    "message": "Mua ada ở đâu?"
   },
   "getStarted.hero.title": {
-    "message": "Get started with Cardano"
+    "message": "Bắt đầu với Cardano"
   },
   "getStarted.hero.description": {
     "message": "Step into the new world yourself and learn all the basics in just few steps."
@@ -848,7 +848,7 @@
     "message": "Obtain ada, Cardano's native cryptocurrency, to start using the blockchain."
   },
   "getStarted.step5.heading": {
-    "message": "Where to get ada"
+    "message": "Mua ada ở đâu"
   },
   "getStarted.step5.text": {
     "message": "There are several ways to obtain ada, but the most common method is buying it on cryptocurrency exchanges using fiat currency or other cryptocurrencies."
@@ -869,7 +869,7 @@
     "message": "Now that you have a wallet and ada, you are ready to explore everything Cardano has to offer. A good place to start is by exploring popular apps."
   },
   "whereToGetAda.hero.title": {
-    "message": "Where to get ada?"
+    "message": "Mua ada ở đâu?"
   },
   "whereToGetAda.hero.description": {
     "message": "There are many ways to obtain ada to use the Cardano blockchain."
@@ -1100,219 +1100,219 @@
     "message": "Cardano is the most secure, reliable and censorship-resistant blockchain for mission critical applications to power economies and societies of the future."
   },
   "home.hero.ctaWhatIsAda": {
-    "message": "What is ada?"
+    "message": "Ada là gì?"
   },
   "home.hero.ctaGetStarted": {
-    "message": "Get Started"
+    "message": "Bắt đầu"
   },
   "home.featured.title": {
-    "message": "Our World Is Changing. Together, We Can Change It For The Better."
+    "message": "Thế giới đang thay đổi. Cùng nhau, chúng ta có thể thay đổi nó theo hướng tốt hơn."
   },
   "home.featured.description1": {
-    "message": "Cardano is a proof-of-stake blockchain platform: the first to be founded on [peer-reviewed research](/research) and developed through evidence-based methods. It combines pioneering technologies to provide unparalleled security and sustainability to decentralized applications, systems, and societies."
+    "message": "Cardano là nền tảng blockchain proof-of-stake: nền tảng đầu tiên được xây dựng dựa trên [nghiên cứu peer-reviewed](/research) và phát triển bằng phương pháp dựa trên bằng chứng. Cardano kết hợp các công nghệ tiên phong để mang đến sự bảo mật và tính bền vững chưa từng có cho các ứng dụng, hệ thống và xã hội phi tập trung."
   },
   "home.featured.description2": {
-    "message": "With a leading team of engineers, Cardano exists to redistribute power from unaccountable structures to the margins – to individuals – and be an enabling force for positive change and progress."
+    "message": "Với đội ngũ kỹ sư hàng đầu, Cardano tồn tại để phân phối lại quyền lực từ các cấu trúc thiếu trách nhiệm đến từng cá nhân – và trở thành động lực cho sự thay đổi và tiến bộ tích cực."
   },
   "home.featured.quote1": {
-    "message": "A History Of Impossible,"
+    "message": "Lịch sử của những điều bất khả,"
   },
   "home.featured.quote2": {
-    "message": "Made Possible"
+    "message": "trở thành hiện thực"
   },
   "home.featured.buttonLabel": {
-    "message": "Use Cardano Apps"
+    "message": "Sử dụng ứng dụng Cardano"
   },
   "home.divider.benefits": {
-    "message": "Benefits"
+    "message": "Lợi ích"
   },
   "home.quoteBox.description": {
-    "message": "Cardano restores trust to global systems – creating, through science, a more secure, transparent, and sustainable foundation for individuals to transact and exchange, systems to govern, and enterprises to grow."
+    "message": "Cardano khôi phục niềm tin cho các hệ thống toàn cầu – thông qua khoa học, tạo ra nền tảng an toàn, minh bạch và bền vững hơn cho cá nhân giao dịch, hệ thống quản trị và doanh nghiệp phát triển."
   },
   "home.quoteBox.quote": {
-    "message": "Cardano brings a new standard in technology – open and inclusive – to challenge the old and activate a new age of sustainable, globally-distributed innovation."
+    "message": "Cardano mang đến tiêu chuẩn mới trong công nghệ – mở và bao trùm – để thách thức cái cũ và khởi động kỷ nguyên mới của đổi mới bền vững, phân tán toàn cầu."
   },
   "home.benefits.ouroboros.label": {
-    "message": "Proof-of-stake and Ouroboros"
+    "message": "Proof-of-Stake và Ouroboros"
   },
   "home.benefits.ouroboros.category": {
-    "message": "Protocol"
+    "message": "Giao thức"
   },
   "home.benefits.ouroboros.title": {
-    "message": "Proof-Of-Stake And Ouroboros: The Most Environmentally Sustainable Blockchain Protocol"
+    "message": "Proof-of-Stake và Ouroboros: Giao thức blockchain bền vững nhất với môi trường"
   },
   "home.benefits.ouroboros.body": {
-    "message": "Ouroboros is the first peer-reviewed, verifiably-secure blockchain protocol, and Cardano is the first blockchain to implement it. Ouroboros enables decentralization in the Cardano network on a sustainable scale for global requirements and most crucially, without compromising security.<br /><br />The protocol is the result of tireless efforts, based on foundational research, propelled by a vision for more secure and transparent global payment systems, and provides the means to equitably redistribute power and control."
+    "message": "Ouroboros là giao thức blockchain peer-reviewed đầu tiên, được xác minh an toàn, và Cardano là blockchain đầu tiên triển khai nó. Ouroboros cho phép phi tập trung hóa mạng lưới Cardano ở quy mô bền vững cho các yêu cầu toàn cầu, và quan trọng nhất là không ảnh hưởng đến bảo mật.<br /><br />Giao thức này là kết quả của nỗ lực không ngừng, dựa trên nghiên cứu nền tảng, được thúc đẩy bởi tầm nhìn về hệ thống thanh toán toàn cầu an toàn và minh bạch hơn, đồng thời cung cấp phương tiện để phân phối lại quyền lực và quyền kiểm soát một cách công bằng."
   },
   "home.benefits.ouroboros.cta": {
-    "message": "Learn about Ouroboros"
+    "message": "Tìm hiểu về Ouroboros"
   },
   "home.benefits.research.label": {
-    "message": "Evidence-based development"
+    "message": "Phát triển dựa trên bằng chứng"
   },
   "home.benefits.research.category": {
-    "message": "Research"
+    "message": "Nghiên cứu"
   },
   "home.benefits.research.title": {
-    "message": "The Highest Standards In Development, Rooted In Science"
+    "message": "Tiêu chuẩn phát triển cao nhất, bắt nguồn từ khoa học"
   },
   "home.benefits.research.body": {
-    "message": "Cardano is developed using evidence-based methods; a novel combination of formal methods, normally found in critical high-stakes applications, and an agile approach, which helps the project remain adaptable and responsive to emerging requirements and new innovations. To support global applications, systems, and solutions, we believe security assurance is not a choice: it is a requirement. Our protocol implementations and platform integrations are first researched, challenged, and mathematically modeled and tested before they are specified. These specifications then inform development which, in turn, is independently audited. The result is a codebase offering an unrivaled level of assurance."
+    "message": "Cardano được phát triển bằng phương pháp dựa trên bằng chứng – sự kết hợp mới lạ giữa phương pháp hình thức, thường thấy trong các ứng dụng quan trọng có rủi ro cao, và phương pháp linh hoạt (agile), giúp dự án luôn thích ứng và phản hồi nhanh với các yêu cầu mới. Để hỗ trợ các ứng dụng, hệ thống và giải pháp toàn cầu, chúng tôi tin rằng đảm bảo bảo mật không phải là lựa chọn mà là yêu cầu bắt buộc. Các giao thức và tích hợp nền tảng được nghiên cứu, thử thách và mô hình hóa toán học trước khi được đặc tả. Các đặc tả này sau đó định hướng quá trình phát triển, và kết quả được kiểm toán độc lập. Kết quả là một mã nguồn với mức độ đảm bảo chưa từng có."
   },
   "home.benefits.research.cta": {
-    "message": "Discover the research"
+    "message": "Khám phá nghiên cứu"
   },
   "home.benefits.secure.label": {
-    "message": "Secure"
+    "message": "Bảo mật"
   },
   "home.benefits.secure.category": {
-    "message": "Transact"
+    "message": "Giao dịch"
   },
   "home.benefits.secure.title": {
-    "message": "Unparalleled Security - And The Makings Of A Trustless World"
+    "message": "Bảo mật vượt trội – Nền tảng của thế giới không cần tin cậy"
   },
   "home.benefits.secure.body": {
-    "message": "Cardano makes it possible for any actors who do not know each other - and have no reason to trust one another - to interact and transact, securely. It is a platform for building trust where none might naturally exist, opening up whole new markets and opportunities. Through Ouroboros, Cardano is provably secure against bad actors and Sybil attacks. Every transaction, interaction, and exchange is immutably and transparently recovered, and securely validated using multi-signature and a pioneering extended UTXO model."
+    "message": "Cardano cho phép các bên không quen biết nhau – và không có lý do để tin tưởng lẫn nhau – tương tác và giao dịch một cách an toàn. Đây là nền tảng xây dựng niềm tin nơi vốn không tồn tại, mở ra thị trường và cơ hội hoàn toàn mới. Thông qua Ouroboros, Cardano được bảo vệ trước các tác nhân xấu và tấn công Sybil. Mỗi giao dịch, tương tác và trao đổi đều được ghi lại bất biến và minh bạch, được xác thực an toàn bằng đa chữ ký và mô hình UTXO mở rộng tiên phong."
   },
   "home.benefits.secure.cta": {
-    "message": "Visit the roadmap"
+    "message": "Xem lộ trình"
   },
   "home.benefits.participation.label": {
-    "message": "Incentivized participation"
+    "message": "Tham gia có khuyến khích"
   },
   "home.benefits.participation.category": {
-    "message": "Open"
+    "message": "Mở"
   },
   "home.benefits.participation.title": {
-    "message": "Open And Incentivized Participation"
+    "message": "Mở và khuyến khích sự tham gia"
   },
   "home.benefits.participation.body": {
-    "message": "With a committed community at its core, Cardano is an open-source project developed through open participation. To ensure the longevity and health of the network, Cardano features an incentive mechanism that rewards users - either as stake pool operators or stake delegators - for their participation. The platform is built and expanded through enhancement and improvement proposals. Cardano's governance system gives everyone a democratic voice; ada holders can submit or vote on proposals to upgrade the platform or help determine the direction of development. The governance model uniquely positions Cardano for future growth and development, and provides the means to introduce new capabilities tailored to user needs. It ensures Cardano and its community can continuously fund and decide upon platform and ecosystem improvements."
+    "message": "Với cộng đồng tận tâm làm nòng cốt, Cardano là dự án mã nguồn mở được phát triển thông qua sự tham gia mở. Để đảm bảo sự bền vững và sức khỏe của mạng lưới, Cardano có cơ chế khuyến khích thưởng cho người dùng – dù là nhà vận hành stake pool hay người ủy quyền – cho sự tham gia của họ. Nền tảng được xây dựng và mở rộng thông qua các đề xuất cải tiến. Hệ thống quản trị của Cardano trao cho mọi người tiếng nói dân chủ; người nắm giữ ada có thể gửi hoặc bỏ phiếu cho các đề xuất nâng cấp nền tảng hoặc định hướng phát triển. Mô hình quản trị này đặt Cardano vào vị thế thuận lợi cho sự tăng trưởng trong tương lai, đồng thời cung cấp phương tiện để giới thiệu tính năng mới phù hợp với nhu cầu người dùng. Điều này đảm bảo Cardano và cộng đồng có thể liên tục tài trợ và quyết định các cải tiến cho nền tảng và hệ sinh thái."
   },
   "home.benefits.participation.cta": {
-    "message": "Learn about governance"
+    "message": "Tìm hiểu về quản trị"
   },
   "home.benefits.scalable.label": {
-    "message": "Scalable and sustainable"
+    "message": "Khả năng mở rộng và bền vững"
   },
   "home.benefits.scalable.category": {
-    "message": "Ecosystem"
+    "message": "Hệ sinh thái"
   },
   "home.benefits.scalable.title": {
-    "message": "Extremely Scalable And Environmentally Sustainable"
+    "message": "Khả năng mở rộng vượt trội và bền vững với môi trường"
   },
   "home.benefits.scalable.body": {
-    "message": "Ouroboros allows Cardano to scale to global requirements with minimal energy consumption. Unlike other blockchains, Cardano does not require exponentially increasing energy to enhance performance and add blocks. The balance between performance and sustainability is achieved through a combination of novel approaches, including multi-ledger, side chains, and parallel transaction processing through multi-party state channels.<br /><br />The network proliferates as the number of stake pools increases, while parameters are set and adjusted to measure the attractiveness of specific stake pools. This is a network that rewards participation directly. Cardano is designed to ensure that those who act in the best interests of the network are also acting in their own best interests. This ensures the development of a healthy ecosystem with a durable, healthy, and robust network, now and into the future. The combination of sustainability and scalability allows Cardano to achieve the throughput required to meet the evolving demands of global systems— financial, logistical, identity-related, societal."
+    "message": "Ouroboros cho phép Cardano mở rộng theo yêu cầu toàn cầu với mức tiêu thụ năng lượng tối thiểu. Khác với các blockchain khác, Cardano không yêu cầu tăng năng lượng theo cấp số nhân để nâng cao hiệu suất và thêm khối. Sự cân bằng giữa hiệu suất và tính bền vững đạt được thông qua sự kết hợp các phương pháp mới, bao gồm đa sổ cái, chuỗi phụ và xử lý giao dịch song song qua kênh trạng thái đa bên.<br /><br />Mạng lưới phát triển khi số lượng stake pool tăng lên, trong khi các tham số được thiết lập và điều chỉnh để đo lường sức hấp dẫn của từng stake pool. Đây là mạng lưới thưởng trực tiếp cho sự tham gia. Cardano được thiết kế để đảm bảo rằng những ai hành động vì lợi ích tốt nhất của mạng lưới cũng đang hành động vì lợi ích của chính mình. Điều này đảm bảo sự phát triển của một hệ sinh thái lành mạnh với mạng lưới bền bỉ và mạnh mẽ, cho hiện tại và tương lai. Sự kết hợp giữa tính bền vững và khả năng mở rộng cho phép Cardano đạt được thông lượng cần thiết để đáp ứng nhu cầu ngày càng phát triển của các hệ thống toàn cầu – tài chính, hậu cần, danh tính, xã hội."
   },
   "home.benefits.scalable.cta": {
-    "message": "Learn about Hydra"
+    "message": "Tìm hiểu về Hydra"
   },
   "home.vision.title1": {
-    "message": "Define Your Possible."
+    "message": "Định nghĩa khả năng của bạn."
   },
   "home.vision.title2": {
-    "message": "Change Your World."
+    "message": "Thay đổi thế giới của bạn."
   },
   "home.divider.makeTheChange": {
-    "message": "Make the Change"
+    "message": "Tạo sự thay đổi"
   },
   "home.discover.title": {
-    "message": "Discover Cardano"
+    "message": "Khám phá Cardano"
   },
   "home.discover.description": {
-    "message": "Cardano is the first blockchain platform to be built through [peer-reviewed research](/research), to be secure enough to protect the data of billions, scalable enough to accommodate global systems, and robust enough to support foundational change."
+    "message": "Cardano là nền tảng blockchain đầu tiên được xây dựng dựa trên [nghiên cứu peer-reviewed](/research), đủ an toàn để bảo vệ dữ liệu của hàng tỷ người, đủ khả năng mở rộng để phục vụ các hệ thống toàn cầu, và đủ vững chắc để hỗ trợ thay đổi nền tảng."
   },
   "home.discover.people": {
-    "message": "People"
+    "message": "Con người"
   },
   "home.discover.purpose": {
-    "message": "Purpose"
+    "message": "Mục đích"
   },
   "home.discover.research": {
-    "message": "Research"
+    "message": "Nghiên cứu"
   },
   "home.discover.technology": {
-    "message": "Technology"
+    "message": "Công nghệ"
   },
   "home.discover.opportunity": {
-    "message": "Opportunity"
+    "message": "Cơ hội"
   },
   "home.discover.quote1": {
-    "message": "We have changed science. We have changed what it means to build global systems and sustainable models of exchange and governance."
+    "message": "Chúng tôi đã thay đổi khoa học. Chúng tôi đã thay đổi ý nghĩa của việc xây dựng các hệ thống toàn cầu và mô hình trao đổi, quản trị bền vững."
   },
   "home.discover.quote2": {
-    "message": "Alongside the community, entities, and companies building on Cardano, a new future is being defined: a decentralized future without intermediaries, where power is returned to the individual"
+    "message": "Cùng với cộng đồng, các tổ chức và doanh nghiệp xây dựng trên Cardano, một tương lai mới đang được định hình: tương lai phi tập trung không có trung gian, nơi quyền lực được trao lại cho mỗi cá nhân"
   },
   "home.divider.entities": {
-    "message": "Entities"
+    "message": "Các tổ chức"
   },
   "home.entities.description": {
-    "message": "Multiple independent entities collaborate within a decentralized team framework to drive Cardano forward, ensuring that it remains aligned with its core mission as it progresses and develops. These are a few of them:"
+    "message": "Nhiều tổ chức độc lập cùng hợp tác trong khuôn khổ phi tập trung để thúc đẩy Cardano tiến lên, đảm bảo luôn phù hợp với sứ mệnh cốt lõi trong quá trình phát triển. Dưới đây là một số tổ chức tiêu biểu:"
   },
   "home.follow.divider": {
-    "message": "Social"
+    "message": "Mạng xã hội"
   },
   "home.follow.title": {
-    "message": "Get Involved"
+    "message": "Tham gia cùng chúng tôi"
   },
   "navbar.mega.column.Get to know": {
-    "message": "Get to know",
+    "message": "Tìm hiểu",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Take part": {
-    "message": "Take part",
+    "message": "Tham gia",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Research": {
-    "message": "Research",
+    "message": "Nghiên cứu",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Connect": {
-    "message": "Connect",
+    "message": "Kết nối",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Engage": {
-    "message": "Engage",
+    "message": "Cộng đồng",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Governance": {
-    "message": "Governance",
+    "message": "Quản trị",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Get started": {
-    "message": "Get started",
+    "message": "Bắt đầu",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Tools": {
-    "message": "Tools",
+    "message": "Công cụ",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.For Enterprise": {
-    "message": "For Enterprise",
+    "message": "Doanh nghiệp",
     "description": "Mega menu column title"
   },
   "navbar.mega.column.Use Cases": {
-    "message": "Use Cases",
+    "message": "Ứng dụng thực tế",
     "description": "Mega menu column title"
   },
   "navbar.mega.label.What is ada?": {
-    "message": "What is ada?",
+    "message": "Ada là gì?",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Get started with Cardano": {
-    "message": "Get started with Cardano",
+    "message": "Bắt đầu với Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Where to get ada?": {
-    "message": "Where to get ada?",
+    "message": "Mua ada ở đâu?",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Protect your ada": {
-    "message": "Protect your ada",
+    "message": "Bảo vệ ada của bạn",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Delegate your ada": {
-    "message": "Delegate your ada",
+    "message": "Ủy quyền ada của bạn",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Delegate your vote": {
@@ -1320,123 +1320,123 @@
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Use Cardano Apps": {
-    "message": "Use Cardano Apps",
+    "message": "Sử dụng ứng dụng Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Code of Conduct": {
-    "message": "Code of Conduct",
+    "message": "Quy tắc ứng xử",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Research": {
-    "message": "Cardano Research",
+    "message": "Nghiên cứu Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Insights": {
-    "message": "Cardano Insights",
+    "message": "Thông tin chi tiết về Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Hard Forks": {
-    "message": "Hard Forks",
+    "message": "Hard Fork",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.News": {
-    "message": "News",
+    "message": "Tin tức",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Newsletter": {
-    "message": "Newsletter",
+    "message": "Bản tin",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Online Communities": {
-    "message": "Online Communities",
+    "message": "Cộng đồng trực tuyến",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Ambassador Program": {
-    "message": "Ambassador Program",
+    "message": "Chương trình Đại sứ",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Events": {
-    "message": "Cardano Events",
+    "message": "Sự kiện Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Forum": {
-    "message": "Cardano Forum",
+    "message": "Diễn đàn Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Get involved in cardano.org": {
-    "message": "Get involved in cardano.org",
+    "message": "Đóng góp cho cardano.org",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Participate in governance": {
-    "message": "Participate in governance",
+    "message": "Tham gia quản trị",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Governance Tools": {
-    "message": "Governance Tools",
+    "message": "Công cụ quản trị",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Cardano Constitution": {
-    "message": "Cardano Constitution",
+    "message": "Hiến pháp Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Start building on Cardano": {
-    "message": "Start building on Cardano",
+    "message": "Bắt đầu phát triển trên Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Integrate Cardano": {
-    "message": "Integrate Cardano",
+    "message": "Tích hợp Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Developer Portal": {
-    "message": "Developer Portal",
+    "message": "Cổng nhà phát triển",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Builder Tools": {
-    "message": "Builder Tools",
+    "message": "Công cụ phát triển",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Companies building on Cardano": {
-    "message": "Companies building on Cardano",
+    "message": "Doanh nghiệp xây dựng trên Cardano",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Enterprise Solutions": {
-    "message": "Enterprise Solutions",
+    "message": "Giải pháp doanh nghiệp",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Contact the Foundation": {
-    "message": "Contact the Foundation",
+    "message": "Liên hệ với Foundation",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.All Use Cases": {
-    "message": "All Use Cases",
+    "message": "Tất cả ứng dụng",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Identity": {
-    "message": "Identity",
+    "message": "Danh tính",
     "description": "Mega menu item label"
   },
   "navbar.mega.label.Supply Chain": {
-    "message": "Supply Chain",
+    "message": "Chuỗi cung ứng",
     "description": "Mega menu item label"
   },
   "navbar.mega.description.What is ada?": {
-    "message": "Cardano's native token",
+    "message": "Token gốc của Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Get started with Cardano": {
-    "message": "Learn the basics and start using Cardano",
+    "message": "Tìm hiểu cơ bản và bắt đầu sử dụng Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Where to get ada?": {
-    "message": "Obtain ada to use Cardano",
+    "message": "Sở hữu ada để sử dụng Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Protect your ada": {
-    "message": "Don't fall for scams",
+    "message": "Đừng để bị lừa đảo",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Delegate your ada": {
-    "message": "Be a part of it and earn rewards",
+    "message": "Tham gia và nhận phần thưởng",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Delegate your vote": {
@@ -1444,103 +1444,103 @@
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Use Cardano Apps": {
-    "message": "Explore curated applications",
+    "message": "Khám phá các ứng dụng được tuyển chọn",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Code of Conduct": {
-    "message": "Community standards and values",
+    "message": "Tiêu chuẩn và giá trị cộng đồng",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Research": {
-    "message": "Peer-reviewed research and papers",
+    "message": "Nghiên cứu và bài báo peer-reviewed",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Insights": {
-    "message": "On-chain or regularly refreshed data",
+    "message": "Dữ liệu on-chain và cập nhật định kỳ",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Hard Forks": {
-    "message": "Implemented Upgrades",
+    "message": "Các nâng cấp đã triển khai",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.News": {
-    "message": "Latest Cardano news and updates",
+    "message": "Tin tức và cập nhật mới nhất về Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Newsletter": {
-    "message": "Stay updated with Cardano news",
+    "message": "Cập nhật tin tức Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Online Communities": {
-    "message": "Recommended Channels",
+    "message": "Các kênh được khuyên dùng",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Ambassador Program": {
-    "message": "Meet Cardano Ambassadors",
+    "message": "Gặp gỡ các Đại sứ Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Events": {
-    "message": "Join Cardano community events",
+    "message": "Tham gia các sự kiện cộng đồng Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Forum": {
-    "message": "Structured long-format discussions",
+    "message": "Thảo luận chuyên sâu theo chủ đề",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Get involved in cardano.org": {
-    "message": "If you'd like to participate, this will get you started",
+    "message": "Nếu bạn muốn tham gia, hãy bắt đầu từ đây",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Participate in governance": {
-    "message": "Shape Cardano's future",
+    "message": "Định hình tương lai của Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Governance Tools": {
-    "message": "Tools for transparent, community-driven decisions",
+    "message": "Công cụ cho các quyết định minh bạch của cộng đồng",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Cardano Constitution": {
-    "message": "Learn about governance",
+    "message": "Tìm hiểu về quản trị",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Start building on Cardano": {
-    "message": "Developer resources and tooling",
+    "message": "Tài nguyên và công cụ cho nhà phát triển",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Integrate Cardano": {
-    "message": "Exchange and integration guides",
+    "message": "Hướng dẫn tích hợp cho sàn giao dịch",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Developer Portal": {
-    "message": "Cardano developer portal and docs",
+    "message": "Cổng và tài liệu cho nhà phát triển Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Builder Tools": {
-    "message": "Tools to build on Cardano",
+    "message": "Công cụ xây dựng trên Cardano",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Companies building on Cardano": {
-    "message": "Companies, associations, and collaborations",
+    "message": "Doanh nghiệp, hiệp hội và hợp tác",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Enterprise Solutions": {
-    "message": "Case studies and proven deployments",
+    "message": "Nghiên cứu tình huống và triển khai thực tế",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Contact the Foundation": {
-    "message": "Partner with the Cardano Foundation",
+    "message": "Hợp tác với Cardano Foundation",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.All Use Cases": {
-    "message": "Explore blockchain applications",
+    "message": "Khám phá các ứng dụng blockchain",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Identity": {
-    "message": "Credentials & verification",
+    "message": "Xác thực và chứng nhận",
     "description": "Mega menu item description"
   },
   "navbar.mega.description.Supply Chain": {
-    "message": "Traceability & provenance",
+    "message": "Truy xuất nguồn gốc",
     "description": "Mega menu item description"
   },
   "solutions.data.dpp.title": {
@@ -1550,7 +1550,7 @@
     "message": "EU-compliant digital product passports for transparency and sustainability."
   },
   "solutions.data.category.supplyChain": {
-    "message": "Supply Chain"
+    "message": "Chuỗi cung ứng"
   },
   "solutions.data.traceability.title": {
     "message": "Traceability"
@@ -1577,7 +1577,7 @@
     "message": "Secure, distributed data storage solutions for enterprises."
   },
   "solutions.data.category.dataTech": {
-    "message": "Data & Technology"
+    "message": "Dữ liệu & Công nghệ"
   },
   "solutions.data.navio.description": {
     "message": "Blockchain-based solution for supply chain management."
@@ -1589,106 +1589,106 @@
     "message": "Explore real-world implementations of Cardano blockchain solutions."
   },
   "useCases.category.identity": {
-    "message": "Identity"
+    "message": "Danh tính"
   },
   "useCases.card.education.title": {
-    "message": "Education"
+    "message": "Giáo dục"
   },
   "useCases.card.education.summary": {
     "message": "Blockchain-verified academic credentials"
   },
   "useCases.card.digitalIdentity.title": {
-    "message": "Digital Identity"
+    "message": "Định danh kỹ thuật số"
   },
   "useCases.card.digitalIdentity.summary": {
     "message": "Own and control your digital identity"
   },
   "useCases.card.financeKyc.title": {
-    "message": "Finance KYC"
+    "message": "KYC tài chính"
   },
   "useCases.card.financeKyc.summary": {
     "message": "Streamlined identity verification"
   },
   "useCases.card.government.title": {
-    "message": "Government"
+    "message": "Chính phủ"
   },
   "useCases.card.government.summary": {
     "message": "Tamper-proof official documents"
   },
   "useCases.category.finance": {
-    "message": "Finance"
+    "message": "Tài chính"
   },
   "useCases.card.defi.summary": {
     "message": "Decentralized lending and exchanges"
   },
   "useCases.card.payments.title": {
-    "message": "Payments"
+    "message": "Thanh toán"
   },
   "useCases.card.payments.summary": {
     "message": "Fast, low-cost cross-border transfers"
   },
   "useCases.category.supplyChain": {
-    "message": "Supply Chain"
+    "message": "Chuỗi cung ứng"
   },
   "useCases.card.agriculture.title": {
-    "message": "Agriculture"
+    "message": "Nông nghiệp"
   },
   "useCases.card.agriculture.summary": {
     "message": "Farm-to-table traceability"
   },
   "useCases.card.retail.title": {
-    "message": "Retail"
+    "message": "Bán lẻ"
   },
   "useCases.card.retail.summary": {
     "message": "Combat counterfeiting with provenance"
   },
   "useCases.card.logistics.title": {
-    "message": "Logistics"
+    "message": "Logistic"
   },
   "useCases.card.logistics.summary": {
     "message": "Real-time tracking and verification"
   },
   "useCases.category.socialImpact": {
-    "message": "Social Impact"
+    "message": "Tác động xã hội"
   },
   "useCases.card.socialPrograms.title": {
-    "message": "Social Programs"
+    "message": "Chương trình xã hội"
   },
   "useCases.card.socialPrograms.summary": {
     "message": "Transparent fund distribution"
   },
   "useCases.category.dataTech": {
-    "message": "Data & Technology"
+    "message": "Dữ liệu & Công nghệ"
   },
   "useCases.card.dataStorage.title": {
-    "message": "Data Storage"
+    "message": "Lưu trữ dữ liệu"
   },
   "useCases.card.dataStorage.summary": {
     "message": "Decentralized, secure storage"
   },
   "useCases.card.tokenizedAssets.title": {
-    "message": "Tokenized Assets"
+    "message": "Token hoá tài sản"
   },
   "useCases.card.tokenizedAssets.summary": {
     "message": "Fractional ownership of real-world assets"
   },
   "useCases.category.emerging": {
-    "message": "Emerging Applications"
+    "message": "Ứng dụng mới nổi"
   },
   "useCases.card.votingSystems.title": {
-    "message": "Voting Systems"
+    "message": "Hệ thống bỏ phiếu"
   },
   "useCases.card.votingSystems.summary": {
     "message": "Secure, transparent elections"
   },
   "useCases.card.healthcare.title": {
-    "message": "Healthcare"
+    "message": "Chăm sóc sức khỏe"
   },
   "useCases.card.healthcare.summary": {
     "message": "Portable, secure health records"
   },
   "useCases.card.musicIp.title": {
-    "message": "Music & IP"
+    "message": "Âm nhạc và sở hữu trí tuệ"
   },
   "useCases.card.musicIp.summary": {
     "message": "Direct royalty payments to artists"
@@ -1718,10 +1718,10 @@
     "message": "Ambassadorship is a reflection of commitment and contribution. Those who actively support the community and help Cardano grow naturally step into this role."
   },
   "ambassadors.cta.rightButtonLabel": {
-    "message": "Get Started"
+    "message": "Hãy Bắt Đầu"
   },
   "brandAssets.hero.title": {
-    "message": "Brand Assets"
+    "message": "Tài sản thương hiệu"
   },
   "brandAssets.hero.description": {
     "message": "Our brand is a reflection of everything that we create. Here are some of the things that make up our brand and how you can use them."
@@ -1961,7 +1961,7 @@
     "message": "Discover the Cardano Constitution: the governance framework of the Cardano blockchain. Read the current enacted charter, explore its ratification history, and download the full text via IPFS."
   },
   "contact.hero.title": {
-    "message": "Contact"
+    "message": "Liên hệ"
   },
   "contact.hero.description": {
     "message": "Cardano is supported by the Cardano Foundation, IOG, EMURGO, Intersect, PRAGMA and others. Fill out the contact form below and we will put you in touch with the team best placed to assist you."
@@ -2030,7 +2030,7 @@
     "message": "Making the World Work Better for All"
   },
   "artworkContest.hero.description": {
-    "message": "Cardano is a blockchain platform for changemakers, innovators, and visionaries, with the tools and technologies required to create possibility for the many, as well as the few, and bring about positive global change."
+    "message": "Cardano là nền tảng blockchain dành cho những người tiên phong, nhà đổi mới và người có tầm nhìn – với đầy đủ công cụ và công nghệ để tạo cơ hội cho số đông, không chỉ cho số ít, nhằm mang lại thay đổi tích cực trên toàn cầu."
   },
   "artworkContest.imagePreview.alt": {
     "message": "Preview"
@@ -2039,7 +2039,7 @@
     "message": "Cardano Artwork Contest"
   },
   "artworkContest.layout.description": {
-    "message": "An open platform designed to empower billions without economic identity by offering decentralized applications for managing identity, value, and governance."
+    "message": "Nền tảng mở được thiết kế để trao quyền cho hàng tỷ người chưa có danh tính kinh tế, thông qua các ứng dụng phi tập trung quản lý danh tính, giá trị và quản trị."
   },
   "artworkContest.content.title": {
     "message": "Artwork Contest Test Page"
@@ -2084,7 +2084,7 @@
     "message": "Explore the tools, projects, and updates that are shaping the Cardano ecosystem. Below you'll find links to builder tools, a showcase of projects built on Cardano, and a technical updates tracker that aggregates commits within the last 7 days from all branches of Cardano development-related repos."
   },
   "developers.support.title": {
-    "message": "Support"
+    "message": "Hỗ trợ"
   },
   "developers.support.text": {
     "message": "Join the vibrant Cardano developer community through various platforms. Below you'll find links to the Cardano Stack Exchange, the Cardano Forum, and the official Telegram group. Connect with fellow developers, ask questions, and share insights in our decentralized ecosystem."
@@ -2096,7 +2096,7 @@
     "message": "Play the game"
   },
   "discoverCardano.hero.title": {
-    "message": "Discover Cardano"
+    "message": "Khám phá Cardano"
   },
   "discoverCardano.hero.description": {
     "message": "Cardano is the nexus of five principles: People, purpose, technology, research, and opportunity. Explore and learn this new constellation of knowledge."
@@ -2108,7 +2108,7 @@
     "message": "Discover what makes Cardano different. Built on peer-reviewed science, powered by a global community, and designed for a sustainable, decentralized future."
   },
   "discoverCardano.people.title": {
-    "message": "People"
+    "message": "Con người"
   },
   "discoverCardano.people.subtitle": {
     "message": "Working together, we achieve more for the many."
@@ -2120,7 +2120,7 @@
     "message": "Every ada holder also holds a stake in the Cardano network. Ada stored in a wallet can be delegated to a stake pool to earn rewards – to participate in the successful running of the network – or pledged to a stake pool to increase the pool's likelihood of receiving rewards. In time, ada will also be usable for a variety of applications and services on the Cardano platform."
   },
   "discoverCardano.purpose.title": {
-    "message": "Purpose"
+    "message": "Mục đích"
   },
   "discoverCardano.purpose.subtitle": {
     "message": "A platform built for a sustainable future, to help people work better together, trust one another, and build global solutions to global problems."
@@ -2132,7 +2132,7 @@
     "message": "Cardano began with a vision of a world without intermediaries, in which power is not controlled by an accountable few, but by the empowered many. In this world, individuals have control over their data and how they interact and transact. Businesses have the opportunity to grow independent of monopolistic and bureaucratic power structures. Societies are able to pursue true democracy: self-governing, fair, and accountable. It is a world made possible by Cardano."
   },
   "discoverCardano.technology.title": {
-    "message": "Technology"
+    "message": "Công nghệ"
   },
   "discoverCardano.technology.subtitle": {
     "message": "Cardano brings a new standard in technology - open and inclusive – to challenge the old and activate a new age of sustainable, globally-distributed innovation."
@@ -2147,7 +2147,7 @@
     "message": "Our technology is underpinned by [research](/research). We have redefined what it means to create a global software platform through scientific methods. We have not compromised on our belief, or in our approach. To build a better future - secure, sustainable, and governable by the many - we have taken the road less traveled. The result of our efforts is a blockchain platform unparalleled in its capability and performance, and which is truly able to support global applications, systems, and real-life business use cases."
   },
   "discoverCardano.research.title": {
-    "message": "Research"
+    "message": "Nghiên cứu"
   },
   "discoverCardano.research.subtitle": {
     "message": "Pioneering tech begins with groundbreaking research."
@@ -2159,7 +2159,7 @@
     "message": "[Our research](/research) - led by leading academics - explores philosophy, sociology, behavior, and game theory. To achieve each outcome, we consider the minutiae of possibilities: the variables that often go unconsidered, but which may ultimately impact the integrity and sustainability of a global, decentralized platform. We take nothing for granted."
   },
   "discoverCardano.opportunity.title": {
-    "message": "Opportunity"
+    "message": "Cơ hội"
   },
   "discoverCardano.opportunity.subtitle": {
     "message": "The staging point for every new opportunity. Empower your business through Cardano, and discover the future of technology."
@@ -2198,7 +2198,7 @@
     "message": "add your company"
   },
   "events.hero.title": {
-    "message": "Cardano Events"
+    "message": "Sự kiện Cardano"
   },
   "events.hero.description": {
     "message": "Upcoming Cardano events in one place, so you never miss a chance to connect, learn, and grow with the Cardano Community."
@@ -2207,7 +2207,7 @@
     "message": "Previous"
   },
   "events.pagination.next": {
-    "message": "Next"
+    "message": "Tiếp theo"
   },
   "events.meta.title": {
     "message": "Cardano Events, Conferences and Meetups"
@@ -2237,7 +2237,7 @@
     "message": "Watch here"
   },
   "exchanges.hero.title": {
-    "message": "Integrate Cardano"
+    "message": "Tích hợp Cardano"
   },
   "exchanges.hero.description": {
     "message": "Easy integration with Cardano. All of the upgrades. None of the maintenance."
@@ -2531,7 +2531,7 @@
     "message": "Note that some hard forks, particularly Byron and Shelley, transitioned through a series of updates and may not have a single specific transaction id associated with them. For the others, the provided transaction ids correspond to significant parameter updates leading to the hard forks."
   },
   "learn.hero.title": {
-    "message": "Learn"
+    "message": "Tìm hiểu"
   },
   "learn.hero.description": {
     "message": "Empowering the digital architects of the future."
@@ -2645,7 +2645,7 @@
     "message": "Play the game"
   },
   "research.hero.title": {
-    "message": "Research"
+    "message": "Nghiên cứu"
   },
   "research.hero.description": {
     "message": "Cardano relevant research papers and specifications."
@@ -2720,7 +2720,7 @@
     "message": "Available Topics"
   },
   "solutions.hero.title": {
-    "message": "Enterprise Solutions"
+    "message": "Giải pháp doanh nghiệp"
   },
   "solutions.hero.description": {
     "message": "Proven blockchain solutions for supply chain, identity, and beyond."
@@ -2984,7 +2984,7 @@
     "message": "Try Out"
   },
   "useCases.hero.title": {
-    "message": "Use Cases"
+    "message": "Ứng dụng thực tế"
   },
   "useCases.hero.description": {
     "message": "How Cardano blockchain solves real-world problems across industries."
@@ -2999,7 +2999,7 @@
     "message": "Explore blockchain applications across industries. From identity verification to supply chain tracking, Cardano provides secure, scalable solutions for real-world challenges."
   },
   "useCases.divider.enterprise": {
-    "message": "Enterprise Solutions"
+    "message": "Giải pháp doanh nghiệp"
   },
   "useCases.enterprise.description": {
     "message": "Looking for proven enterprise deployments? Explore case studies and real-world implementations by the Cardano Foundation and partners."
@@ -3122,7 +3122,7 @@
     "message": "Vote"
   },
   "apps.intent.build": {
-    "message": "Build"
+    "message": "Phát triển"
   },
   "apps.intent.mintNfts": {
     "message": "Mint NFTs"
@@ -3248,7 +3248,7 @@
     "message": "Previous"
   },
   "apps.carousel.next": {
-    "message": "Next"
+    "message": "Tiếp theo"
   },
   "apps.mostActive.leaderboardLink": {
     "message": "Live from the transaction leaderboard"
@@ -3317,7 +3317,7 @@
     "message": "Filter by topic"
   },
   "insights.filter.clear": {
-    "message": "Clear"
+    "message": "Xóa"
   },
   "insights.pagination.prevAriaLabel": {
     "message": "Previous page"
@@ -3332,7 +3332,7 @@
     "message": "Next page"
   },
   "insights.pagination.next": {
-    "message": "Next"
+    "message": "Tiếp theo"
   },
   "insights.noResults": {
     "message": "No insights matched your filters."
@@ -3691,6 +3691,9 @@
   "ambassadors.directory.socialAria.youtube": {
     "message": "YouTube channel"
   },
+  "ambassadors.directory.socialAria.github": {
+    "message": "GitHub profile"
+  },
   "ambassadors.stories.divider": {
     "message": "Impact Stories"
   },
@@ -3740,7 +3743,7 @@
     "message": "Open-source contributions that make Cardano easier to use for developers everywhere."
   },
   "enterprise.label.solutions": {
-    "message": "Solutions"
+    "message": "Giải pháp"
   },
   "enterprise.label.products": {
     "message": "Products"
@@ -4028,7 +4031,7 @@
     "message": "An era of optimization, improving the scalability and interoperability of the network. Enhancing the network performance, Basho will introduce sidechains, new blockchains, interoperable with the main Cardano chain, with immense potential to extend the network's capabilities."
   },
   "research.voltaire.subtitle": {
-    "message": "Governance"
+    "message": "Quản trị"
   },
   "research.voltaire.description": {
     "message": "The development era is currently enabling the Cardano network to become a self-sustaining system. Voltaire is introducing a voting and treasury system that allows network participants to use their stake and voting rights to influence the future development of the blockchain."
@@ -4037,7 +4040,7 @@
     "message": "Learn more"
   },
   "solutions.section.title": {
-    "message": "Enterprise Solutions"
+    "message": "Giải pháp doanh nghiệp"
   },
   "termExplainer.divider": {
     "message": "{category} Terms you should know"
@@ -4406,7 +4409,7 @@
     "message": "Last updated: {lastUpdated}. Charts are using real time data."
   },
   "apps.card.getStarted": {
-    "message": "Get Started"
+    "message": "Hãy Bắt Đầu"
   },
   "apps.card.source": {
     "message": "Source"


### PR DESCRIPTION
- Restore the Japanese, German, Spanish and Vietnamese translations across all pages and use-case docs, which had fallen back to English while only the navigation stayed translated
- Content now shows in the selected language again (Japanese 82%, German 61%, Spanish 53%, Vietnamese 13% of strings translated)