### PR TITLE
refactor: share wallet transaction helpers

### DIFF
--- a/src/components/DRepDelegate/index.js
+++ b/src/components/DRepDelegate/index.js
@@ -11,6 +11,13 @@ import {
   delegateVote,
 } from "@site/src/utils/cardano/wallet";
 import drepAvatarsManifest from "@site/src/data/drep-avatars.json";
+import {
+  EXPECTED_NETWORK_ID,
+  EXPLORER_TX_BASE,
+  shortAddress,
+  stringifyError,
+  classifyError,
+} from "@site/src/utils/walletTx";
 import styles from "./styles.module.css";
 
 const AVATAR_SET = new Set(drepAvatarsManifest.ids);
@@ -20,8 +27,6 @@ const VP_MAX_LOVELACE = 50_000_000_000_000;  // 50M ada
 const DISPLAY_COUNT = 8;
 // data.cardano.org proxy caps POST bodies at 5120 bytes — ~80 drep_ids max per batch.
 const BATCH_SIZE = 50;
-const EXPECTED_NETWORK_ID = 1; // mainnet
-const EXPLORER_TX_BASE = "https://explorer.cardano.org/transaction/";
 const POOL_CACHE_KEY = "cardano-org.drep-pool.v2";
 const POOL_CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
@@ -115,36 +120,6 @@ function isValidDRepId(input) {
   if (/^drep(_script)?1[a-z0-9]{40,}$/.test(t)) return true;
   if (/^[0-9a-f]{56,64}$/i.test(t)) return true;
   return false;
-}
-
-function shortAddress(addr) {
-  if (!addr) return "";
-  return `${addr.slice(0, 12)}…${addr.slice(-8)}`;
-}
-
-function stringifyError(err) {
-  if (!err) return "";
-  if (typeof err === "string") return err;
-  if (err instanceof Error) return err.message || err.toString();
-  const parts = [];
-  if (err.message) parts.push(String(err.message));
-  if (err.info) parts.push(String(err.info));
-  if (err.code != null) parts.push(`code=${err.code}`);
-  if (!parts.length) {
-    try { return JSON.stringify(err); } catch { return String(err); }
-  }
-  return parts.join(" · ");
-}
-
-function classifyError(err) {
-  const msg = stringifyError(err);
-  if (/StakeKeyNotRegistered|StakeNotRegistered/i.test(msg)) return "stakeNotRegistered";
-  // CIP-30 signTx throws code 2 for UserDeclined; submitTx code 2 means Failure.
-  // Only classify as cancel when the message corroborates it.
-  if (/user\s*(declined|rejected|cancel)|declined\s*by\s*user|rejected\s*by\s*user/i.test(msg)) {
-    return "userCancelled";
-  }
-  return "generic";
 }
 
 function WalletPicker({ onConnect, busy }) {

--- a/src/components/TreasuryDonate/index.js
+++ b/src/components/TreasuryDonate/index.js
@@ -3,6 +3,13 @@ import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { translate } from "@docusaurus/Translate";
 import { makeApiClient } from "@site/src/utils/insights/api";
 import {
+  EXPECTED_NETWORK_ID,
+  EXPLORER_TX_BASE,
+  shortAddress,
+  stringifyError,
+  classifyError,
+} from "@site/src/utils/walletTx";
+import {
   detectWallets,
   enableWallet,
   firstAddressBech32,
@@ -10,8 +17,6 @@ import {
 } from "@site/src/utils/cardano/wallet";
 import styles from "./styles.module.css";
 
-const EXPECTED_NETWORK_ID = 1; // mainnet
-const EXPLORER_TX_BASE = "https://explorer.cardano.org/transaction/";
 const DEFAULT_AMOUNT_ADA = "10";
 const LOVELACE_PER_ADA = 1_000_000n;
 
@@ -31,35 +36,6 @@ function formatAda(lovelace) {
   if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(2)}B ada`;
   if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(2)}M ada`;
   return `${Math.round(ada).toLocaleString()} ada`;
-}
-
-function shortAddress(addr) {
-  if (!addr) return "";
-  return `${addr.slice(0, 12)}…${addr.slice(-8)}`;
-}
-
-function stringifyError(err) {
-  if (!err) return "";
-  if (typeof err === "string") return err;
-  if (err instanceof Error) return err.message || err.toString();
-  const parts = [];
-  if (err.message) parts.push(String(err.message));
-  if (err.info) parts.push(String(err.info));
-  if (err.code != null) parts.push(`code=${err.code}`);
-  if (!parts.length) {
-    try { return JSON.stringify(err); } catch { return String(err); }
-  }
-  return parts.join(" · ");
-}
-
-function classifyError(err) {
-  const msg = stringifyError(err);
-  // CIP-30 signTx throws code 2 for UserDeclined; only treat as a cancel when
-  // the message corroborates it so we don't swallow genuine failures.
-  if (/user\s*(declined|rejected|cancel)|declined\s*by\s*user|rejected\s*by\s*user/i.test(msg)) {
-    return "userCancelled";
-  }
-  return "generic";
 }
 
 // Read the current treasury balance from Koios; /totals lists the current epoch first.

--- a/src/utils/walletTx.js
+++ b/src/utils/walletTx.js
@@ -1,0 +1,40 @@
+// Shared helpers for the wallet transaction flows (DRepDelegate, TreasuryDonate).
+// Pure, UI- and i18n-neutral: address formatting, error normalization, and the
+// constants both flows use to talk to Mainnet and link to the explorer.
+
+export const EXPECTED_NETWORK_ID = 1; // mainnet
+export const EXPLORER_TX_BASE = "https://explorer.cardano.org/transaction/";
+
+export function shortAddress(addr) {
+  if (!addr) return "";
+  return `${addr.slice(0, 12)}…${addr.slice(-8)}`;
+}
+
+// Flatten an unknown thrown value (Error, CIP-30 object, string) into one string.
+export function stringifyError(err) {
+  if (!err) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message || err.toString();
+  const parts = [];
+  if (err.message) parts.push(String(err.message));
+  if (err.info) parts.push(String(err.info));
+  if (err.code != null) parts.push(`code=${err.code}`);
+  if (!parts.length) {
+    try { return JSON.stringify(err); } catch { return String(err); }
+  }
+  return parts.join(" · ");
+}
+
+// Classify an error for user-facing messaging. The stakeNotRegistered case only
+// arises in the delegation flow; its message never matches in the treasury flow,
+// so this stays safe to share.
+export function classifyError(err) {
+  const msg = stringifyError(err);
+  if (/StakeKeyNotRegistered|StakeNotRegistered/i.test(msg)) return "stakeNotRegistered";
+  // CIP-30 signTx throws code 2 for UserDeclined; submitTx code 2 means Failure.
+  // Only classify as cancel when the message corroborates it.
+  if (/user\s*(declined|rejected|cancel)|declined\s*by\s*user|rejected\s*by\s*user/i.test(msg)) {
+    return "userCancelled";
+  }
+  return "generic";
+}


### PR DESCRIPTION
Fourth duplicate-component cleanup. No behavior change.

- The delegation and treasury-donation flows each carried identical copies of the wallet address, error-normalization, and error-classification helpers; they now share one module
- Both pages verified to render unchanged
- The wallet-picker and network-warning UI stay per-flow, since they differ only in their Crowdin-managed translation keys
