### PR TITLE
fix: harden output escaping, supply insights, and accessibility

### DIFF
--- a/src/components/AppDetail/index.js
+++ b/src/components/AppDetail/index.js
@@ -15,6 +15,7 @@ import {
 } from "@site/src/utils/appStats";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
 import AppTile from "@site/src/components/AppTile";
+import { jsonLdString } from "@site/src/utils/jsonLd";
 
 import styles from "./styles.module.css";
 
@@ -22,7 +23,7 @@ const APPS_JS_GITHUB_URL =
   "https://github.com/cardano-foundation/cardano-org/blob/staging/src/data/apps.js";
 
 function buildJsonLd(app) {
-  return JSON.stringify({
+  return jsonLdString({
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     name: app.title,

--- a/src/components/DRepDelegate/index.js
+++ b/src/components/DRepDelegate/index.js
@@ -292,7 +292,7 @@ function WalletStatus({ wallet, delegation, onDisconnect }) {
 
 function NetworkWarning() {
   return (
-    <div className={`${styles.banner} ${styles.bannerWarning}`}>
+    <div className={`${styles.banner} ${styles.bannerWarning}`} role="alert">
       {translate({
         id: "governance.delegate.networkWarning",
         message: "Your wallet is on the wrong network. Switch to Mainnet to delegate.",
@@ -304,7 +304,7 @@ function NetworkWarning() {
 function TxBanner({ state }) {
   if (state.status === "building") {
     return (
-      <div className={`${styles.banner} ${styles.bannerInfo}`}>
+      <div className={`${styles.banner} ${styles.bannerInfo}`} role="status">
         {translate(
           { id: "governance.delegate.tx.building", message: "Preparing delegation to {target}. Please confirm in your wallet…" },
           { target: state.target }
@@ -314,7 +314,7 @@ function TxBanner({ state }) {
   }
   if (state.status === "success") {
     return (
-      <div className={`${styles.banner} ${styles.bannerSuccess}`}>
+      <div className={`${styles.banner} ${styles.bannerSuccess}`} role="status">
         <p style={{ margin: 0 }}>
           {translate(
             { id: "governance.delegate.tx.success", message: "Delegation submitted to {target}." },
@@ -329,7 +329,7 @@ function TxBanner({ state }) {
   }
   if (state.status === "error") {
     return (
-      <div className={`${styles.banner} ${styles.bannerError}`}>
+      <div className={`${styles.banner} ${styles.bannerError}`} role="alert">
         {state.message}
       </div>
     );

--- a/src/components/FAQSection/index.js
+++ b/src/components/FAQSection/index.js
@@ -36,6 +36,7 @@ export default function FAQSection({ jsonFileName = "delegationFAQ", data }) {
         >
           <Collapsible
             trigger={faq.question}
+            tabIndex={0}
             onOpening={() => setActiveIndex(index)}
             onClosing={() => setActiveIndex((current) => (current === index ? null : current))}
           >

--- a/src/components/GlossaryTerm/index.js
+++ b/src/components/GlossaryTerm/index.js
@@ -17,15 +17,9 @@ import {
 } from '@site/src/data/glossaryCategories';
 import OpenGraphInfo from '@site/src/components/Layout/OpenGraphInfo';
 import SiteHero from '@site/src/components/Layout/SiteHero';
+import { jsonLdString } from '@site/src/utils/jsonLd';
 
 import styles from './styles.module.css';
-
-// Escapes any literal `</` in JSON before it is embedded inside a <script>
-// tag so a future term containing the substring cannot terminate the script
-// element early (also covers the XSS shape if data ever becomes user-supplied).
-function jsonLdString(data) {
-  return JSON.stringify(data).replace(/</g, '\\u003c');
-}
 
 function buildJsonLd(term, siteUrl, termUrl, glossaryUrl) {
   const definedTerm = {

--- a/src/components/HomeBenefitsSection/index.js
+++ b/src/components/HomeBenefitsSection/index.js
@@ -15,8 +15,9 @@ import {translate} from '@docusaurus/Translate';
 // The benefit copy is translator-supplied (Crowdin) and uses "<br />" for its
 // paragraph breaks. Render it as escaped text with real <br /> elements rather
 // than dangerouslySetInnerHTML, so a malicious translation cannot inject markup.
+const BR_TAG = /<br\s*\/?>/i;
 function renderWithLineBreaks(text) {
-  const segments = String(text ?? "").split(/<br\s*\/?>/i);
+  const segments = String(text ?? "").split(BR_TAG);
   return segments.map((segment, index) => (
     <React.Fragment key={index}>
       {index > 0 && <br />}

--- a/src/components/HomeBenefitsSection/index.js
+++ b/src/components/HomeBenefitsSection/index.js
@@ -12,6 +12,19 @@ import {translate} from '@docusaurus/Translate';
 // This component:
 // Shows a tab list on the left with some swapable content on the right.
 
+// The benefit copy is translator-supplied (Crowdin) and uses "<br />" for its
+// paragraph breaks. Render it as escaped text with real <br /> elements rather
+// than dangerouslySetInnerHTML, so a malicious translation cannot inject markup.
+function renderWithLineBreaks(text) {
+  const segments = String(text ?? "").split(/<br\s*\/?>/i);
+  return segments.map((segment, index) => (
+    <React.Fragment key={index}>
+      {index > 0 && <br />}
+      {segment}
+    </React.Fragment>
+  ));
+}
+
 function getBenefitsData() {
   return [
     {
@@ -106,11 +119,7 @@ export default function HomeBenefitsSection() {
                 }`}
               >
                 <h2>{benefit.benefits_item_title}</h2>
-                <p
-                  dangerouslySetInnerHTML={{
-                    __html: benefit.benefits_item_body,
-                  }}
-                />
+                <p>{renderWithLineBreaks(benefit.benefits_item_body)}</p>
                 <p className={styles.buttonWrap}>
                   <Link
                     className="button button--primary button--lg"

--- a/src/components/QuizModal/index.js
+++ b/src/components/QuizModal/index.js
@@ -19,9 +19,9 @@ const QuizModal = ({ quizData, buttonText = "Test Your Knowledge", questionCount
       </button>
 
       {isOpen && (
-        // Backdrop click-outside-to-close. Keyboard equivalent is the
-        // document-level Escape handler above plus the dedicated close
-        // button, both of which are accessible to keyboard users.
+        // Backdrop click-outside-to-close. Keyboard equivalents (Escape to
+        // close, focus trap and restore) live in useModalA11y, alongside the
+        // dedicated close button.
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
           className={styles.modalOverlay}

--- a/src/components/QuizModal/index.js
+++ b/src/components/QuizModal/index.js
@@ -1,35 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Quiz from '../Quiz';
+import useModalA11y from '@site/src/utils/useModalA11y';
 import styles from './styles.module.css';
 
 const QuizModal = ({ quizData, buttonText = "Test Your Knowledge", questionCount = 5, allowRetry = true, passingScore = 60 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  // Prevent body scroll when modal is open
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isOpen]);
-
-  // Close on Escape key
-  useEffect(() => {
-    const handleEscape = (e) => {
-      if (e.key === 'Escape' && isOpen) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen]);
-
   const handleOpen = () => setIsOpen(true);
   const handleClose = () => setIsOpen(false);
+
+  // Locks scroll, moves + traps + restores focus, and closes on Escape.
+  const dialogRef = useModalA11y(isOpen, handleClose);
 
   return (
     <>
@@ -51,6 +32,8 @@ const QuizModal = ({ quizData, buttonText = "Test Your Knowledge", questionCount
             role="dialog"
             aria-modal="true"
             aria-label="Quiz"
+            ref={dialogRef}
+            tabIndex={-1}
           >
             <button
               onClick={handleClose}

--- a/src/components/SurveyModal/index.js
+++ b/src/components/SurveyModal/index.js
@@ -1,30 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Survey from '../Survey';
+import useModalA11y from '@site/src/utils/useModalA11y';
 import styles from './styles.module.css';
 
 const SurveyModal = ({ surveyData, buttonText = "Start", questionCount, buttonClassName }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isOpen]);
+  const handleClose = () => setIsOpen(false);
 
-  useEffect(() => {
-    const handleEscape = (e) => {
-      if (e.key === 'Escape' && isOpen) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen]);
+  // Locks scroll, moves + traps + restores focus, and closes on Escape.
+  const dialogRef = useModalA11y(isOpen, handleClose);
 
   return (
     <>
@@ -42,16 +27,18 @@ const SurveyModal = ({ surveyData, buttonText = "Start", questionCount, buttonCl
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
           className={styles.modalOverlay}
-          onClick={(e) => { if (e.target === e.currentTarget) setIsOpen(false); }}
+          onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
         >
           <div
             className={styles.modalContent}
             role="dialog"
             aria-modal="true"
             aria-label="Survey"
+            ref={dialogRef}
+            tabIndex={-1}
           >
             <button
-              onClick={() => setIsOpen(false)}
+              onClick={handleClose}
               className={styles.closeButton}
               aria-label="Close survey"
             >

--- a/src/components/SurveyModal/index.js
+++ b/src/components/SurveyModal/index.js
@@ -21,9 +21,9 @@ const SurveyModal = ({ surveyData, buttonText = "Start", questionCount, buttonCl
       </button>
 
       {isOpen && (
-        // Backdrop click-outside-to-close. Keyboard equivalent is the
-        // document-level Escape handler above plus the dedicated close
-        // button, both of which are accessible to keyboard users.
+        // Backdrop click-outside-to-close. Keyboard equivalents (Escape to
+        // close, focus trap and restore) live in useModalA11y, alongside the
+        // dedicated close button.
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
           className={styles.modalOverlay}

--- a/src/components/TreasuryDonate/index.js
+++ b/src/components/TreasuryDonate/index.js
@@ -167,7 +167,7 @@ function WalletStatus({ wallet, onDisconnect }) {
 
 function NetworkWarning() {
   return (
-    <div className={`${styles.banner} ${styles.bannerWarning}`}>
+    <div className={`${styles.banner} ${styles.bannerWarning}`} role="alert">
       {translate({
         id: "governance.treasury.networkWarning",
         message: "Your wallet is on the wrong network. Switch to Mainnet to donate.",
@@ -179,7 +179,7 @@ function NetworkWarning() {
 function TxBanner({ state }) {
   if (state.status === "building") {
     return (
-      <div className={`${styles.banner} ${styles.bannerInfo}`}>
+      <div className={`${styles.banner} ${styles.bannerInfo}`} role="status">
         {translate({
           id: "governance.treasury.tx.building",
           message: "Building the treasury donation. Please confirm in your wallet…",
@@ -189,7 +189,7 @@ function TxBanner({ state }) {
   }
   if (state.status === "success") {
     return (
-      <div className={`${styles.banner} ${styles.bannerSuccess}`}>
+      <div className={`${styles.banner} ${styles.bannerSuccess}`} role="status">
         <p style={{ margin: 0 }}>
           {translate(
             { id: "governance.treasury.tx.success", message: "Donation of {amount} submitted to the treasury." },
@@ -204,7 +204,7 @@ function TxBanner({ state }) {
   }
   if (state.status === "error") {
     return (
-      <div className={`${styles.banner} ${styles.bannerError}`}>
+      <div className={`${styles.banner} ${styles.bannerError}`} role="alert">
         {state.message}
       </div>
     );
@@ -385,6 +385,9 @@ export default function TreasuryDonate() {
             className="button button--primary"
             disabled={!canDonate}
             onClick={handleDonate}
+            aria-describedby={
+              !canDonate && !txBusy && disabledReason ? "treasury-donate-hint" : undefined
+            }
           >
             {txBusy
               ? translate({ id: "governance.treasury.amount.ctaBusy", message: "Building…" })
@@ -392,7 +395,7 @@ export default function TreasuryDonate() {
           </button>
         </div>
         {!canDonate && !txBusy && disabledReason && (
-          <p className={styles.donateHint}>{disabledReason}</p>
+          <p className={styles.donateHint} id="treasury-donate-hint">{disabledReason}</p>
         )}
         <p className={styles.footnote}>
           {translate({

--- a/src/components/WalletFinderFilters/index.js
+++ b/src/components/WalletFinderFilters/index.js
@@ -16,6 +16,7 @@ function FilterPill({ label, active, onClick }) {
       className={`${styles.pill} ${active ? styles.pillActive : ""}`}
       onClick={onClick}
       type="button"
+      aria-pressed={active}
     >
       {label}
     </button>

--- a/src/pages/apps/index.js
+++ b/src/pages/apps/index.js
@@ -36,6 +36,7 @@ import {
   isTrackable,
   compareByTxDesc,
 } from "@site/src/utils/appStats";
+import { jsonLdString } from "@site/src/utils/jsonLd";
 
 import styles from "./styles.module.css";
 
@@ -158,7 +159,7 @@ const STATS_GENERATED_AT_LABEL = STATS_GENERATED_AT
 const LIVE_TRACKING_COUNT = countLiveTracking(Showcases);
 
 const ITEM_LIST_LIMIT = 30;
-const APPS_ITEM_LIST_JSON_LD = JSON.stringify({
+const APPS_ITEM_LIST_JSON_LD = jsonLdString({
   "@context": "https://schema.org",
   "@type": "ItemList",
   name: "Cardano apps and dApps",

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -17,18 +17,13 @@ import {
 } from '@site/src/data/glossaryCategories';
 import OpenGraphInfo from '@site/src/components/Layout/OpenGraphInfo';
 import SiteHero from '@site/src/components/Layout/SiteHero';
+import { jsonLdString } from '@site/src/utils/jsonLd';
 
 import styles from './glossary.module.css';
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 const POPULAR_PILL_SLUGS = ['eutxo', 'stake-pool', 'drep', 'governance-action', 'smart-contract', 'treasury'];
 const SEARCH_DROPDOWN_LIMIT = 6;
-
-// Escapes any literal `</` so a future term containing the substring cannot
-// terminate the embedded <script type="application/ld+json"> early.
-function jsonLdString(data) {
-  return JSON.stringify(data).replace(/</g, '\\u003c');
-}
 
 function buildJsonLd(terms, glossaryFullUrl) {
   return jsonLdString({

--- a/src/pages/insights/supply/index.js
+++ b/src/pages/insights/supply/index.js
@@ -172,7 +172,10 @@ function PageContent() {
   const isPrimed = Boolean(totalsCurr && totalsPrev && epochInfoPrev1);
 
   const lastScrollYRef = useRef(0);
-  
+  // Monotonic id so out-of-order fetches (rapid epoch nav, back/forward) can be
+  // discarded: only the most recent call is allowed to commit state.
+  const latestReqId = useRef(0);
+
   const fetchData = async () => {
     if (!API_URL) {
       setErrorInfo({ kind: 'config', title: translate({id: 'insightsSupply.error.configTitle', message: 'Missing configuration'}), message: translate({id: 'insightsSupply.error.configMessage', message: 'API URL is missing.'}) });
@@ -182,19 +185,34 @@ function PageContent() {
     setErrorInfo(null);
     const api = apiClient ?? makeApiClient(API_URL);
 	
+    const reqId = ++latestReqId.current;
     try {
       // parse & validate current URL epoch
       const tipRes = await api.get('/tip');
+      if (reqId !== latestReqId.current) return;
       const tipEpoch = tipRes.data?.[0]?.epoch_no;
       setCurrentEpochNo(tipEpoch);
       const urlEpochNow = new URLSearchParams(window.location.search).get('epoch');
       const parsed = parseInt(urlEpochNow, 10);
-      const validEpoch = urlEpochNow && !Number.isNaN(parsed) && parsed >= MIN_EPOCH ? parsed : null;
-      if (urlEpochNow && (Number.isNaN(parsed) || parsed < MIN_EPOCH)) {
-        setErrorInfo({ kind: 'input', title: translate({id: 'insightsSupply.error.invalidEpochTitle', message: 'Invalid epoch'}), message: translate({id: 'insightsSupply.error.invalidEpochMessage', message: 'Epoch must be ≥ {minEpoch}.'}, {minEpoch: MIN_EPOCH}) });
+      // Reject an epoch below MIN_EPOCH or above the chain tip. Without a tip we
+      // cannot bound the upper end, so skip that half of the check rather than
+      // reject everything.
+      const hasTip = Number.isFinite(tipEpoch);
+      const outOfRange =
+        urlEpochNow &&
+        (Number.isNaN(parsed) || parsed < MIN_EPOCH || (hasTip && parsed > tipEpoch));
+      if (outOfRange) {
+        setErrorInfo({
+          kind: 'input',
+          title: translate({id: 'insightsSupply.error.invalidEpochTitle', message: 'Invalid epoch'}),
+          message: hasTip
+            ? translate({id: 'insightsSupply.error.epochRangeMessage', message: 'Epoch must be between {minEpoch} and {maxEpoch}.'}, {minEpoch: MIN_EPOCH, maxEpoch: tipEpoch})
+            : translate({id: 'insightsSupply.error.invalidEpochMessage', message: 'Epoch must be ≥ {minEpoch}.'}, {minEpoch: MIN_EPOCH}),
+        });
         setIsLoading(false);
         return;
       }
+      const validEpoch = urlEpochNow && !Number.isNaN(parsed) ? parsed : null;
       const displayedEpoch = validEpoch ?? tipEpoch;
 
       // fetch epoch data in parallel (previous ones for delta calculations)
@@ -203,6 +221,19 @@ function PageContent() {
         api.get(`/totals?_epoch_no=${displayedEpoch - 1}`),
         api.get(`/epoch_info?_epoch_no=${displayedEpoch - 1}`),
       ]);
+      if (reqId !== latestReqId.current) return;
+      // An epoch at/after the chain tip (or otherwise without data) returns empty
+      // rows. Surface it as an input error rather than priming the page with
+      // undefined values (which render as NaN) or hanging on the loader forever.
+      if (!totalsCurrRes.data?.[0] || !totalsPrevRes.data?.[0] || !epochInfoPrev1Res.data?.[0]) {
+        setErrorInfo({
+          kind: 'input',
+          title: translate({id: 'insightsSupply.error.noEpochDataTitle', message: 'No data for this epoch'}),
+          message: translate({id: 'insightsSupply.error.noEpochDataMessage', message: 'No supply data is available for that epoch yet. Choose an epoch up to the current one.'}),
+        });
+        setIsLoading(false);
+        return;
+      }
       setTotalsCurr({ epoch_no: displayedEpoch, ...totalsCurrRes.data[0] });
       setTotalsPrev(totalsPrevRes.data[0]);
       setEpochInfoPrev1(epochInfoPrev1Res.data[0]);
@@ -260,13 +291,15 @@ function PageContent() {
         }
       }
       
+      if (reqId !== latestReqId.current) return;
       setWithdrawalsCurr(withdrawalsCurr);
       setWithdrawalsPrev(withdrawalsPrev);
 		
     } catch (err) {
+      if (reqId !== latestReqId.current) return;
       setErrorInfo(parseApiError(err));
     } finally {
-      setIsLoading(false);
+      if (reqId === latestReqId.current) setIsLoading(false);
     }
   }
 

--- a/src/pages/insights/supply/index.js
+++ b/src/pages/insights/supply/index.js
@@ -12,6 +12,7 @@ import {translate} from '@docusaurus/Translate';
 
 import { makeApiClient } from '@site/src/utils/insights/api';
 import { parseApiError } from '@site/src/utils/insights/errors';
+import { jsonLdString } from '@site/src/utils/jsonLd';
 import { convertLovelacesToAda, toAdaIfMoney, LOVELACE_KEY, sumWithdrawalAmounts } from '@site/src/utils/insights/numbers';
 import { MIN_EPOCH, GOVERNANCE_EPOCH_THRESHOLD, getEpochDate } from '@site/src/utils/insights/epochs';
 
@@ -212,7 +213,8 @@ function PageContent() {
         setIsLoading(false);
         return;
       }
-      const validEpoch = urlEpochNow && !Number.isNaN(parsed) ? parsed : null;
+      // parsed is a valid in-range number here (outOfRange returned otherwise).
+      const validEpoch = urlEpochNow ? parsed : null;
       const displayedEpoch = validEpoch ?? tipEpoch;
 
       // fetch epoch data in parallel (previous ones for delta calculations)
@@ -470,15 +472,13 @@ function PageContent() {
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:url" content={canonicalUrl} />
         <link rel="canonical" href={canonicalUrl} />
-        <script type="application/ld+json">{`
-        {
+        <script type="application/ld+json">{jsonLdString({
           "@context": "https://schema.org",
           "@type": "Article",
-          "headline": "${pageTitle}",
-          "description": "${pageDescription}",
-          "url": "${canonicalUrl}"
-        }
-        `}</script>
+          headline: pageTitle,
+          description: pageDescription,
+          url: canonicalUrl,
+        })}</script>
       </Head>
 
       <div className={navStickyClass}>

--- a/src/utils/jsonLd.js
+++ b/src/utils/jsonLd.js
@@ -1,0 +1,10 @@
+// Serialize a JSON-LD object for safe embedding inside a <script> element.
+//
+// react-helmet-async (used by Docusaurus <Head>) writes <script> children
+// verbatim, so a "</script>" sequence inside any string value would terminate
+// the script tag early and let following markup execute. Escaping "<" to its
+// JSON unicode form is enough to prevent that; the browser's JSON-LD parser
+// decodes < transparently, so the structured data is unchanged.
+export function jsonLdString(data) {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}

--- a/src/utils/useModalA11y.js
+++ b/src/utils/useModalA11y.js
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react";
+
+// Elements considered focusable for the modal focus trap.
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+// Accessible-dialog behavior shared by the Quiz and Survey modals:
+//  - locks background scroll while open
+//  - moves focus into the dialog on open
+//  - traps Tab / Shift+Tab within the dialog
+//  - closes on Escape
+//  - restores focus to the triggering element on close
+//
+// Attach the returned ref to the dialog container (give it tabIndex={-1} so it
+// can receive focus when it holds no focusable children).
+export default function useModalA11y(isOpen, onClose) {
+  const dialogRef = useRef(null);
+  const triggerRef = useRef(null);
+  // Keep the latest onClose without making it an effect dependency, so the main
+  // effect runs once per open/close rather than on every parent render (which
+  // would steal and mis-restore focus).
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    // Remember what had focus so we can restore it when the dialog closes.
+    triggerRef.current =
+      typeof document !== "undefined" ? document.activeElement : null;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const dialog = dialogRef.current;
+    // Move focus into the dialog (first focusable, else the container itself).
+    const initial = dialog?.querySelector(FOCUSABLE_SELECTOR) || dialog;
+    initial?.focus();
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onCloseRef.current?.();
+        return;
+      }
+      if (event.key !== "Tab" || !dialog) return;
+
+      const focusable = dialog.querySelectorAll(FOCUSABLE_SELECTOR);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey && (active === first || !dialog.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      const trigger = triggerRef.current;
+      if (trigger && typeof trigger.focus === "function") trigger.focus();
+    };
+  }, [isOpen]);
+
+  return dialogRef;
+}


### PR DESCRIPTION
- Escape embedded JSON-LD so app and glossary content can't alter the surrounding markup
- Render homepage benefit copy as text rather than raw HTML
- Keep the supply insights page in sync when navigating epochs quickly, and show a clear error for out-of-range or dataless epochs instead of blank or NaN values
- Make FAQ questions operable by keyboard
- Trap and restore focus in the quiz and survey dialogs
- Announce wallet delegation and donation status to screen readers
- Mark the active wallet-finder filters for assistive technology