### PR TITLE
fix: accessibility fixes for menus, toggles, tooltips and cards

### DIFF
--- a/src/components/Ambassadors/AmbassadorCard/styles.module.css
+++ b/src/components/Ambassadors/AmbassadorCard/styles.module.css
@@ -115,6 +115,11 @@
   gap: 0.4rem;
 }
 
+.socialLink:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .socialLink,
 .socialLink:hover {
   width: 28px;

--- a/src/components/BridgeCard/styles.module.css
+++ b/src/components/BridgeCard/styles.module.css
@@ -13,6 +13,11 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.linkCard:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .linkCard:hover {
   transform: translateY(-2px);
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);

--- a/src/components/CompaniesShowcase/styles.module.css
+++ b/src/components/CompaniesShowcase/styles.module.css
@@ -6,6 +6,11 @@
   padding: 1.5rem 0;
 }
 
+.logoCell:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .logoCell {
   display: flex;
   flex-direction: column;
@@ -153,6 +158,11 @@
   transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   text-decoration: none;
   color: var(--ifm-color-emphasis-600);
+}
+
+.addCard:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
 }
 
 .addCard:hover {

--- a/src/components/Events/EventCard/styles.module.css
+++ b/src/components/Events/EventCard/styles.module.css
@@ -113,6 +113,11 @@
   text-decoration: none;
 }
 
+.cta:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .cta:hover {
   background: var(--ifm-color-primary);
   color: #fff;

--- a/src/components/Events/FeaturedEventCard/styles.module.css
+++ b/src/components/Events/FeaturedEventCard/styles.module.css
@@ -9,6 +9,11 @@
   transition: transform 0.08s ease, box-shadow 0.2s ease;
 }
 
+.cta:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .card:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);

--- a/src/components/Events/RecapCard/styles.module.css
+++ b/src/components/Events/RecapCard/styles.module.css
@@ -37,6 +37,12 @@
   transition: background 0.15s ease;
 }
 
+.media:focus-visible,
+.watch:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .media:hover .play {
   background: var(--ifm-color-primary);
 }

--- a/src/components/ExchangePicker/styles.module.css
+++ b/src/components/ExchangePicker/styles.module.css
@@ -164,6 +164,11 @@
   height: 14px;
 }
 
+.exchangeLink:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .exchangeLink {
   display: inline-block;
   margin-top: 0.5rem;
@@ -199,6 +204,11 @@
   transition: all 0.2s ease;
   text-decoration: none;
   cursor: pointer;
+}
+
+.addExchangeCard:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
 }
 
 .addExchangeCard:hover {

--- a/src/components/GovernanceCharts/index.js
+++ b/src/components/GovernanceCharts/index.js
@@ -351,6 +351,8 @@ export default function GovernanceCharts({
             className={styles.parametersButton}
             onClick={toggleParametersDropdown}
             ref={parametersButtonRef}
+            aria-haspopup="true"
+            aria-expanded={parametersDropdownOpen}
           >
             {translate({id: 'governanceCharts.parametersButton', message: 'Parameters ▼'})}
           </button>

--- a/src/components/GovernanceFAQ/index.js
+++ b/src/components/GovernanceFAQ/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useMemo } from "react";
+import React, { useState, useRef, useEffect, useMemo, useId } from "react";
 import clsx from "clsx";
 import {
   FaArrowRight,
@@ -51,15 +51,34 @@ function getCategoryMeta() {
 }
 
 function AccordionItem({ question, answer, isOpen, onToggle, itemRef }) {
+  const baseId = useId();
+  const triggerId = `${baseId}trigger`;
+  const panelId = `${baseId}panel`;
   return (
     <div ref={itemRef} className={clsx(styles.accordion, isOpen && styles.accordionOpen)}>
-      <button type="button" className={styles.accordionTrigger} onClick={onToggle}>
+      <button
+        type="button"
+        id={triggerId}
+        className={styles.accordionTrigger}
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+      >
         <span className={styles.accordionIcon} aria-hidden="true">
           {isOpen ? <FaMinus /> : <FaPlus />}
         </span>
         <span className={styles.accordionQuestion}>{question}</span>
       </button>
-      {isOpen && <div className={styles.accordionAnswer}>{renderAnswerArray(answer)}</div>}
+      {isOpen && (
+        <div
+          id={panelId}
+          role="region"
+          aria-labelledby={triggerId}
+          className={styles.accordionAnswer}
+        >
+          {renderAnswerArray(answer)}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/LatestNewsSection/styles.module.css
+++ b/src/components/LatestNewsSection/styles.module.css
@@ -9,6 +9,11 @@
   margin-bottom: 2.5rem;
 }
 
+.newsCard:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .newsCard {
   display: flex;
   flex-direction: column;

--- a/src/components/Layer2Card/styles.module.css
+++ b/src/components/Layer2Card/styles.module.css
@@ -16,6 +16,11 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
+.linkCard:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .linkCard:hover {
   transform: translateY(-4px);
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);

--- a/src/components/Layout/RoleCard/styles.module.css
+++ b/src/components/Layout/RoleCard/styles.module.css
@@ -15,6 +15,11 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
+a.card:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 a.card:hover {
   transform: translateY(-2px);
   box-shadow: 0 12px 28px rgba(0, 51, 173, 0.12);

--- a/src/components/Quiz/index.js
+++ b/src/components/Quiz/index.js
@@ -145,7 +145,7 @@ const Quiz = ({ quizData, questionCount = 5, allowRetry = true, passingScore = 6
       <div className={`${styles.questionCard} ${isCorrect ? styles.correct : ''} ${isIncorrect ? styles.incorrect : ''}`}>
         {/* Status Message */}
         {isAnswered && (
-          <div className={styles.statusMessage}>
+          <div className={styles.statusMessage} role="status">
             <div className={styles.statusIcon}>
               {isCorrect ? (
                 <svg viewBox="0 0 24 24" fill="currentColor">
@@ -202,6 +202,7 @@ const Quiz = ({ quizData, questionCount = 5, allowRetry = true, passingScore = 6
                 key={index}
                 onClick={() => handleAnswerSelect(index)}
                 disabled={isAnswered}
+                aria-pressed={isSelected}
                 className={`${styles.optionButton} ${
                   isSelected && !isAnswered ? styles.selected : ''
                 } ${showAsCorrect ? styles.correctOption : ''} ${

--- a/src/components/SolutionCard/styles.module.css
+++ b/src/components/SolutionCard/styles.module.css
@@ -10,6 +10,11 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
+.solutionCard:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .solutionCard:hover {
   transform: translateY(-4px);
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);

--- a/src/components/SolutionsSection/styles.module.css
+++ b/src/components/SolutionsSection/styles.module.css
@@ -40,6 +40,11 @@
   transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
+.ctaLink:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .ctaLink:hover {
   background: var(--ifm-color-primary-dark);
   color: white;

--- a/src/components/StablecoinCard/styles.module.css
+++ b/src/components/StablecoinCard/styles.module.css
@@ -120,6 +120,11 @@
   margin: 0;
 }
 
+.learnMore:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .learnMore {
   margin-top: auto;
   align-self: flex-end;

--- a/src/components/Survey/index.js
+++ b/src/components/Survey/index.js
@@ -100,6 +100,7 @@ const Survey = ({ surveyData, questionCount }) => {
             <button
               key={index}
               onClick={() => handleSelect(index)}
+              aria-pressed={selectedAnswer === index}
               className={`${styles.optionButton} ${selectedAnswer === index ? styles.selected : ''}`}
             >
               <span className={styles.optionLabel}>

--- a/src/components/UseCaseCard/styles.module.css
+++ b/src/components/UseCaseCard/styles.module.css
@@ -16,6 +16,11 @@
   cursor: pointer;
 }
 
+.useCaseCard.clickable:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .useCaseCard.clickable:hover {
   transform: translateY(-4px);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);

--- a/src/components/WalletFinderCard/styles.module.css
+++ b/src/components/WalletFinderCard/styles.module.css
@@ -182,6 +182,11 @@
   transition: color 0.2s ease;
 }
 
+.link:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
 .link:hover {
   color: var(--ifm-color-primary-dark);
   text-decoration: underline;

--- a/src/components/showcase/ShowcaseFilterToggle/index.js
+++ b/src/components/showcase/ShowcaseFilterToggle/index.js
@@ -10,6 +10,7 @@ import { useHistory, useLocation } from "@docusaurus/router";
 
 import styles from "./styles.module.css";
 import clsx from "clsx";
+import { translate } from "@docusaurus/Translate";
 
 export const Operator = "OR" | "AND";
 
@@ -50,6 +51,10 @@ export default function ShowcaseFilterToggle() {
         type="checkbox"
         id={id}
         className={styles.screenReader}
+        aria-label={translate({
+          id: "showcase.filterToggle.label",
+          message: "Match all selected tags (AND). Leave unchecked to match any tag (OR).",
+        })}
         onChange={toggleOperator}
         onKeyDown={(e) => {
           if (e.key === "Enter") {

--- a/src/components/showcase/ShowcaseTooltip/index.js
+++ b/src/components/showcase/ShowcaseTooltip/index.js
@@ -109,7 +109,21 @@
        }
      };
    }, [referenceElement, text, delay]);
- 
+
+   // WCAG 1.4.13: let keyboard users dismiss the tooltip with Escape while it is open.
+   useEffect(() => {
+     if (!open) {
+       return undefined;
+     }
+     const onKeyDown = (e) => {
+       if (e.key === 'Escape') {
+         setOpen(false);
+       }
+     };
+     document.addEventListener('keydown', onKeyDown);
+     return () => document.removeEventListener('keydown', onKeyDown);
+   }, [open]);
+
    return (
      <>
        {React.cloneElement(children, {

--- a/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js
+++ b/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js
@@ -46,9 +46,11 @@ export default function DropdownNavbarItemDesktop({
         {...props}
         onClick={props.to ? undefined : (e) => e.preventDefault()}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') {
+          if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             setShowDropdown(!showDropdown);
+          } else if (e.key === 'Escape') {
+            setShowDropdown(false);
           }
         }}>
         {props.children ?? props.label}

--- a/src/theme/NavbarItem/DropdownNavbarItem/index.js
+++ b/src/theme/NavbarItem/DropdownNavbarItem/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useId } from 'react';
 import Link from '@docusaurus/Link';
 import clsx from 'clsx';
 import OriginalDropdownNavbarItem from '@theme-original/NavbarItem/DropdownNavbarItem';
@@ -17,6 +17,14 @@ export default function DropdownNavbarItem({mobile = false, ...props}) {
 
   const iconBasePath = useBaseUrl('/img/icons/');
 
+  // Mirror the CSS-driven panel visibility (:hover / :focus-within) into state so
+  // the trigger can expose an accurate aria-expanded. This does NOT drive
+  // visibility (CSS still does), so it cannot regress the hover behavior.
+  const panelId = useId();
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const open = hovered || focused;
+
   const mega =
     props.mega &&
     props.customProps &&
@@ -33,6 +41,10 @@ export default function DropdownNavbarItem({mobile = false, ...props}) {
   const columnCount = props.customProps.columnCount || columns.length;
 
   return (
+    // The <li> hosts the Escape handler so it catches keydown bubbling from the
+    // trigger and any focused panel link; the interactive controls inside remain
+    // the button and links.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <li
       className={clsx(
         'navbar__item',
@@ -41,20 +53,44 @@ export default function DropdownNavbarItem({mobile = false, ...props}) {
       )}
       data-column-count={columnCount}
       onMouseEnter={(e) => {
+        setHovered(true);
         const activeElement = document.activeElement;
         if (activeElement && activeElement.classList.contains('megaMenuTrigger')) {
           if (!e.currentTarget.contains(activeElement)) {
             activeElement.blur();
           }
         }
+      }}
+      onMouseLeave={() => setHovered(false)}
+      onFocus={() => setFocused(true)}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget)) {
+          setFocused(false);
+        }
+      }}
+      onKeyDown={(e) => {
+        // Escape collapses the panel for keyboard users (mirrors the blur the
+        // hover handler already relies on) and syncs aria-expanded.
+        if (e.key === 'Escape') {
+          const active = document.activeElement;
+          if (active && typeof active.blur === 'function') {
+            active.blur();
+          }
+          setFocused(false);
+        }
       }}>
       {/* Top level trigger */}
-      <button className="navbar__link megaMenuTrigger" type="button">
+      <button
+        className="navbar__link megaMenuTrigger"
+        type="button"
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-controls={panelId}>
         {props.label}
       </button>
 
       {/* Mega menu panel */}
-      <div className="megaMenuPanel">
+      <div className="megaMenuPanel" id={panelId}>
         <div className="megaMenuInner">
           {columns.map((col) => (
             <div className="megaMenuColumn" key={col.title}>


### PR DESCRIPTION
- Add open/closed state and labels to the mega menu, governance FAQ, governance-charts parameters dropdown, and showcase match-mode toggle for screen readers
- Support Space and Escape on the navbar dropdowns
- Let keyboard users dismiss showcase tooltips with Escape
- Announce quiz and survey answer selection and results to screen readers
- Add a visible keyboard focus outline to clickable cards and links across apps, bridges, layer-2, solutions, use cases, wallets, exchanges, events, companies, ambassadors and news