### PR TITLE
fix: improve events card layout on mobile and medium widths

### DIFF
--- a/src/components/Events/EventCard/styles.module.css
+++ b/src/components/Events/EventCard/styles.module.css
@@ -124,15 +124,19 @@
 }
 
 @media (max-width: 800px) {
+  /* Thumbnail spans only the date + title block so it never leaves a void; the
+     location and CTA drop to full-width rows below, where the address has room
+     to breathe and the button stays attached to its event. */
   .row {
-    grid-template-columns: 120px 1fr;
+    grid-template-columns: 96px 1fr;
     grid-template-areas:
       "thumb date"
       "thumb main"
-      "thumb place"
+      "place place"
       "cta   cta";
-    row-gap: 0.3rem;
+    row-gap: 0.2rem;
     column-gap: 0.85rem;
+    padding: 1rem 0.4rem;
   }
 
   .thumb {
@@ -140,8 +144,18 @@
     align-self: start;
   }
 
+  /* Inline, left-aligned date label above the title (the desktop calendar-style
+     vertical stack reads as disconnected once the row is stacked). */
   .date {
     grid-area: date;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: flex-start;
+    gap: 0.4rem;
+  }
+
+  .dateDay {
+    font-size: 0.95rem;
   }
 
   .main {
@@ -151,12 +165,13 @@
   .place {
     grid-area: place;
     white-space: normal;
+    margin-top: 0.4rem;
   }
 
   .cta {
     grid-area: cta;
     justify-self: start;
-    margin-top: 0.35rem;
+    margin-top: 0.65rem;
   }
 
   /* Category chip is the least essential column on narrow screens. */

--- a/src/components/Events/EventCard/styles.module.css
+++ b/src/components/Events/EventCard/styles.module.css
@@ -96,10 +96,13 @@
   flex: 0 0 auto;
 }
 
+/* Cap the location column and let it wrap: a long address on a single nowrap
+   line would otherwise starve the flexible title column (min-width: 0), which
+   then collapses to one character per line. */
 .place {
   font-size: 0.85rem;
   color: var(--ifm-color-emphasis-700);
-  white-space: nowrap;
+  max-width: 240px;
 }
 
 .cta {
@@ -123,7 +126,9 @@
   color: #fff;
 }
 
-@media (max-width: 800px) {
+/* The six-column single-row layout needs room; below this the columns get too
+   cramped (the title collapses), so switch to the stacked card earlier. */
+@media (max-width: 1024px) {
   /* Thumbnail spans only the date + title block so it never leaves a void; the
      location and CTA drop to full-width rows below, where the address has room
      to breathe and the button stays attached to its event. */


### PR DESCRIPTION
- Stack the mobile event card cleanly: inline date next to the title, full-width location, and the "View event" button attached to its event
- Remove the large empty gap under the thumbnail on small screens
- Fix the title collapsing to vertical, one-character-per-line text at medium widths by capping the location column and letting it wrap
- Switch to the stacked card layout earlier so mid-size viewports no longer use the cramped six-column row