### PR TITLE
Fix broken app directory links

### DIFF
--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -1089,7 +1089,25 @@ export const Showcases = [
     maintainerPick: false,
     beginnerFriendly: false,
   },
-
+  {
+    title: "Medusa Wallet",
+    description:
+        "A lightweight Cardano wallet focused on privacy and user protection, enabling easy and secure access to funds even in untrusted or compromised environments. ",
+    tagline: "Privacy-focused lightweight Cardano wallet",
+    icon: "/img/app-icons/medusa.jpg",
+    website: "https://adawallet.io",
+    source: null,
+    category: "wallet",
+    properties: [],
+    maintainerPick: false,
+    beginnerFriendly: false,
+    walletFeatures: {
+      platforms: ["web"],
+      custody: "non-custodial",
+      features: ["staking"],
+      type: "light",
+    },
+   },
   {
     title: "Dano Finance",
     description:

--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -909,7 +909,7 @@ export const Showcases = [
       "Standardized NFT that maps a Cardano wallet address to a human-readable handle. Used by wallets and dApps as the network's de facto naming layer.",
     tagline: "Human-readable Cardano addresses as NFTs",
     icon: "/img/app-icons/adahandle.jpg",
-    website: "https://adahandle.com",
+    website: "https://handle.me/",
     source: null,
     category: "identity",
     properties: ["nft"],
@@ -1089,25 +1089,7 @@ export const Showcases = [
     maintainerPick: false,
     beginnerFriendly: false,
   },
-  {
-    title: "Medusa Wallet",
-    description:
-        "A lightweight Cardano wallet focused on privacy and user protection, enabling easy and secure access to funds even in untrusted or compromised environments. ",
-    tagline: "Privacy-focused lightweight Cardano wallet",
-    icon: "/img/app-icons/medusa.jpg",
-    website: "https://adawallet.io",
-    source: null,
-    category: "wallet",
-    properties: [],
-    maintainerPick: false,
-    beginnerFriendly: false,
-    walletFeatures: {
-      platforms: ["web"],
-      custody: "non-custodial",
-      features: ["staking"],
-      type: "light",
-    },
-   },
+
   {
     title: "Dano Finance",
     description:


### PR DESCRIPTION
Fixes #463

## Summary

This PR updates the apps directory to address broken website links listed in #463.

Changes:
- Updated `adahandle` from `https://adahandle.com` to `https://handle.me/`, since the old URL redirects there and the final URL resolves successfully.
- Removed `Medusa Wallet`, since its listed website `https://adawallet.io` currently returns HTTP 500 and I could not verify a working replacement website.

## Verification

Checked the current `staging` app entries:

- `adahandle`: `https://adahandle.com` redirects to `https://handle.me/` and returns 200
- `Book.io`: returns 200, unchanged
- `Ale & Axes`: returns 200, unchanged
- `Cardano Academy`: opens successfully in browser, unchanged
- `cardano-tools.io`: returns 200, unchanged
- `Medusa Wallet`: returns 500, removed

Some apps listed in the original issue were not present in the current `staging` version of `src/data/apps.js`.

## Type of change

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature