### PR TITLE
fix: use "More {label} apps" for apps category rest headings

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -3208,8 +3208,8 @@
   "apps.allApps.titleScoped": {
     "message": "All {label}"
   },
-  "apps.allApps.titleOther": {
-    "message": "Other {label}"
+  "apps.allApps.titleMore": {
+    "message": "More {label} apps"
   },
   "apps.mostActive.titleScoped": {
     "message": "Most active {label}"

--- a/src/pages/apps/index.js
+++ b/src/pages/apps/index.js
@@ -671,14 +671,15 @@ function ShowcaseSections() {
   const scopeLabel = !isUnfiltered && selectedTags.length === 1
     ? Categories[selectedTags[0]]?.label
     : null;
+  // Heading for the apps below the "Most active {label}" leaderboard.
   const restHeadingId = scopeLabel
     ? mostActiveApps.length > 0
-      ? "apps.allApps.titleOther"
+      ? "apps.allApps.titleMore"
       : "apps.allApps.titleScoped"
     : "apps.allApps.title";
   const restHeadingMessage = scopeLabel
     ? mostActiveApps.length > 0
-      ? "Other {label}"
+      ? "More {label} apps"
       : "All {label}"
     : "All apps";
   const restHeading = scopeLabel


### PR DESCRIPTION
## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/cardano-foundation/cardano-org/blob/staging/CONTRIBUTING.md).
- [x] I have run `yarn build` after adding my changes **without getting any errors**.
- [x] I have not committed any changes to `yarn.lock`.

## Updating documentation or Bugfix

Category pages show a "Most active {label}" leaderboard, then the remaining apps below it. That second heading was "Other {label}", which read as "Other Other" when the category itself was "Other".

Changed it to "More {label} apps" for every category (e.g. "More DEX apps", "More Other apps") instead of special-casing one. Consistent wording across all categories, and the "Other Other" stutter is gone.

Before/After on the Other category:

| Before | After |
|--------|-------|
| <img width="1385" height="361" alt="SCR-20260629-myrp" src="https://github.com/user-attachments/assets/29b39c95-49af-49cc-9322-a654e97f41b2" /> | <img width="1339" height="368" alt="SCR-20260629-myqq" src="https://github.com/user-attachments/assets/fd881742-e1dd-471d-8de4-4c1eead40307" /> |
