### PR TITLE
ci: switch Crowdin skip flag so Netlify still deploys

### DIFF
--- a/.github/workflows/crowdin-progress.yml
+++ b/.github/workflows/crowdin-progress.yml
@@ -32,7 +32,7 @@ jobs:
           git add src/data/translation-progress.json src/data/top-translators.json
           git diff --cached --quiet && echo "No changes" && exit 0
           git checkout -b chore/update-crowdin-data
-          git commit -m "chore: update translation progress from Crowdin [skip ci]"
+          git commit -m "chore: update translation progress from Crowdin [skip actions]"
           git push -f origin chore/update-crowdin-data
           gh pr list --head chore/update-crowdin-data --state open | grep -q . || \
             gh pr create --base staging \

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -19,7 +19,7 @@ jobs:
           skip_untranslated_files: false
           create_pull_request: true
           pull_request_base_branch_name: 'staging'
-          commit_message: 'i18n: update translations from Crowdin [skip ci]'
+          commit_message: 'i18n: update translations from Crowdin [skip actions]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}


### PR DESCRIPTION
- Change the Crowdin sync commit tags from a flag that both GitHub Actions and Netlify honor to one only GitHub Actions honors, so the anti-loop behavior stays but promotions to production no longer skip the Netlify build.