### PR TITLE
ci: enforce css and editorial guards, run tests in CI

### DIFF
--- a/.github/workflows/yarn-build.yml
+++ b/.github/workflows/yarn-build.yml
@@ -19,6 +19,7 @@ jobs:
       - run: corepack enable
       - run: yarn install --frozen-lockfile
       - run: yarn lint
+      - run: yarn test
       # PR check only verifies the build compiles. Build the default locale
       # only (~5x faster); all locales are built on the production deploy.
       - run: yarn build --locale en

--- a/blog/2023-08-30-cardano-summit-hackathon/index.md
+++ b/blog/2023-08-30-cardano-summit-hackathon/index.md
@@ -5,6 +5,6 @@ authors: [cf, emurgo]
 tags: [summit, events, hackathons]
 ---
 
-The first-ever Cardano Summit Hackathon precedes the Summit’s main event and is already happening online. Final submissions close on 14 September 2023, with an expert panel from the Cardano Foundation and EMURGO judging each entry to decide which participants will take home the top prize—USD $10,000, plus a $5,000 travel and accommodation allowance for attending the Summit in Dubai. [**Read more**](https://cardanofoundation.org/en/news/cardano-summit-hackathon/)
+The first-ever Cardano Summit Hackathon precedes the Summit’s main event and is already happening online. Final submissions close on 14 September 2023, with an expert panel from the Cardano Foundation and EMURGO judging each entry to decide which participants will take home the top prize: USD $10,000, plus a $5,000 travel and accommodation allowance for attending the Summit in Dubai. [**Read more**](https://cardanofoundation.org/en/news/cardano-summit-hackathon/)
 
 ![Transparency for Governance](./banner.png)

--- a/blog/2025-06-27-media-cardano-developer-office-hours/index.md
+++ b/blog/2025-06-27-media-cardano-developer-office-hours/index.md
@@ -5,7 +5,7 @@ authors: [cf]
 tags: [media]
 ---
 
-In this session of the Cardano Developer Office Hours, Giovanni Gargiulo, Senior Software Engineer – DevOps at the Cardano Foundation, presents the new Token Registry API v2 with full CIP-68 support. He demonstrates API endpoints, explains best practices for using the query_priority parameter, and covers support for tokens under both CIP-26 and CIP-68. A live demo shows practical use cases and integration opportunities for developers.
+In this session of the Cardano Developer Office Hours, Giovanni Gargiulo, Senior Software Engineer, DevOps at the Cardano Foundation, presents the new Token Registry API v2 with full CIP-68 support. He demonstrates API endpoints, explains best practices for using the query_priority parameter, and covers support for tokens under both CIP-26 and CIP-68. A live demo shows practical use cases and integration opportunities for developers.
 
 <div style={{ textAlign: 'right' }}>
 [**Watch now**](https://www.youtube.com/watch?v=R9Qjn4pFIf8)

--- a/blog/2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits/index.md
+++ b/blog/2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits
-title: "SPO Table Talk: Understanding GA – Updates to Plutus execution limits"
+title: "SPO Table Talk: Understanding GA, Updates to Plutus execution limits"
 authors: [community]
 tags: [media]
 ---

--- a/blog/2026-02-20-hydra-adaption-phase/index.md
+++ b/blog/2026-02-20-hydra-adaption-phase/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-02-20-hydra-adaption-phase
-title: "Hydra – adoption phase"
+title: "Hydra: adoption phase"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-03-31-community-digest/index.md
+++ b/blog/2026-03-31-community-digest/index.md
@@ -7,7 +7,7 @@ tags: [community digest,ambassadors]
 ---
 
 
-The Midnight network has officially launched its mainnet, enabling privacy-preserving applications via zero-knowledge proofs. FluidTokens executed the first native Bitcoin–Cardano atomic swap, allowing trustless trading without bridges. Cardano Node v.10.7.0 was pre-released, introducing the LSM Tree to reduce RAM usage from 24GB to 8GB. Stake Pool Operators are invited to an SPO Call on April 2 to discuss these updates and the path toward the Van Rossum hard fork.
+The Midnight network has officially launched its mainnet, enabling privacy-preserving applications via zero-knowledge proofs. FluidTokens executed the first native Bitcoin-Cardano atomic swap, allowing trustless trading without bridges. Cardano Node v.10.7.0 was pre-released, introducing the LSM Tree to reduce RAM usage from 24GB to 8GB. Stake Pool Operators are invited to an SPO Call on April 2 to discuss these updates and the path toward the Van Rossum hard fork.
 
 <div style={{ textAlign: 'right' }}>
  [**Read more**](https://forum.cardano.org/t/digest-march-31-2026-midnight-network-launches-mainnet-fluidtokens-first-native-bitcoin-cardano-atomic-swap-cardano-node-10-7-0-pre-release-spo-call-april-2-defi-liquidity-node-diversity-cap-etc-ambassador-stories-neal-lam/153858) 

--- a/blog/2026-06-19-cardano-vision-2026/index.md
+++ b/blog/2026-06-19-cardano-vision-2026/index.md
@@ -1,7 +1,7 @@
 ---
 slug: 2026-06-19-cardano-vision-2026
 title: "Cardano Vision 2026"
-description: "The first R&D session of 2026 unveiled the Cardano Vision 2026 research program – spanning post-quantum security, multi-layer scalability, decentralized identity, and zero-knowledge verification"
+description: "The first R&D session of 2026 unveiled the Cardano Vision 2026 research program, spanning post-quantum security, multi-layer scalability, decentralized identity, and zero-knowledge verification"
 authors: [iog]
 tags: [development]
 ---

--- a/docs/get-involved/create-react-page.md
+++ b/docs/get-involved/create-react-page.md
@@ -12,9 +12,9 @@ For more complex layouts and interactive features, you can create pages using Re
 
 Add React (`.js` or `.jsx`) files to `/src/pages/` to create standalone pages:
 
-- `src/pages/index.js` → `localhost:3000/`
-- `src/pages/foo.js` → `localhost:3000/foo`
-- `src/pages/foo/bar.js` → `localhost:3000/foo/bar`
+- `src/pages/index.js` maps to `localhost:3000/`
+- `src/pages/foo.js` maps to `localhost:3000/foo`
+- `src/pages/foo/bar.js` maps to `localhost:3000/foo/bar`
 
 ## Create a simple React page
 

--- a/docs/get-involved/index.md
+++ b/docs/get-involved/index.md
@@ -165,7 +165,7 @@ Before contributing, familiarize yourself with these resources:
 Every contribution follows this lifecycle:
 
 ```
-Idea → Discussion → Issue → Implementation → PR → Review → Preview → Merge
+Idea -> Discussion -> Issue -> Implementation -> PR -> Review -> Preview -> Merge
 ```
 
 1. **Idea**: Start with a concept or problem to solve

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:constitution": "node scripts/test-constitution-toc.js",
     "test:events": "node scripts/test-events-model.js",
     "test:css": "node scripts/check-css.js",
-    "test": "yarn test:sitemap && yarn test:constitution && yarn test:events && yarn test:css",
+    "test:docs-style": "node scripts/check-docs-style.js",
+    "test": "yarn test:sitemap && yarn test:constitution && yarn test:events && yarn test:css && yarn test:docs-style",
     "lint": "eslint src scripts docusaurus.config.js",
     "lint:fix": "eslint --fix src scripts docusaurus.config.js"
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:sitemap": "node scripts/test-sitemap-hreflang.js",
     "test:constitution": "node scripts/test-constitution-toc.js",
     "test:events": "node scripts/test-events-model.js",
+    "test:css": "node scripts/check-css.js",
+    "test": "yarn test:sitemap && yarn test:constitution && yarn test:events && yarn test:css",
     "lint": "eslint src scripts docusaurus.config.js",
     "lint:fix": "eslint --fix src scripts docusaurus.config.js"
   },

--- a/scripts/check-css.js
+++ b/scripts/check-css.js
@@ -1,0 +1,66 @@
+/**
+ * CSS drift guard. Catches the specific regressions the design-consistency
+ * work fixed, without failing on the pre-migration brownfield:
+ *   1. Project-namespaced CSS custom properties used via var() WITHOUT a
+ *      fallback that are never defined (the --site-color-* bug class).
+ *      Infima/Docusaurus/DocSearch vars are external and skipped. Vars set
+ *      from JS (style objects / setProperty) count as defined.
+ *   2. Known breakpoint typos that must never come back (966px for 996px).
+ *
+ * Exits non-zero on any violation so CI blocks it. Run with `node`, no framework.
+ */
+const { readFileSync } = require('node:fs');
+const { execFileSync } = require('node:child_process');
+
+const find = (args) =>
+  execFileSync('find', args, { encoding: 'utf8' }).trim().split('\n').filter(Boolean);
+
+const cssFiles = find(['src', '-name', '*.css']);
+const jsFiles = find(['src', '(', '-name', '*.js', '-o', '-name', '*.jsx', ')']);
+
+// --- 1. undefined project vars ----------------------------------------------
+const defined = new Set();
+for (const f of cssFiles)
+  for (const m of readFileSync(f, 'utf8').matchAll(/(--[a-z0-9-]+)\s*:/gi)) defined.add(m[1]);
+
+// Any custom property token appearing in JS is treated as runtime-defined.
+const jsSet = new Set();
+for (const f of jsFiles)
+  for (const m of readFileSync(f, 'utf8').matchAll(/(--[a-z0-9-]+)/gi)) jsSet.add(m[1]);
+
+const isExternal = (v) => /^--(ifm|docusaurus|docsearch)-/.test(v);
+const varViolations = [];
+for (const f of cssFiles) {
+  readFileSync(f, 'utf8')
+    .split('\n')
+    .forEach((line, i) => {
+      // var(--x) with no fallback (no comma before the closing paren)
+      for (const m of line.matchAll(/var\(\s*(--[a-z0-9-]+)\s*\)/gi)) {
+        const v = m[1];
+        if (isExternal(v) || defined.has(v) || jsSet.has(v)) continue;
+        varViolations.push(`${f}:${i + 1}  ${v} (used without fallback, never defined)`);
+      }
+    });
+}
+
+// --- 2. known breakpoint typos ----------------------------------------------
+// 966 is a proven typo for 996 (navbar/sidebar collapse). Extend if new appear.
+const BAD_BREAKPOINTS = [966];
+const bpViolations = [];
+for (const f of cssFiles) {
+  readFileSync(f, 'utf8')
+    .split('\n')
+    .forEach((line, i) => {
+      for (const bp of BAD_BREAKPOINTS) {
+        if (new RegExp(`(max|min)-width:\\s*${bp}px`).test(line))
+          bpViolations.push(`${f}:${i + 1}  ${bp}px (breakpoint typo, use 996px)`);
+      }
+    });
+}
+
+const all = [...varViolations, ...bpViolations];
+if (all.length) {
+  console.error(`check-css: ${all.length} violation(s)\n` + all.map((v) => '  ' + v).join('\n'));
+  process.exit(1);
+}
+console.log('check-css: ok (no undefined project vars, no breakpoint typos)');

--- a/scripts/check-docs-style.js
+++ b/scripts/check-docs-style.js
@@ -1,0 +1,52 @@
+/**
+ * Editorial guard for docs/ and blog/ content. Flags typographic style-guide
+ * violations that are unambiguous and safe to enforce:
+ *   - em dash (—) and horizontal bar (―) anywhere
+ *   - en dash (–) EXCEPT between digits (numeric ranges like 60–70 are allowed)
+ *   - arrow glyphs (→ ←) anywhere
+ *   - the HTML entities that render to the above
+ *
+ * style-guide.md is excluded: it documents these characters by design.
+ * IOHK/IOG are intentionally NOT enforced here (dated archive references and
+ * proper names need editorial judgement, not a mechanical rule).
+ *
+ * Exits non-zero on any violation so CI blocks it.
+ */
+const { readFileSync } = require('node:fs');
+const { execFileSync } = require('node:child_process');
+
+const files = execFileSync(
+  'find',
+  ['docs', 'blog', '-name', '*.md', '-o', '-name', '*.mdx'],
+  { encoding: 'utf8' }
+)
+  .trim()
+  .split('\n')
+  .filter(Boolean)
+  .filter((f) => !f.endsWith('get-involved/style-guide.md'));
+
+const ENTITIES = /&mdash;|&ndash;|&#8212;|&#8211;|&#x2014;|&#x2013;/;
+const violations = [];
+
+for (const f of files) {
+  readFileSync(f, 'utf8')
+    .split('\n')
+    .forEach((line, i) => {
+      const hits = [];
+      if (line.includes('—') || line.includes('―')) hits.push('em dash');
+      if (line.includes('→') || line.includes('←')) hits.push('arrow');
+      if (ENTITIES.test(line)) hits.push('dash entity');
+      // en dash, but not a numeric range (digit – digit, optional spaces)
+      if (/–/.test(line) && /(?<!\d\s?)–(?!\s?\d)/.test(line)) hits.push('en dash');
+      if (hits.length) violations.push(`${f}:${i + 1}  ${hits.join(', ')}`);
+    });
+}
+
+if (violations.length) {
+  console.error(
+    `check-docs-style: ${violations.length} violation(s)\n` +
+      violations.map((v) => '  ' + v).join('\n')
+  );
+  process.exit(1);
+}
+console.log('check-docs-style: ok (no stray dashes or arrows in docs/blog)');


### PR DESCRIPTION
Adds automated checks so styling and editorial drift is caught in CI instead of review. No functional changes.

- Run the existing test suite in CI (it was defined but never executed)
- Fail CI on undefined CSS variables and the known breakpoint typo
- Fail CI on stray em or en dashes and arrow glyphs in docs and blog
- Fix the existing dash and arrow occurrences these checks flagged
