### PR TITLE
docs: document key components and add contributor guidelines

### DIFF
--- a/docs/get-involved/component-guidelines.md
+++ b/docs/get-involved/component-guidelines.md
@@ -1,0 +1,80 @@
+---
+sidebar_label: Component Guidelines
+sidebar_position: 14
+title: Component Guidelines
+description: Conventions for building components and pages on cardano.org, dark mode, images, links, translation, and accessibility.
+---
+
+Follow these conventions when you add a component or build a page. They keep the site consistent, translatable, and accessible, and several are enforced in CI.
+
+## Reuse before you create
+
+Before writing a new component, check [`src/components/Layout/`](https://github.com/cardano-foundation/cardano-org/tree/staging/src/components/Layout) for an existing primitive. Most pages are composed from [Site Hero](./components/site-hero.md), [Boundary Box](./components/boundary-box.md), [Title With Text](./components/title-with-text.md), [Divider](./components/divider.md), and [Spacer Box](./components/spacer-box.md). Only create a new component when nothing fits and the result is reusable. A one-off layout for a single page usually does not need its own component.
+
+When you do add a reusable component, document it with a page under `docs/get-involved/components/`.
+
+## Styling: use tokens
+
+Style with the [design tokens](./design-tokens.md) rather than hardcoded values. Put component styles in a co-located `styles.module.css` (CSS Modules), and use the shared `--site-*` and `--ifm-*` variables for color, spacing, radius, shadow, and motion.
+
+`yarn test:css` fails the build on undefined variables and known breakpoint typos, so keep to the documented scales.
+
+## Dark mode is required
+
+Every component must be legible in both light and dark mode. This is free if you use tokens and Infima's neutral scale (`--ifm-color-emphasis-*`, `--ifm-background-surface-color`), because those invert automatically.
+
+The common bug is a hardcoded light surface with theme-aware text:
+
+```css
+/* Wrong: white never inverts, so text disappears in dark mode */
+.box { background: white; color: var(--ifm-color-emphasis-900); }
+
+/* Right: the surface inverts with the theme */
+.box { background: var(--ifm-background-surface-color); color: var(--ifm-color-emphasis-900); }
+```
+
+Check your work by toggling the theme switch in the navbar.
+
+## Images: resolve with base URL
+
+Non-default locales are served under a path prefix (`/de/`, `/ja/`). A hardcoded `/img/...` path breaks there. Resolve image paths through Docusaurus:
+
+```jsx
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
+<img src={useBaseUrl("/img/example.png")} alt="Example" />
+```
+
+## Internal links: use Link
+
+Use the Docusaurus `<Link>` component for internal navigation, never a raw `<a href>`. `<Link>` keeps client-side routing and the active locale prefix; a raw anchor triggers a full reload and drops the locale.
+
+```jsx
+import Link from "@docusaurus/Link";
+
+<Link to="/governance">Governance</Link>
+```
+
+## Translatable text
+
+Wrap any new user-facing string so it can be translated. Do not hardcode English in JSX.
+
+```jsx
+import Translate, { translate } from "@docusaurus/Translate";
+
+// As an element
+<Translate id="home.hero.title">A new way to transact</Translate>
+
+// Where a plain string is needed (props, alt text)
+alt={translate({ id: "home.hero.alt", message: "Cardano logo" })}
+```
+
+Translations themselves are managed through Crowdin, not by editing locale files directly.
+
+## Accessibility
+
+Accessibility rules (`jsx-a11y`) run in CI and block the build when violated.
+
+- Use a real `<button>` or `<Link>` for anything clickable. If you must attach `onClick` to a `<div>`, add `role`, `tabIndex={0}`, and a keyboard handler.
+- Do not remove focus outlines. The global `:focus-visible` baseline gives every control a consistent ring; keep it.
+- Give images meaningful `alt` text, and mark purely decorative images `aria-hidden`.

--- a/docs/get-involved/components/open-graph-info.md
+++ b/docs/get-involved/components/open-graph-info.md
@@ -1,0 +1,43 @@
+---
+title: Open Graph Info
+description: Add Open Graph and Twitter card meta tags to a page with the OpenGraphInfo component on cardano.org.
+---
+
+import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
+
+## Open Graph Info
+
+`<OpenGraphInfo>` adds the social-sharing meta tags (Open Graph and Twitter card) for a page, so a link to it shows a proper preview image, title, and description when shared. Add it once near the top of a React page.
+
+## Basic Usage
+
+Image only:
+
+```jsx
+<OpenGraphInfo pageName="apps" />
+```
+
+With title and description:
+
+```jsx
+<OpenGraphInfo
+  pageName="apps"
+  title="Cardano Apps and dApps"
+  description="Discover curated apps live on Cardano mainnet today."
+/>
+```
+
+## Props
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `pageName` | `string` | Yes | Base name of the preview image. Resolves to `static/img/og/<pageName>.jpg`. |
+| `title` | `string` | No | Sets `og:title` and `twitter:title`. Omit to leave the page's own title. |
+| `description` | `string` | No | Sets `og:description` and `twitter:description`. |
+
+## Notes
+
+- The preview image **must** live in `static/img/og/` and be a `.jpg` named exactly `<pageName>.jpg`.
+- `og:image` and `twitter:image` use the same file; there is no separate Twitter image.
+- The canonical `og:url` is derived automatically from the current path, and `og:site_name` from the site config. You do not set these.
+- Use `summary_large_image` previews, so design the image for a wide 1.91:1 crop.

--- a/docs/get-involved/components/title-with-text.md
+++ b/docs/get-involved/components/title-with-text.md
@@ -1,0 +1,70 @@
+---
+title: Title With Text
+description: Render a section title with body text, optional list, and an optional call-to-action using the TitleWithText component on cardano.org.
+---
+
+import TitleWithText from "@site/src/components/Layout/TitleWithText";
+
+## Title With Text
+
+`<TitleWithText>` renders a title followed by body text, and optionally a call-to-action button. It is one of the most-used building blocks for React pages.
+
+## Basic Usage
+
+```jsx
+<TitleWithText
+  title="What is Cardano?"
+  description="A proof-of-stake blockchain platform for changemakers, innovators, and visionaries."
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | | The heading. Rendered as an `<h1>`, so treat it as the primary heading of its section. |
+| `description` | `string` \| `array` \| `object` | | Body content (see formats below). |
+| `titleType` | `"red"` \| `"green"` \| _(other)_ | black | Title color. Any other value renders the default black. |
+| `headingDot` | `boolean` | `false` | Adds the decorative leading dot to the title. |
+| `slightText` | `string[]` | | Extra muted lines rendered below the description. |
+| `buttonLabel` | `string` | | Call-to-action label. Requires `buttonLink` to appear. |
+| `buttonLink` | `string` | | Destination for the button. Requires `buttonLabel`. |
+
+## Description formats
+
+`description` accepts three shapes, and text runs through basic Markdown parsing (bold, links):
+
+- **String** renders as a paragraph:
+
+  ```jsx
+  <TitleWithText title="Governance" description="Ada holders shape the platform." />
+  ```
+
+- **`{ list: [...] }`** renders a bullet list:
+
+  ```jsx
+  <TitleWithText
+    title="Why Cardano"
+    description={{ list: ["Peer-reviewed research", "Formal methods", "Sustainable"] }}
+  />
+  ```
+
+- **Array** renders each entry in order (mix paragraphs and lists):
+
+  ```jsx
+  <TitleWithText
+    title="Overview"
+    description={["An intro paragraph.", { list: ["Point one", "Point two"] }]}
+  />
+  ```
+
+## With a call-to-action
+
+```jsx
+<TitleWithText
+  title="Get started"
+  description="Set up a wallet and receive your first ada."
+  buttonLabel="Get a wallet"
+  buttonLink="/what-is-a-wallet"
+/>
+```


### PR DESCRIPTION
Fills the remaining documentation gaps for building on cardano.org. No site changes.

- Document the OpenGraphInfo and TitleWithText components, the two most-used that had no page
- Add a component guidelines page: reuse before creating, styling with tokens, dark mode, base-url images, internal links, translation, and accessibility
