### PR TITLE
ci: include partially translated files in Crowdin download

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           upload_sources: true
           download_translations: true
-          skip_untranslated_files: true
+          skip_untranslated_files: false
           create_pull_request: true
           pull_request_base_branch_name: 'staging'
           commit_message: 'i18n: update translations from Crowdin [skip ci]'


### PR DESCRIPTION
- Set skip_untranslated_files to false so the Crowdin sync also pulls down partially translated files (like the German and Vietnamese UI strings), not only fully translated ones.