### PR TITLE
refactor: share one app icon resolver

### DIFF
--- a/src/components/AppGrid/index.js
+++ b/src/components/AppGrid/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Showcases } from "@site/src/data/apps";
 import { getAppStats, formatTxCount as formatNumber } from "@site/src/utils/appStats";
 import { safeUrl } from "@site/src/utils/safeUrl";
+import { resolveIconSrc } from "@site/src/utils/appIcon";
 import styles from "./styles.module.css";
 
 function AppCard({ app, stats, appRank, ctaText }) {
@@ -9,24 +10,7 @@ function AppCard({ app, stats, appRank, ctaText }) {
   const showRank = appRank !== null && appRank !== undefined;
   const isTop3 = showRank && appRank <= 3;
 
-  // Get the image source, handling both require() objects and string URLs
-  const getIconSrc = () => {
-    if (!app.icon) return null;
-
-    // Handle string URLs (for SVGs in static directory)
-    if (typeof app.icon === 'string') {
-      return app.icon;
-    }
-
-    // Handle require() objects (for PNG/WebP in src directory)
-    if (typeof app.icon === 'object') {
-      return app.icon.default || app.icon.src || null;
-    }
-
-    return null;
-  };
-
-  const iconSrc = getIconSrc();
+  const iconSrc = resolveIconSrc(app);
 
   // Get initial letter for fallback
   const initial = app.title.charAt(0).toUpperCase();

--- a/src/components/AppList/index.js
+++ b/src/components/AppList/index.js
@@ -4,27 +4,13 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import { Showcases, Tags } from "@site/src/data/apps";
 import { getAppStats, formatTxCountCompact as formatTxCount, getAppAxes } from "@site/src/utils/appStats";
 import { safeUrl } from "@site/src/utils/safeUrl";
+import { resolveIconSrc } from "@site/src/utils/appIcon";
 import styles from "./styles.module.css";
 
 function AppListItem({ app, stats, showTxCount, showTags, showDescription = true }) {
   const hasTxData = stats && stats.txCount > 0;
 
-  // Get the image source
-  const getIconSrc = () => {
-    if (!app.icon) return null;
-
-    if (typeof app.icon === 'string') {
-      return app.icon;
-    }
-
-    if (typeof app.icon === 'object') {
-      return app.icon.default || app.icon.src || null;
-    }
-
-    return null;
-  };
-
-  const rawIconSrc = getIconSrc();
+  const rawIconSrc = resolveIconSrc(app);
   const iconSrc = useBaseUrl(rawIconSrc || '');
   const initial = app.title.charAt(0).toUpperCase();
   

--- a/src/pages/apps/leaderboard.js
+++ b/src/pages/apps/leaderboard.js
@@ -8,6 +8,7 @@ import * as echarts from 'echarts';
 import SiteHero from "@site/src/components/Layout/SiteHero";
 import { makeApiClient } from '@site/src/utils/insights/api';
 import { dateToEpoch } from '@site/src/utils/insights/epochs';
+import { resolveIconSrc } from '@site/src/utils/appIcon';
 import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
 import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
 import TitleWithText from "@site/src/components/Layout/TitleWithText";
@@ -64,13 +65,6 @@ function findAppDetails(statEntry) {
   return appOverrides[statEntry.label] || null;
 }
 
-// Get the image source, handling both require() objects and string URLs
-function getIconSrc(app) {
-  if (!app?.icon) return null;
-  if (typeof app.icon === 'string') return app.icon;
-  if (typeof app.icon === 'object') return app.icon.default || app.icon.src || null;
-  return null;
-}
 
 function getCategoryForApp(app) {
   if (!app) return 'Not Listed';
@@ -457,7 +451,7 @@ function MetadataTreemap({ data }) {
 
 // App Row Component for the leaderboard list
 function AppRow({ app, rank, appDetails }) {
-  const iconSrc = getIconSrc(appDetails);
+  const iconSrc = resolveIconSrc(appDetails);
   const initial = app.displayName.charAt(0).toUpperCase();
   const category = getCategoryForEntry(app, appDetails);
   const isTop3 = rank <= 3;

--- a/src/utils/appIcon.js
+++ b/src/utils/appIcon.js
@@ -1,0 +1,14 @@
+// Resolve an app's icon to a usable image src.
+//
+// `app.icon` comes in two shapes:
+//   - a string path (SVGs kept in static/img/app-icons)
+//   - a require() module object (PNG/WebP imported from src/), which exposes the
+//     final URL on `.default` or `.src` depending on the loader
+//
+// Returns null when there is no usable icon, so callers can render a fallback.
+export function resolveIconSrc(app) {
+  if (!app?.icon) return null;
+  if (typeof app.icon === "string") return app.icon;
+  if (typeof app.icon === "object") return app.icon.default || app.icon.src || null;
+  return null;
+}


### PR DESCRIPTION
Third duplicate-component cleanup. No visual change.

- AppGrid, AppList, and the leaderboard each carried an identical copy of the app-icon resolution logic; they now share one helper
- Icons resolve exactly as before, both SVG string paths and imported PNG/WebP (verified on the rendered grid)
