### PR TITLE
fix: harden security headers, external links, and accessibility

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,16 +6,19 @@
   [headers.values]
     # Prevents the site from being framed by other sites, protecting against clickjacking.
     X-Frame-Options = "DENY"
-    # Activates the browser's built-in cross-site scripting (XSS) filter and blocks responses if an attack is detected.
-    X-XSS-Protection = "1; mode=block"
+    # Stops browsers from MIME-sniffing a response away from its declared Content-Type.
+    X-Content-Type-Options = "nosniff"
+    # Disabled: the legacy XSS auditor is deprecated and can introduce vulnerabilities;
+    # the Content-Security-Policy below is the real protection.
+    X-XSS-Protection = "0"
     # Ensures that only trusted content is executed and styled. TODO: Consider using nonces or hashes for inline scripts instead of unsafe-inline.
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cardano.org https://hey.cardano.org https://new-cardano-org-staging.netlify.app https://www.googletagmanager.com https://js.hsforms.net https://forms.hsforms.com https://www.google.com https://www.gstatic.com; img-src 'self' https://cardano.org https://new-cardano-org-staging.netlify.app https://forms.hsforms.com https://forms-eu1.hsforms.com data: https://*.ytimg.com https://img.youtube.com https://ipfs.io https://crowdin-static.cf-downloads.crowdin.com https://*.lumacdn.com; style-src 'self' 'unsafe-inline' https://hey.cardano.org; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://www.google.com https://*.hsforms.com https://new-cardano-org-staging.netlify.app/reward-calculator/ https://cardano.org/reward-calculator/ https://hey.cardano.org; media-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://hubspot-forms-static-embed.s3.amazonaws.com https://*.hsforms.com https://*.google-analytics.com https://data.cardano.org https://ipfs.io https://*.algolianet.com https://*.algolia.net;"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cardano.org https://hey.cardano.org https://new-cardano-org-staging.netlify.app https://www.googletagmanager.com https://js.hsforms.net https://forms.hsforms.com https://www.google.com https://www.gstatic.com; img-src 'self' https://cardano.org https://new-cardano-org-staging.netlify.app https://forms.hsforms.com https://forms-eu1.hsforms.com data: https://*.ytimg.com https://img.youtube.com https://ipfs.io https://crowdin-static.cf-downloads.crowdin.com https://*.lumacdn.com; style-src 'self' 'unsafe-inline' https://hey.cardano.org; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://www.google.com https://*.hsforms.com https://new-cardano-org-staging.netlify.app/reward-calculator/ https://cardano.org/reward-calculator/ https://hey.cardano.org; media-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://hubspot-forms-static-embed.s3.amazonaws.com https://*.hsforms.com https://*.google-analytics.com https://data.cardano.org https://ipfs.io https://*.algolianet.com https://*.algolia.net; base-uri 'self'; object-src 'none';"
     # Enforces secure connections via HTTPS, protecting against certain types of man-in-the-middle attacks.
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
     # Controls information provided as the HTTP Referer header when navigating from your site, enhancing privacy and security.
-    Referrer-Policy = "no-referrer-when-downgrade"
-    # Allows you to explicitly enable or disable various browser features and APIs for your site, enhancing security.
-    Feature-Policy = "geolocation 'none'; microphone 'none';"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    # Disables browser features the site does not use (Permissions-Policy supersedes the deprecated Feature-Policy).
+    Permissions-Policy = "geolocation=(), microphone=(), camera=()"
 
 # Specific header configuration for iframe exceptions
 [[headers]]

--- a/src/components/AppDetail/index.js
+++ b/src/components/AppDetail/index.js
@@ -16,6 +16,7 @@ import {
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
 import AppTile from "@site/src/components/AppTile";
 import { jsonLdString } from "@site/src/utils/jsonLd";
+import { safeUrl } from "@site/src/utils/safeUrl";
 
 import styles from "./styles.module.css";
 
@@ -391,7 +392,7 @@ export default function AppDetail({ app }) {
 
         {app.spotlight && (
           <Link
-            href={app.spotlight.url}
+            href={safeUrl(app.spotlight.url)}
             className={styles.spotlight}
             aria-label={translate({
               id: "apps.detail.spotlight.aria",
@@ -419,7 +420,7 @@ export default function AppDetail({ app }) {
         )}
 
         <div className={styles.actions}>
-          <Link href={app.website} className={styles.visitButton}>
+          <Link href={safeUrl(app.website)} className={styles.visitButton}>
             {translate(
               { id: "apps.detail.visit", message: "Visit {title}" },
               { title: app.title }
@@ -457,7 +458,7 @@ export default function AppDetail({ app }) {
           )}
           {app.source && (
             <Link
-              href={app.source}
+              href={safeUrl(app.source)}
               className={styles.iconButton}
               aria-label={translate({
                 id: "apps.detail.viewSource",

--- a/src/components/AppGrid/index.js
+++ b/src/components/AppGrid/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Showcases } from "@site/src/data/apps";
 import { getAppStats, formatTxCount as formatNumber } from "@site/src/utils/appStats";
+import { safeUrl } from "@site/src/utils/safeUrl";
 import styles from "./styles.module.css";
 
 function AppCard({ app, stats, appRank, ctaText }) {
@@ -71,7 +72,7 @@ function AppCard({ app, stats, appRank, ctaText }) {
       )}
 
       <a
-        href={app.website}
+        href={safeUrl(app.website)}
         target="_blank"
         rel="noopener noreferrer"
         className={styles.appLink}

--- a/src/components/AppList/index.js
+++ b/src/components/AppList/index.js
@@ -3,6 +3,7 @@ import Link from "@docusaurus/Link";
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { Showcases, Tags } from "@site/src/data/apps";
 import { getAppStats, formatTxCountCompact as formatTxCount, getAppAxes } from "@site/src/utils/appStats";
+import { safeUrl } from "@site/src/utils/safeUrl";
 import styles from "./styles.module.css";
 
 function AppListItem({ app, stats, showTxCount, showTags, showDescription = true }) {
@@ -31,7 +32,7 @@ function AppListItem({ app, stats, showTxCount, showTags, showDescription = true
 
   return (
     <a 
-      href={app.website} 
+      href={safeUrl(app.website)}
       target="_blank" 
       rel="noopener noreferrer"
       className={styles.appListItem}

--- a/src/components/CompaniesShowcase/index.js
+++ b/src/components/CompaniesShowcase/index.js
@@ -5,6 +5,7 @@ import ThemedImage from "@theme/ThemedImage";
 import Link from "@docusaurus/Link";
 import {translate} from '@docusaurus/Translate';
 import companies from "@site/src/data/logosCompanies.json";
+import { safeUrl } from "@site/src/utils/safeUrl";
 import styles from "./styles.module.css";
 
 function getCompanyId(company) {
@@ -46,7 +47,7 @@ function SpotlightPanel({ company, onClose }) {
           Known for: {company.knownFor}
         </p>
       )}
-      <Link className={styles.spotlightLink} href={company.link}>
+      <Link className={styles.spotlightLink} href={safeUrl(company.link)}>
         Visit website
       </Link>
     </div>

--- a/src/components/ExchangePicker/index.js
+++ b/src/components/ExchangePicker/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import data from "@site/src/data/exchanges.json";
+import { safeUrl } from "@site/src/utils/safeUrl";
 import styles from "./styles.module.css";
 
 const { regions, countries } = data;
@@ -104,7 +105,7 @@ function ExchangeCard({ exchange }) {
       </div>
 
       <a 
-        href={exchange.link} 
+        href={safeUrl(exchange.link)}
         target="_blank" 
         rel="noopener noreferrer"
         className={styles.exchangeLink}

--- a/src/components/GlossaryTerm/index.js
+++ b/src/components/GlossaryTerm/index.js
@@ -19,6 +19,7 @@ import OpenGraphInfo from '@site/src/components/Layout/OpenGraphInfo';
 import SiteHero from '@site/src/components/Layout/SiteHero';
 import { jsonLdString } from '@site/src/utils/jsonLd';
 
+import { safeUrl } from '@site/src/utils/safeUrl';
 import styles from './styles.module.css';
 
 function buildJsonLd(term, siteUrl, termUrl, glossaryUrl) {
@@ -339,7 +340,7 @@ export default function GlossaryTerm({ term }) {
                 <ul className={styles.sourcesList}>
                   {term.sources.map(source => (
                     <li key={source.url}>
-                      <a href={source.url} target="_blank" rel="noopener noreferrer">
+                      <a href={safeUrl(source.url)} target="_blank" rel="noopener noreferrer">
                         {source.title}
                       </a>
                     </li>
@@ -432,7 +433,7 @@ export default function GlossaryTerm({ term }) {
                     </span>
                   </a>
                 ) : (
-                  <Link className={styles.sideCtaBtn} to={term.link}>
+                  <Link className={styles.sideCtaBtn} to={safeUrl(term.link)}>
                     {translate({
                       id: 'glossary.term.openPage',
                       message: 'Open the page',

--- a/src/components/Layout/CtaOneColumn/styles.module.css
+++ b/src/components/Layout/CtaOneColumn/styles.module.css
@@ -26,7 +26,7 @@
 }
 
 .buttonWhite:hover,
-buttonWhite:focus {
+.buttonWhite:focus-visible {
   background-color: #cbcbc9;
   color: #1c1e21;
   border: none;

--- a/src/components/Layout/CtaTwoColumn/styles.module.css
+++ b/src/components/Layout/CtaTwoColumn/styles.module.css
@@ -32,7 +32,7 @@
 }
 
 .buttonWhite:hover,
-buttonWhite:focus {
+.buttonWhite:focus-visible {
   background-color: #cbcbc9;
   color: #1c1e21;
   border: none;

--- a/src/components/WalletFinderCard/index.js
+++ b/src/components/WalletFinderCard/index.js
@@ -7,6 +7,7 @@ import {
   WalletCustodyTypes,
   WalletNodeTypes,
 } from "@site/src/data/walletFeatures";
+import { safeUrl } from "@site/src/utils/safeUrl";
 import styles from "./styles.module.css";
 
 export default function WalletFinderCard({ wallet }) {
@@ -79,7 +80,7 @@ export default function WalletFinderCard({ wallet }) {
       </div>
 
       <a
-        href={wallet.website}
+        href={safeUrl(wallet.website)}
         target="_blank"
         rel="noopener noreferrer"
         className={styles.link}

--- a/src/components/WalletFinderFilters/index.js
+++ b/src/components/WalletFinderFilters/index.js
@@ -47,7 +47,7 @@ export default function WalletFinderFilters({
         <h2 className={styles.filterTitle}>
           {translate({id: 'walletFinder.filters.title', message: 'Filters'})}
           {hasFilters && (
-            <span className={styles.filterCount}>
+            <span className={styles.filterCount} aria-live="polite" aria-atomic="true">
               {" "}
               ({resultCount}{" "}
               {resultCount === 1

--- a/src/pages/apps/leaderboard.js
+++ b/src/pages/apps/leaderboard.js
@@ -20,6 +20,7 @@ import { Showcases, Tags, Categories } from "@site/src/data/apps";
 import appStats from "@site/src/data/tx-stats.json";
 import appStats73 from "@site/src/data/tx-stats-73epochs.json";
 
+import { safeUrl } from "@site/src/utils/safeUrl";
 import styles from "./leaderboard.module.css";
 
 const CIP20_LABEL = 674;
@@ -498,7 +499,7 @@ function AppRow({ app, rank, appDetails }) {
       </div>
       {appDetails?.website ? (
         <a
-          href={appDetails.website}
+          href={safeUrl(appDetails.website)}
           target="_blank"
           rel="noopener noreferrer"
           className={styles.visitLink}

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -131,6 +131,7 @@ export default function Home() {
             className={clsx("selectField", "selectFieldArrow")}
             onChange={handleTopicChange}
             value={selectedTopic ?? ""}
+            aria-label={translate({id: 'contact.select.label', message: 'What can we help you with?'})}
           >
             <option value="">{translate({id: 'contact.select.placeholder', message: 'not yet decided (please select)'})}</option>
             <option value="iog">

--- a/src/utils/safeUrl.js
+++ b/src/utils/safeUrl.js
@@ -1,0 +1,15 @@
+// Guards a URL that comes from community-submitted data (app/exchange/wallet
+// entries, glossary sources) before it is used as an href/to target.
+//
+// Returns the value only when it is a site-relative path ("/…" or "#…") or an
+// http(s) URL; anything else (javascript:, data:, vbscript:, a scheme hidden
+// behind embedded control characters, …) collapses to "#" so a malicious value
+// can never become an executable link. The allowlist is fail-closed: any value
+// that is not clearly relative or http(s) is rejected.
+export function safeUrl(url) {
+  if (typeof url !== "string") return "#";
+  const trimmed = url.trim();
+  if (trimmed.startsWith("/") || trimmed.startsWith("#")) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return "#";
+}

--- a/src/utils/safeUrl.js
+++ b/src/utils/safeUrl.js
@@ -9,6 +9,8 @@
 export function safeUrl(url) {
   if (typeof url !== "string") return "#";
   const trimmed = url.trim();
+  // Reject protocol-relative "//host" (resolves off-site); allow on-site "/path".
+  if (trimmed.startsWith("//")) return "#";
   if (trimmed.startsWith("/") || trimmed.startsWith("#")) return trimmed;
   if (/^https?:\/\//i.test(trimmed)) return trimmed;
   return "#";


### PR DESCRIPTION
- Add hardening HTTP security headers
- Only follow http(s) or on-site links from community-submitted app, exchange, wallet, company and glossary entries
- Restore the focus outline on the white call-to-action button
- Label the contact page's topic dropdown for screen readers
- Announce the wallet finder result count to screen readers when filters change