### PR TITLE
docs: link tx leaderboard script and document registries

### DIFF
--- a/docs/get-involved/tx-rankings.md
+++ b/docs/get-involved/tx-rankings.md
@@ -13,13 +13,23 @@ Some applications and on-chain standards listed on cardano.org are ranked accord
 
 To determine transaction activity, we aggregate and correlate multiple on-chain and off-chain data sources, including:
 - Transaction labels, used to associate transactions with known applications or use cases.
+- The [CIP-0010 registry](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0010/registry.json), used to verify which transaction metadata labels are registered standards.
 - Script hashes, mapped to applications using curated registries:
-- The CRFA off-chain data registry
-https://github.com/mezuny/crfa-offchain-data-registry
-- The Cardano contracts registry maintained by StricaHQ
-https://github.com/StricaHQ/cardano-contracts-registry
+  - The [CRFA off-chain data registry](https://github.com/mezuny/crfa-offchain-data-registry)
+  - The [Cardano contracts registry](https://github.com/StricaHQ/cardano-contracts-registry) maintained by StricaHQ
+  - The [Eternl script registry](https://github.com/Tastenkunst/eternl-cardano-registry)
 
 By combining these sources, we can more reliably attribute transactions to specific applications and calculate relative activity levels.
+
+### The ranking script
+
+The rankings are produced by an open-source script: [cardano-foundation/tx-leaderboard-script](https://github.com/cardano-foundation/tx-leaderboard-script).
+
+It connects to a Cardano [db-sync](https://github.com/IntersectMBO/cardano-db-sync) database, reads the latest fully completed epochs, and combines the on-chain data with the registries listed above. Each run emits two reports:
+- A 30-day window (6 epochs)
+- A 1-year window (73 epochs)
+
+These reports are committed to this repository as `src/data/tx-stats.json` and `src/data/tx-stats-73epochs.json`, which power the leaderboard's 30-day and 1-year toggle.
 
 ### Important notes
 - Rankings reflect usage activity, not endorsement, code quality, security, or governance maturity.
@@ -52,7 +62,7 @@ There are two paths to appear on the leaderboard, depending on how your project 
 
 ### Path 1: App Tracking (Smart Contracts / Script Hashes)
 
-If your project deploys smart contracts on Cardano, your transactions are attributed via script hashes mapped through curated registries ([CRFA](https://github.com/mezuny/crfa-offchain-data-registry), [StricaHQ](https://github.com/StricaHQ/cardano-contracts-registry)).
+If your project deploys smart contracts on Cardano, your transactions are attributed via script hashes mapped through curated registries ([CRFA](https://github.com/mezuny/crfa-offchain-data-registry), [StricaHQ](https://github.com/StricaHQ/cardano-contracts-registry), [Eternl](https://github.com/Tastenkunst/eternl-cardano-registry)).
 
 To appear on the leaderboard with your app's icon and details:
 
@@ -92,7 +102,7 @@ Key details:
 - Messages are stored permanently on-chain
 - See the official spec: [CIP-20 - Transaction message/comment metadata](https://cips.cardano.org/cip/CIP-20)
 
-**Other verified metadata standards** that are automatically tracked include:
+A metadata label counts as verified when it is registered in the [CIP-0010 registry](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0010/registry.json). **Other verified metadata standards** that are automatically tracked include:
 
 | Label | Standard | Category |
 |-------|----------|----------|
@@ -110,13 +120,13 @@ Key details:
 
 The data flow from blockchain to leaderboard:
 
-1. **On-chain transactions** are processed by the stats pipeline
-2. The pipeline produces `tx-stats.json` containing two arrays:
+1. **On-chain transactions** are processed by the [tx-leaderboard-script](https://github.com/cardano-foundation/tx-leaderboard-script) pipeline
+2. The pipeline produces `tx-stats.json` (30-day) and `tx-stats-73epochs.json` (1-year), each containing two arrays:
    - `appStats`: transactions attributed to applications via script hashes
    - `metadataLabelStats`: transactions using registered metadata labels
 3. The **leaderboard page** merges both arrays (verified metadata only) and ranks everything by transaction count
 4. `appStats` entries are matched to `src/data/apps.js` via the `statsLabel` field to display icons, descriptions, and website links
-5. `metadataLabelStats` entries are shown with their CIP description and mapped to existing categories (Governance, Bridge, Minting, etc.)
+5. `metadataLabelStats` entries are verified against the CIP-0010 registry, shown with their CIP description, and mapped to existing categories (Governance, Bridge, Minting, etc.)
 
 Both types of entries are ranked together in a single unified leaderboard, giving a complete picture of what is driving on-chain activity on Cardano.
 


### PR DESCRIPTION
- Link the open-source ranking script (cardano-foundation/tx-leaderboard-script) from the transaction rankings docs and explain the reporting windows
- Add the Eternl script registry alongside CRFA and StricaHQ as a script-hash source
- Document the CIP-0010 registry as the source that verifies tracked metadata labels