### PR TITLE
docs: correct stale docs and document design tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ Welcome! This guide enables AI agents (and their operators) to contribute produc
 - `scripts/` – Utility scripts
 - `docusaurus.config.js` – Docusaurus site config
 - `sidebars.js` – Sidebar/navigation config
-- `variables.js` – Design tokens, theme variables
+- `variables.js` – Repository and branch URLs used by build scripts
+- `src/css/custom.css` – Global styles and design tokens (see `docs/get-involved/design-tokens.md`)
 - `package.json` – Scripts, dependencies
 - `netlify.toml` – Netlify build/deploy config
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ To maintain the quality of content on cardano.org, we use pull requests to integ
 Please follow these steps to have your contribution considered by the maintainers:
 
 1. Follow all instructions in [the template](.github/PULL_REQUEST_TEMPLATE.md)
-2. Follow the [styleguides of developers.cardano.org](https://developers.cardano.org/docs/portal-style-guide/)
+2. Follow the [cardano.org editorial style guide](docs/get-involved/style-guide.md) for content, and the [design tokens](docs/get-involved/design-tokens.md) for styling
 3. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track and resolve that problem.</details>
 
 While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
@@ -34,7 +34,7 @@ While the prerequisites above must be satisfied prior to having your pull reques
 ## Contribution lifecycle description
 
 Every contribution passes through:
-idea → discussion → issue → implementation → PR → review → staging preview → merge
+idea, discussion, issue, implementation, PR, review, staging preview, merge
 
 Discussion is required before implementation for any change that is non-trivial.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cardano.org follows an incremental evolution model. This repository avoids full 
 
 Suitable contributions include:  
 - Content fixes, clarity, translations (once established), link hygiene. 
-- UI/UX improvements that follow existing design tokens. 
+- UI/UX improvements that follow the [design tokens](docs/get-involved/design-tokens.md). 
 - Component or navigation improvements backed by discussion. 
 - Docs, accessibility, performance and “paper cut” improvements. 
 

--- a/docs/get-involved/add-app.md
+++ b/docs/get-involved/add-app.md
@@ -33,30 +33,24 @@ These criteria are also applied retroactively. Apps that go offline, get abandon
 
    | Item | Recommendation |
    |---|---|
-   | Resolution | **1280×720 px** (1280 wide, 16:9), downscales cleanly |
+   | Resolution | **2048×1440 px** source (displays at 1024×720 @2x), downscales cleanly |
    | Aspect ratio | **16:9 or 16:10** landscape; anything taller gets cropped on the card |
-   | Format | **JPEG** (quality 80) for UI screenshots; PNG only when pixel-perfect text or transparency matters; WebP welcome |
-   | File size | **Under 500 KB** (build will fail otherwise; limit enforced by `scripts/check-app-screenshots.js`) |
+   | Format | **WebP** (quality 80) for UI screenshots; PNG only when pixel-perfect text or transparency matters |
+   | File size | **Under 500 KB** (build will fail otherwise; the only spec enforced by `scripts/check-app-screenshots.js`) |
    | Content | the actual app UI, cropped to the meaningful area. Not a marketing landing page. |
    | Theme | prefer **light theme** for visual consistency with the grid |
    | Browser chrome | omit URL bar and tabs unless intentional (use a clean window or crop them out) |
 
-   One-liner to resize and re-encode an oversized PNG (macOS, ships with `sips`):
+   One-liner to resize and re-encode an oversized PNG to WebP (`cwebp`, cross-platform, part of the `webp` package):
 
    ```bash
-   sips -Z 1280 -s formatOptions 80 -s format jpeg input.png --out your-project-name.jpg
+   cwebp -q 80 -resize 2048 0 input.png -o your-project-name.webp
    ```
 
-   Equivalent on Linux (with ImageMagick):
-
-   ```bash
-   convert input.png -resize 1280x -quality 80 your-project-name.jpg
-   ```
-
-   Name the file descriptively, lowercase, hyphens (e.g. `minswap.jpg`, not `Screenshot 2026-04-19.png`).
+   Name the file descriptively, lowercase, hyphens (e.g. `minswap.webp`, not `Screenshot 2026-04-19.png`).
 
 2. **Add your screenshot to the repository**
-   - Place it in: `src/data/app-screenshots/your-project-name.jpg`
+   - Place it in: `src/data/app-screenshots/your-project-name.webp`
 
 3. **(Optional) Add your project icon/logo**
    - Icons are displayed in specialized components like the DEX grid and app lists
@@ -79,7 +73,7 @@ These criteria are also applied retroactively. Apps that go offline, get abandon
      title: "Your Project Name",
      description: "Brief description of what your project does (120-180 chars; avoid 'best/first/only' claims)",
      tagline: "Multi-pool DEX with deepest liquidity",  // max 60 chars; shown on /apps tiles
-     preview: require("./app-screenshots/your-project-name.jpg"),
+     preview: require("./app-screenshots/your-project-name.webp"),
      icon: "/img/app-icons/your-project-name.svg", // OPTIONAL - for logo display in components
      statsLabel: "yourprojectlabel", // OPTIONAL - for transaction statistics mapping
      website: "https://your-project.com",

--- a/docs/get-involved/components/app-grid.md
+++ b/docs/get-involved/components/app-grid.md
@@ -35,15 +35,17 @@ import AppGrid from '@site/src/components/AppGrid';
 | `ctaText` | `string` | `"Visit"` | Text for the call-to-action button on each card. |
 | `moreLink` | `string` | `null` | Custom link for the "More Apps" card. Defaults to `/apps?tags=...` |
 | `moreTitle` | `string` | `"More Apps"` | Title for the "More Apps" card. |
+| `excludeSlug` | `string` | `null` | Slug of an app to exclude from the grid (e.g. to omit the current app). |
+| `prioritizeMaintainerPicks` | `boolean` | `false` | When true, maintainer-picked apps are sorted ahead of others. |
 
 ---
 
 ## Features
 
-### Flexible Tag Filtering
-Filter apps by any tag or combination of tags:
-- Single tag: `tags={['dex']}` or `tags={['lending']}`
-- Multiple tags: `tags={['dex', 'lending']}` (shows apps with ANY of these tags)
+### Flexible Category Filtering
+Filter apps by any category or combination of categories:
+- Single category: `categories={['dex']}` or `categories={['lending']}`
+- Multiple categories: `categories={['dex', 'lending']}` (shows apps in ANY of these categories)
 
 ### Automatic Ranking
 Apps are automatically ranked by their 30-day transaction volume:
@@ -275,7 +277,7 @@ title: Cardano DeFi Ecosystem
 
 import AppGrid from '@site/src/components/AppGrid';
 
-# Decentralized Finance on Cardano
+## Decentralized Finance on Cardano
 
 Explore the growing DeFi ecosystem on Cardano, ranked by real transaction volume.
 
@@ -305,25 +307,3 @@ Explore the growing DeFi ecosystem on Cardano, ranked by real transaction volume
 - Ranking is category-specific (not global app ranking)
 - Handles missing icons gracefully with fallback badges
 - Supports both `require()` and string URL paths for icons
-
----
-
-## Migration from DexGrid
-
-The `AppGrid` component replaces the previous `DexGrid` component. To migrate:
-
-```jsx
-// Before (DexGrid)
-import DexGrid from '@site/src/components/DexGrid';
-<DexGrid limit={5} showRank={false} />
-
-// After (AppGrid)
-import AppGrid from '@site/src/components/AppGrid';
-<AppGrid categories={['dex']} limit={5} showRank={false} ctaText="Visit DEX" moreTitle="More DEXes" />
-```
-
-Key differences:
-- `categories` prop is now required (defaults to `['dex']`)
-- `ctaText` prop allows customizing the button text (was hardcoded as "Visit DEX")
-- `moreTitle` prop allows customizing the "more" card title
-- `moreLink` prop allows customizing the "more" card link

--- a/docs/get-involved/components/app-list.md
+++ b/docs/get-involved/components/app-list.md
@@ -7,7 +7,7 @@ import AppList from "@site/src/components/AppList";
 
 ## App List
 
-The [`<AppList>`](/docs/get-involved/components/app-list) component displays a compact, ranked list of Cardano apps filtered by category tags. Apps are sorted by transaction count (when available), then by favorites, and finally alphabetically.
+The [`<AppList>`](/docs/get-involved/components/app-list) component displays a compact, ranked list of Cardano apps filtered by category tags. Apps are sorted by transaction count (when available), then by maintainer picks, and finally alphabetically.
 
 ## Basic Usage
 
@@ -36,13 +36,17 @@ The [`<AppList>`](/docs/get-involved/components/app-list) component displays a c
 | `limit` | `number` | `5` | Maximum number of apps to display. Set to `null` to show all. |
 | `categoryTitle` | `string` | `"Apps"` | Title displayed in the component header. |
 | `showTxCount` | `boolean` | `false` | Whether to display transaction counts next to each app. |
+| `slugs` | `string[]` | `null` | Explicit list of app slugs to show, in order. Overrides category filtering. |
+| `hideHeader` | `boolean` | `false` | Hide the component header (title and "See all" link). |
+| `showTags` | `boolean` | `false` | Show category tags on each row. |
+| `showDescription` | `boolean` | `true` | Show the app description on each row. |
 
 ## Ranking Logic
 
 Apps are sorted in the following order:
 
 1. **Apps with transaction data** (sorted by transaction count, descending)
-2. **Favorite apps** (among apps without transaction data)
+2. **Maintainer-picked apps** (apps with `maintainerPick: true`, among those without transaction data)
 3. **Alphabetically** (as final tiebreaker)
 
 ## Examples
@@ -167,7 +171,7 @@ The component is fully responsive:
 
 ## Transaction Data
 
-Transaction counts are sourced from `/src/data/app-stats.json` and matched to apps using fuzzy title matching. Apps without transaction data are still displayed but ranked lower (unless marked as favorites).
+Transaction counts are sourced from `/src/data/tx-stats.json` and matched to apps using fuzzy title matching. Apps without transaction data are still displayed but ranked lower (unless marked as maintainer picks).
 
 :::info Want to see your app ranked by transactions?
 

--- a/docs/get-involved/components/site-hero.md
+++ b/docs/get-involved/components/site-hero.md
@@ -10,7 +10,16 @@ import SiteHero from "@site/src/components/Layout/SiteHero";
 
 ## Site Hero
 
-The [`<SiteHero>`](/docs/get-involved/components/site-hero) component is used to define the header banner and title of each page. You can configure it by passing the following properties: a title, a description, and a banner type.
+The [`<SiteHero>`](/docs/get-involved/components/site-hero) component is used to define the header banner and title of each page.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | | The hero heading. |
+| `description` | `string` \| `node` | | Supporting text below the title. |
+| `bannerType` | `string` | `starburst` | One of the banner types below. An unrecognized or missing value falls back to `starburst`. Documentation pages use `docs`. |
+| `children` | `node` | | Optional content rendered inside the hero, below the title and description. |
 
 ## Banner Types
 

--- a/docs/get-involved/components/step-card.md
+++ b/docs/get-involved/components/step-card.md
@@ -55,6 +55,8 @@ Each step object in the `steps` array can have these properties:
 | `content` | React.ReactNode | Yes | Any React component(s) to display in the step |
 | `checkboxLabel` | string | No | Text for the checkbox. Omit for final step |
 | `finalStep` | boolean | No | Set to `true` to hide checkbox and continue button |
+| `hideHeader` | boolean | No | Hide this step's title and description |
+| `hideActions` | boolean | No | Hide this step's checkbox and continue button |
 
 ## Props
 
@@ -63,6 +65,12 @@ Each step object in the `steps` array can have these properties:
 | `steps` | array | `[]` | Array of step objects (see above) |
 | `initialStep` | number | `1` | Which step to start on (1-indexed) |
 | `onStepChange` | function | - | Callback fired when step changes. Receives new step number |
+| `walletConnected` | boolean | - | Pass a wallet-connection flag through to steps that depend on it |
+| `storageKey` | string | `'cardano-get-started-step'` | localStorage key used to persist progress (see below) |
+
+:::info Progress is persisted
+`StepCard` saves the current step to `localStorage` under `storageKey`. On mount, a saved value overrides `initialStep`, so a returning visitor resumes where they left off. Use a distinct `storageKey` per instance to keep them independent.
+:::
 
 
 ## Live Demo

--- a/docs/get-involved/components/two-column-layout.md
+++ b/docs/get-involved/components/two-column-layout.md
@@ -35,6 +35,7 @@ import TwoColumnLayout from '@site/src/components/TwoColumnLayout';
 | `sidebarSticky` | `boolean` | `true` | Whether the sidebar should stick when scrolling |
 | `sidebarTop` | `string` | `'2rem'` | Top offset for sticky sidebar (CSS value) |
 | `ratio` | `string` | `'2:1'` | Column width ratio (e.g., '2:1', '3:1') |
+| `centerVertically` | `boolean` | `false` | Vertically center the two columns relative to each other |
 
 ## Examples
 

--- a/docs/get-involved/create-markdown-page.md
+++ b/docs/get-involved/create-markdown-page.md
@@ -113,13 +113,9 @@ Add a new condition for your page's path to set custom hero values.
 
 ### Available banner types
 
-Choose from these banner designs:
-- `braidBlack` (default for docs)
-- `braidBlue`
-- `ada`
-- `waves`
-- `starburst`
-- `fluid`
+Choose from these banner designs: `ada`, `dots`, `fluidBlue`, `fluidRed`, `overlap`, `zoomRedWhite`, `zoomRedWhiteDark`, `zoomBlueRed`, `waves`, `starburst`, `braidBlue`, `braidRedBlue`, `braidBlack`, `docs`, `ouroboros`.
+
+Documentation pages default to `docs`. Any unrecognized value falls back to `starburst`.
 
 See the [SiteHero component documentation](/docs/get-involved/components/site-hero) for examples of each banner type.
 

--- a/docs/get-involved/create-react-page.md
+++ b/docs/get-involved/create-react-page.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 7
 title: Create a React Page
-description: Build a custom React page on cardano.org with full layout freedom, using the shared component library and Docusaurus i18n helpers.
+description: Build a custom React page on cardano.org with full layout freedom, using the shared component library.
 ---
 
 ## Create a React Page
@@ -50,7 +50,6 @@ import Divider from "@site/src/components/Layout/Divider";
 import TitleWithText from "@site/src/components/Layout/TitleWithText";
 
 function HomepageHeader() {
-  const { siteTitle } = "useDocusaurusContext()";
   return (
     <SiteHero
       title="Hello World"
@@ -135,7 +134,6 @@ import SpacerBox from "@site/src/components/Layout/SpacerBox";
 import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
 
 function HomepageHeader() {
-  const { siteTitle } = "useDocusaurusContext()";
   return (
     <SiteHero
       title="Hello World"

--- a/docs/get-involved/design-tokens.md
+++ b/docs/get-involved/design-tokens.md
@@ -1,0 +1,165 @@
+---
+sidebar_label: Design Tokens
+sidebar_position: 13
+title: Design Tokens
+description: The shared color, spacing, radius, shadow, and motion variables to use when styling cardano.org, instead of hardcoded values.
+---
+
+Design tokens are the shared styling vocabulary for cardano.org. When you write CSS, reach for a token instead of a raw value. This keeps spacing, color, and motion consistent across pages built by different contributors, and it means a change to the palette or scale happens in one place.
+
+All tokens are CSS custom properties defined in [`src/css/custom.css`](https://github.com/cardano-foundation/cardano-org/blob/staging/src/css/custom.css). They are global, so any `*.module.css` file can use them without an import.
+
+:::tip Enforced in CI
+`yarn test:css` fails the build if a `--site-*` or other project variable is used without being defined. Do not invent new hardcoded hex colors or one-off spacing values; use or extend the tokens below.
+:::
+
+## How tokens are organized
+
+Two namespaces, by design:
+
+- **`--ifm-*`** are Infima (Docusaurus) variables. Use these for anything the framework already owns: the brand color and its ramp, neutral greys, and surfaces. Docusaurus's own components (navbar, buttons, admonitions) read them too.
+- **`--site-*`** are this project's own tokens for everything Infima does not provide: semantic status colors, spacing, radius, elevation, motion, and focus.
+
+**Neutrals have no `--site-*` tokens on purpose.** Use Infima's theme-aware emphasis scale rather than a second grey palette:
+
+| Use | Token |
+|-----|-------|
+| Body text | `var(--ifm-font-color-base)` |
+| Strong text | `var(--ifm-color-emphasis-900)` |
+| Muted / secondary text | `var(--ifm-color-emphasis-600)` |
+| Borders, dividers | `var(--ifm-color-emphasis-200)` / `-300` |
+| Card / panel background | `var(--ifm-background-surface-color)` |
+| Page background | `var(--ifm-background-color)` |
+
+These already invert correctly in dark mode, which is why you should not reach for a hardcoded grey.
+
+## Color
+
+### Brand
+
+The Cardano blue and its ramp live on Infima's primary variables. The ramp is a proper mono-hue ladder: darker variants for hover and active states, lighter variants for soft fills.
+
+| Token | Light | Use |
+|-------|-------|-----|
+| `--ifm-color-primary` | `#0033AD` | Brand blue, default |
+| `--ifm-color-primary-dark` | `#002a8e` | Hover on filled buttons/links |
+| `--ifm-color-primary-darker` | `#00257d` | Active / pressed |
+| `--ifm-color-primary-darkest` | `#001f68` | Strongest accent |
+| `--ifm-color-primary-light` … `-lightest` | `#0038be` … `#0042e1` | Lighter accents |
+
+For `rgba()` use the RGB triple: `rgba(var(--ifm-color-primary-rgb), 0.5)`.
+
+In dark mode the whole ramp shifts to a lighter blue automatically; you do not need to handle it per component.
+
+### Semantic status
+
+One canonical value each, with dark-mode variants already defined:
+
+| Token | Light | Meaning |
+|-------|-------|---------|
+| `--site-success` | `#2da06a` | Success, positive |
+| `--site-warning` | `#d97706` | Warning, caution |
+| `--site-danger` | `#dc3545` | Error, destructive |
+| `--site-info` | brand blue | Informational |
+
+### Brand tints
+
+Translucent primary, for soft fills and hover backgrounds (prefer these over a hardcoded `rgba(0,51,173,…)`):
+
+- `--site-tint-weak`: `rgba(var(--ifm-color-primary-rgb), 0.06)`
+- `--site-tint-strong`: `rgba(var(--ifm-color-primary-rgb), 0.12)`
+
+## Spacing
+
+An 8px-based scale. Use it for padding, margins, and gaps.
+
+| Token | Value |
+|-------|-------|
+| `--site-space-3xs` | `0.25rem` (4px) |
+| `--site-space-2xs` | `0.5rem` (8px) |
+| `--site-space-xs` | `0.75rem` (12px) |
+| `--site-space-sm` | `1rem` (16px) |
+| `--site-space-md` | `1.5rem` (24px) |
+| `--site-space-lg` | `2rem` (32px) |
+| `--site-space-xl` | `3rem` (48px) |
+| `--site-space-2xl` | `4rem` (64px) |
+| `--site-space-3xl` | `6rem` (96px) |
+
+For vertical rhythm between sections, the [Spacer Box](./components/spacer-box.md) component wraps `sm` / `lg` / `3xl`.
+
+## Corner radius
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--site-radius-sm` | `6px` | Small controls |
+| `--site-radius-md` | `8px` | Default card |
+| `--site-radius-lg` | `12px` | Large cards |
+| `--site-radius-xl` | `16px` | Feature panels |
+| `--site-radius-pill` | `999px` | Pills, chips |
+
+Circular elements use `border-radius: 50%` directly.
+
+## Elevation
+
+Four shadow steps, each with a stronger dark-mode variant already defined:
+
+| Token | Use |
+|-------|-----|
+| `--site-shadow-xs` | Subtle lift |
+| `--site-shadow-sm` | Resting card |
+| `--site-shadow-md` | Raised card |
+| `--site-shadow-lg` | Hover / floating |
+
+## Motion
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--site-duration-fast` | `150ms` | Small state changes |
+| `--site-duration-base` | `200ms` | Default |
+| `--site-duration-slow` | `300ms` | Larger transitions |
+| `--site-ease` | `cubic-bezier(0.4, 0, 0.2, 1)` | Standard easing |
+| `--site-lift` | `-2px` | Canonical hover lift (`transform: translateY(var(--site-lift))`) |
+
+A typical hover transition:
+
+```css
+.card {
+  transition: transform var(--site-duration-base) var(--site-ease),
+    box-shadow var(--site-duration-base) var(--site-ease);
+}
+.card:hover {
+  transform: translateY(var(--site-lift));
+  box-shadow: var(--site-shadow-lg);
+}
+```
+
+Wrap non-essential animation in `@media (prefers-reduced-motion: reduce)` and disable it there.
+
+## Focus
+
+There is a global keyboard-focus baseline in `custom.css`, so most interactive elements get a consistent ring for free:
+
+```css
+:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+```
+
+Do not remove focus outlines. If a component needs a shadow-style ring instead of an outline, use `--site-focus-ring`.
+
+## Breakpoints
+
+Breakpoints are **not** tokens: CSS custom properties cannot be used inside `@media` queries, and the project has no preprocessor. Use these three canonical values so component collapse points stay in sync with the navbar and sidebar:
+
+| Width | Use |
+|-------|-----|
+| `996px` | Primary. Matches the Docusaurus navbar/sidebar collapse. |
+| `768px` | Tablet. |
+| `480px` | Mobile. |
+
+`yarn test:css` blocks the `966px` typo (a transposition of `996px`) from coming back.
+
+## Adding a token
+
+If you genuinely need a value the scales do not cover, add it to the relevant block in `src/css/custom.css` (with its dark-mode variant if it is a color or shadow) rather than hardcoding it in a component. Keep the naming consistent with the existing `--site-*` groups.

--- a/docs/get-involved/faq-component.md
+++ b/docs/get-involved/faq-component.md
@@ -51,12 +51,13 @@ After creating your JSON file, you'll need to add a static import for it in the 
 
 Before you can use your new FAQ data, you need to add it to the `FAQSection` component. Open `src/components/FAQSection/index.js` and add an import for your JSON file:
 
-```js {6,11} title="src/components/FAQSection/index.js"
+```js title="src/components/FAQSection/index.js"
 import React, { useState } from "react";
 import Divider from "@site/src/components/Layout/Divider";
 import Collapsible from "react-collapsible";
-import { parseMarkdownLikeText } from "@site/src/utils/textUtils";
+import { renderAnswerArray } from "@site/src/utils/textUtils";
 import delegationFAQ from "@site/src/data/delegationFAQ.json";
+import operationFAQ from "@site/src/data/operationFAQ.json";
 import pineappleFAQ from "@site/src/data/pineappleFAQ.json";
 
 const faqData = {
@@ -65,6 +66,10 @@ const faqData = {
   pineappleFAQ,
 };
 ```
+
+:::tip Passing data directly
+If you would rather not register a JSON file, `FAQSection` also accepts a `data` prop with the array inline: `<FAQSection data={myFaqArray} />`. When `data` is given it takes precedence over `jsonFileName`.
+:::
 
 This registers your JSON file so it can be referenced by name when using the component.
 
@@ -83,7 +88,6 @@ import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
 import FAQSection from "@site/src/components/FAQSection";
 
 function HomepageHeader() {
-  const { siteTitle } = "useDocusaurusContext()";
   return (
     <SiteHero
       title="FAQ Component"

--- a/docs/get-involved/style-guide.md
+++ b/docs/get-involved/style-guide.md
@@ -1,10 +1,9 @@
 ---
 sidebar_label: Style Guide
+sidebar_position: 12
 title: Editorial Style Guide
 description: Writing conventions and terminology standards for cardano.org content.
 ---
-
-# Editorial Style Guide
 
 This guide ensures consistency across all cardano.org content. Use it when writing or editing pages, news articles, and documentation.
 


### PR DESCRIPTION
Brings the contribution docs back in line with the code and fills the biggest gap. No site changes.

- Fix incorrect file names, prop names, and examples across the site-component docs
- Document the design token system (color, spacing, radius, shadow, motion) so styling guidance is actionable
- Point the contribution docs to cardano.org's own style guide and design tokens instead of missing or external references
