### PR TITLE
ci: allow manual dispatch of Crowdin sync workflow

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -3,6 +3,7 @@ name: Crowdin Sync
 on:
   push:
     branches: [staging]
+  workflow_dispatch:
 
 jobs:
   sync:


### PR DESCRIPTION
- Add a "Run workflow" button to the Crowdin sync workflow so translations can be pulled from Crowdin on demand, not only on pushes to staging.