### PR TITLE
fix: remove white strip above footer on exchanges page

### DIFF
--- a/src/pages/exchanges.js
+++ b/src/pages/exchanges.js
@@ -415,8 +415,6 @@ export default function Home() {
             />
           </BoundaryBox>
         </BackgroundWrapper>
-
-        <SpacerBox size="medium" />
       </main>
     </Layout>
   );


### PR DESCRIPTION
Remove a stray trailing spacer that rendered a white strip between the closing CTA and the footer on /exchanges.