### PR TITLE
feat: news cards with images and a cleaner category system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/data/recentNews.json
 src/data/apps-metadata.json
 static/apps.llms.txt
 static/img/app-screenshots/
+static/img/news-thumbs/
 
 # Misc
 .DS_Store

--- a/blog/2020-11-01-november/index.md
+++ b/blog/2020-11-01-november/index.md
@@ -2,7 +2,7 @@
 slug: november-spotlight-2020-developer-portal
 title: "Spotlight: Cardanoscan.io and PoolTool.io"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 Welcome to the November Developer Spotlight 2021. This month, we will focus on block explorers and pool tools. Read on to learn about the **Cardanoscan** and the **PoolTool**. 

--- a/blog/2021-01-07-january/index.md
+++ b/blog/2021-01-07-january/index.md
@@ -2,7 +2,7 @@
 slug: january-spotlight-2021-developer-portal
 title: "Spotlight: ADATools.io and Pool.pm"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 Welcome to the January Developer Spotlight 2021. This month, we will focus on pool tools. Read on to learn about the **ADATools.io** and the **Pool.pm**.  

--- a/blog/2021-02-03-february/index.md
+++ b/blog/2021-02-03-february/index.md
@@ -2,7 +2,7 @@
 slug: february-spotlight-2021-developer-portal
 title: "Spotlight: ADA MakerSpace and the Hitchhiker's Guides"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 Welcome to the February Developer Spotlight 2021. This month, we will focus on educators, and developer-focused content creators. Read on to learn about the **ADA MakerSpace** and the **Hitchhiker's Guides**.  

--- a/blog/2021-03-26-march/index.md
+++ b/blog/2021-03-26-march/index.md
@@ -2,7 +2,7 @@
 slug: march-spotlight-2021-developer-portal
 title: "Spotlight: Cardano on the Rocks and JorManager"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 Welcome to the March Developer Spotlight 2021. This month, we will focus on both educational content and stake pool tools. Read on to learn about **Cardano on the Rocks** and **JorManager**.  

--- a/blog/2021-07-12-developer-portal-launch/index.md
+++ b/blog/2021-07-12-developer-portal-launch/index.md
@@ -2,7 +2,7 @@
 slug: launch-of-the-developer-portal-2021-developer-portal
 title: "Cardano Developer Portal launch"
 authors: [cf]
-tags: [development, developers]
+tags: [development]
 ---
 
 ![title image](./developer-portal-launch.jpeg)

--- a/blog/2021-07-26-july/index.md
+++ b/blog/2021-07-26-july/index.md
@@ -2,7 +2,7 @@
 slug: 2021-07-26-july-developer-portal
 title: "Interview: NMKR"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 ![title image](./nmkr_preview.png)

--- a/blog/2021-08-09-nft-minting-standard/index.md
+++ b/blog/2021-08-09-nft-minting-standard/index.md
@@ -2,7 +2,7 @@
 slug: nft-minting-standard-developer-portal
 title: "How we minted the NFTAs, and why we went for this standard"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 ![title image](./nfta.jpg)

--- a/blog/2021-08-23-august/index.md
+++ b/blog/2021-08-23-august/index.md
@@ -2,7 +2,7 @@
 slug: 2021-08-23-august-developer-portal
 title: "Interview: Mercury for WooCommerce"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 ![title image](./mercury-logo.jpg)

--- a/blog/2021-09-20-september/index.md
+++ b/blog/2021-09-20-september/index.md
@@ -2,7 +2,7 @@
 slug: 2021-09-20-september-developer-portal
 title: "Interview: NOWPayments"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2021-11-23-november/index.md
+++ b/blog/2021-11-23-november/index.md
@@ -2,7 +2,7 @@
 slug: 2021-11-23-november-developer-portal
 title: "Interview: Nami Wallet"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 For the November edition of the Developer Spotlight, we will interview Alessandro, the creator of the Nami Wallet, co-founder of SpaceBudz, and Cardano stake pool operator.

--- a/blog/2021-12-20-december/index.md
+++ b/blog/2021-12-20-december/index.md
@@ -2,7 +2,7 @@
 slug: 2021-12-20-december-developer-portal
 title: "Interview: ADApools"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 For the December edition of the Spotlight article, we interviewed Josef from [ADApools](https://adapools.org/).

--- a/blog/2022-01-24-january/index.md
+++ b/blog/2022-01-24-january/index.md
@@ -2,7 +2,7 @@
 slug: 2022-01-24-january-developer-portal
 title: "Interview: Charli3"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 For the January edition of the Spotlight Article, we interviewed Robert Hever, COO / Co-Founder, and Damon Zwarich, CMO / Co-Founder from Charli3, a decentralized oracle solution natively built in Haskell / on the [PAB](https://iohk.io/en/blog/posts/2021/10/28/plutus-application-backend-pab-supporting-dapp-development-on-cardano/) (Plutus Application Backend).

--- a/blog/2022-02-28-february/index.md
+++ b/blog/2022-02-28-february/index.md
@@ -2,7 +2,7 @@
 slug: 2022-02-28-february-developer-portal
 title: "Interview: COTI"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2022-03-30-march/index.md
+++ b/blog/2022-03-30-march/index.md
@@ -2,7 +2,7 @@
 slug: 2022-03-30-march-developer-portal
 title: "Interview: Lovelace Academy"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
  ![title image](./lovelace.png)

--- a/blog/2022-04-27-april/index.md
+++ b/blog/2022-04-27-april/index.md
@@ -2,7 +2,7 @@
 slug: 2022-04-27-april-developer-portal
 title: "Interview: Minswap"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2022-05-30-may/index.md
+++ b/blog/2022-05-30-may/index.md
@@ -2,7 +2,7 @@
 slug: 2022-05-30-may-developer-portal
 title: "Interview: Milkomeda"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2022-07-11-july/index.md
+++ b/blog/2022-07-11-july/index.md
@@ -2,7 +2,7 @@
 slug: 2022-07-11-july-developer-portal
 title: "Interview: Koios"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2022-08-11-august/index.md
+++ b/blog/2022-08-11-august/index.md
@@ -2,7 +2,7 @@
 slug: 2022-08-11-august-developer-portal
 title: "Interview: Strica"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2022-09-23-september/index.md
+++ b/blog/2022-09-23-september/index.md
@@ -2,7 +2,7 @@
 slug: 2022-09-23-september-developer-portal
 title: "Interview: ADAO"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2022-12-05-monthly-report-cardano-scaling/index.md
+++ b/blog/2022-12-05-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2022-12-05-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since October 2022, the Hydra team released versions 0.8.0 and 0.8.1, introducing persistence and improving user experience. The roadmap now focuses on finalizing the Hydra V1 specification and preparing for an audit. Key projects include Hydra for Payments and Hydra for Voting, with progress in formal verification and product demonstrations. The team rebranded the repository to reflect its maturity and held a workshop to set new goals for 2023.
 

--- a/blog/2023-01-02-january/index.md
+++ b/blog/2023-01-02-january/index.md
@@ -2,7 +2,7 @@
 slug: 2023-01-02-january-developer-portal
 title: "Interview: Gimbalabs"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2023-01-09-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-01-09-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-01-09-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since November 2022, the Hydra project has made notable progress. The team completed the validation of the coordinated head protocol against a formal model and detailed a follow-up task on model-based testing. They focused on closing gaps in the specification to support an audit, scoped down version 0.9.0 to script updates, and moved the "Commit from external wallet" feature to the next version. Development highlights include fixing errors in the internal wallet, reducing commit costs using reference scripts, and improving CI with nix-based builds. The Hydra V1 specification is being formalized in LaTeX, and the community projects "Hydra for Payments" and "Hydra for Voting" have advanced, with the former completing its first phase. The Cardano Foundation also published a retrospective blog post on Hydra's progress in 2022.
 

--- a/blog/2023-02-16-cf-expands-executive-team/index.md
+++ b/blog/2023-02-16-cf-expands-executive-team/index.md
@@ -2,7 +2,7 @@
 slug: cardano-foundation-expands-executive-team
 title: Cardano Foundation Expands Executive Team With New COO And CLO
 authors: [cf]
-tags: [strategy]
+tags: [ecosystem]
 ---
 
 The Cardano Foundation has announced today the appointment of Andreas Pletscher as its Chief Operating Officer (COO) and Nicolas Jacquemart as its Chief Legal Officer (CLO). Pletscher joins the Foundation from PwC while Jacquemart joins from FINMA, the Swiss financial market supervisory authority. 

--- a/blog/2023-02-16-february/index.md
+++ b/blog/2023-02-16-february/index.md
@@ -2,7 +2,7 @@
 slug: 2023-02-16-february-developer-portal
 title: "Interview: NEWM"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2023-02-17-cf-core-focus-areas/index.md
+++ b/blog/2023-02-17-cf-core-focus-areas/index.md
@@ -2,7 +2,7 @@
 slug: cardano-foundation-core-focus-areas
 title: Cardano Foundation Core Focus Areas
 authors: [cf]
-tags: [strategy]
+tags: [ecosystem]
 ---
 
 The Cardano Foundation focuses on transparency, governance, and accountability in blockchain, emphasizing the importance of widespread access to information for full realization. It drives the adoption of the Cardano blockchain as a foundational layer for future financial and social systems through three core areas: operational resilience, education, and adoption. 

--- a/blog/2023-02-26-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-02-26-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-02-26-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since December 2022, the Hydra project has made progress on several fronts. The team focused on aligning the implementation with the HeadV1 protocol specification, addressing gaps in the on-chain scripts, and improving the mutation test framework. The roadmap was slightly updated, with new items like creating a use case-centric roadmap. Community efforts include the Hydra for Voting project and a lite paper on Hydra for auctions. The team also outlined key themes for 2023, including achieving mainnet maturity, increasing adoption, and promoting sustainable open-source development. The goal is to position Hydra as a maintainable, community-driven project.
 

--- a/blog/2023-03-02-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-03-02-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-03-02-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since January 2023, the Hydra project has made significant progress. Version 0.9.0 was released, incorporating on-chain and off-chain updates, with a focus now on achieving mainnet compatibility for version 0.10.0. The roadmap was updated to align with 2023 objectives, including new items like creating a use case-centric roadmap and opening the specification with a change process. Key development work included aligning the implementation with the HeadV1 specification, improving Hydra transaction profiling, and addressing off-chain protocol logic. Community efforts included audit guidelines, a new tutorial, and ongoing collaborations like Hydra for Payments and Hydra for Voting. The Hydra project also expanded its presence on Discord to engage more with the community.
 

--- a/blog/2023-03-21-march/index.md
+++ b/blog/2023-03-21-march/index.md
@@ -2,7 +2,7 @@
 slug: 2023-03-21-march-developer-portal
 title: "Interview: Mesh"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2023-04-04-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-04-04-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-04-04-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since February 2023, the Hydra project released version 0.9.0, which brought significant on-chain and off-chain updates, including cost reductions in Plutus scripts, improved mutation testing, and the addition of a new tutorial. The focus now shifts to making Hydra mainnet compatible, with version 0.10.0 being the first mainnet-ready release. The roadmap was updated, prioritizing API configurability and marking less-demanded features as ideas for discussion. The team also optimized on-chain scripts and improved Hydra's UX. A key milestone was opening a Hydra head on the Cardano mainnet during a team workshop in Austria.
 

--- a/blog/2023-04-18-cf-annual-report/index.md
+++ b/blog/2023-04-18-cf-annual-report/index.md
@@ -2,7 +2,7 @@
 slug: cardano-foundation-launches-inaugural-annual-report
 title: Cardano Foundation Launches Inaugural Annual Report
 authors: [cf]
-tags: [activity report, report]
+tags: [ecosystem]
 ---
 
 The Cardano Foundation launched its inaugural Annual Report today. From technical infrastructure support to spreading knowledge or establishing targeted partnerships and collaborations, the report showcases the Foundation’s work across its three core focus areas of operational resilience, education, and adoption. 

--- a/blog/2023-05-03-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-05-03-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-05-03-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since March 2023, the Hydra project made significant progress, focusing on preparing for the 0.10.0 release, which will be the first mainnet-compatible version. Key developments include updates to the configurable API, enhancements to the Hydra specification, and fixing script continuity issues. The team also addressed a rollback bug that affected the opening of Hydra heads on the mainnet. Community projects like Hydra for Voting and Hydra for Auctions are advancing, driving API discussions and exploring new use cases like ballot voting and NFT auctions on both L1 and L2.
 

--- a/blog/2023-05-30-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-05-30-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-05-30-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since April 2023, the Hydra project released version 0.10.0, the first mainnet-compatible release, which includes key features like limited mainnet exposure, client API enhancements, and quality-of-life improvements for running the hydra-node. The team focused on timed transactions, removing unnecessary configuration options, and improving continuous integration (CI) performance. Community contributions included the Hydrozoa research proposal and updates to the Hydra for Payments project, which aims to make Hydra more accessible for payment use cases with the HydraNow mobile app. The team continues to refine and expand Hydra's capabilities and user experience.
 

--- a/blog/2023-06-12-launch-of-intersect/index.md
+++ b/blog/2023-06-12-launch-of-intersect/index.md
@@ -2,7 +2,7 @@
 slug: 2023-06-12-launch-of-intersect
 title: "The Launch of Intersect"
 authors: [intersect]
-tags: [mbo, development]
+tags: [governance, development]
 ---
 
 Intersect, a member-based organization for the Cardano ecosystem, invites the community to join and help shape Cardano's future. Founding Members can co-design Intersect and participate in governance tooling initiatives, with grants up to 1.68 million ada. Intersect, vital to the "age of Voltaire," focuses on Cardano's maintenance and development, uniting companies, developers, and individuals. Membership enables proactive involvement in Cardano's evolution, including applying for grants and participating in committees. Nigel Hemsley emphasizes Cardano's secure, transparent, and decentralized growth, supported by its large community and numerous contributors.

--- a/blog/2023-06-15-june/index.md
+++ b/blog/2023-06-15-june/index.md
@@ -2,7 +2,7 @@
 slug: 2023-06-15-june-developer-portal
 title: "Interview: Mandala Metaverse"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2023-06-27-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-06-27-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-06-27-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since May 2023, the Hydra team has focused on several key developments, preparing for the upcoming version 0.11.0 release. Notable updates include allowing commits with multiple UTXOs, enhancing off-chain performance, and introducing commits from external wallets. The team also benchmarked Hydra Head performance, identified persistence as a bottleneck, and made improvements based on real-world usage. Community engagement included planning a Hydra workshop and concluding the Hydra for Auctions project, which successfully demonstrated moving smart contracts from layer 1 to layer 2 for enhanced scalability.
 

--- a/blog/2023-07-31-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-07-31-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-07-31-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since June 2023, the Hydra project released version 0.11.0, enhancing external wallet support and transaction processing, and deprecating internal commits. The team improved security with authenticated network messages and optimized protocol performance by sending only transaction IDs in snapshots. They also addressed a multi-signature verification bug via GitHub security advisories and updated to GHC 9.2.7, improving compatibility and Plutus script efficiency. The Starmap update focused on making Hydra more accessible and preparing for mainnet deployment.
 

--- a/blog/2023-08-07-august/index.md
+++ b/blog/2023-08-07-august/index.md
@@ -2,7 +2,7 @@
 slug: 2023-08-07-august-developer-portal
 title: "Interview: DEMU"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2023-08-21-august/index.md
+++ b/blog/2023-08-21-august/index.md
@@ -2,7 +2,7 @@
 slug: 2023-08-21-august-developer-portal
 title: "Interview: W3:Ride"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2023-08-30-cardano-summit-hackathon/index.md
+++ b/blog/2023-08-30-cardano-summit-hackathon/index.md
@@ -2,7 +2,7 @@
 slug: cardano-summit-hackathon-transparency-for-governance-2023
 title: "Cardano Summit Hackathon: Transparency for Governance"
 authors: [cf, emurgo]
-tags: [summit, events, hackathons]
+tags: [events]
 ---
 
 The first-ever Cardano Summit Hackathon precedes the Summit’s main event and is already happening online. Final submissions close on 14 September 2023, with an expert panel from the Cardano Foundation and EMURGO judging each entry to decide which participants will take home the top prize: USD $10,000, plus a $5,000 travel and accommodation allowance for attending the Summit in Dubai. [**Read more**](https://cardanofoundation.org/en/news/cardano-summit-hackathon/)

--- a/blog/2023-08-30-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-08-30-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-08-30-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since July 2023, the Hydra project has made significant progress, including the release of version 0.12.0, which introduced support for cardano-node 8.1.2, authenticated messages, event-sourced persistence, new API endpoints, and security fixes. The project roadmap has been updated to prioritize network resiliency and incremental commit/decommit features for version 0.13.0. The team also updated the Hydra tutorial to include Mithril and prepared for a Hydra master class at RareEvo 2023, which had positive feedback. In addition, the team participated in Catalyst Fund10, reviewing several proposals related to Hydra and Mithril.
 

--- a/blog/2023-09-12-speaker-announcement/index.md
+++ b/blog/2023-09-12-speaker-announcement/index.md
@@ -2,7 +2,7 @@
 slug: announcing-the-first-round-of-speakers-for-cardano-summit-2023
 title: Speakers for Cardano Summit 2023
 authors: [cf]
-tags: [summit, events]
+tags: [events]
 ---
 
 The Cardano Foundation today announced the first round of speakers for its flagship annual event, Cardano Summit 2023, which will take place from 2 to 4 November, 2023, with the main stage at the Grand Hyatt in Dubai, United Arab Emirates. This year's event will welcome representatives from a broad range of experts and leaders in the blockchain space. 

--- a/blog/2023-09-18-september/index.md
+++ b/blog/2023-09-18-september/index.md
@@ -2,7 +2,7 @@
 slug: 2023-09-18-august-developer-portal
 title: "Interview: Adastat.net"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2023-09-29-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-09-29-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-09-29-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since August 2023, the Hydra project has made several important strides. The roadmap remained largely unchanged, focusing on clarifying upcoming features. Notable updates include completing support for inline datums in the commit API and making progress on network resilience, particularly in handling node crashes and disconnections. The work on incremental commits and decommits has been split into two features, with ongoing design discussions. A workshop in Nantes, France, brought together the Hydra and Mithril teams, where they explored topics like Aiken validator experiments and the concept of a "Shallow cardano-node" using Mithril to streamline Hydra node operations. Additionally, the team worked on refactoring the chain state to improve storage efficiency and maintain backward compatibility.
 

--- a/blog/2023-10-16-october/index.md
+++ b/blog/2023-10-16-october/index.md
@@ -2,7 +2,7 @@
 slug: 2023-10-16-october-developer-portal
 title: "Interview: Lenfi"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2023-11-06-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-11-06-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-11-06-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since September 2023, the Hydra project has achieved several milestones, including the release of version 0.13.0, which focused on security fixes, inline datums support, improved stability, and state persistence. The project roadmap was updated for version 0.14.0. Key developments include enhancing network resilience, creating a Hydra Poll DApp for the Cardano Summit, and upgrading the toolchain to GHC 9.6 and Brick 1.10. Community contributions were highlighted, such as the Hypix project integrating CIP-68 NFTs, Kupo's integration with Hydra, and progress on offline mode for Hydra nodes. The Hydra-for-voting project was revived to improve on-chain voting processes.
 

--- a/blog/2023-11-27-november/index.md
+++ b/blog/2023-11-27-november/index.md
@@ -2,7 +2,7 @@
 slug: 2023-11-27-november-developer-portal
 title: "Interview: Mainstreet"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2023-12-04-monthly-report-cardano-scaling/index.md
+++ b/blog/2023-12-04-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2023-12-04-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since October 2023, the Hydra project has seen significant developments. The release of version 0.14.0 is imminent, focusing on stateless chain observation and internal refactoring. The roadmap was updated to clarify support for the upcoming Conway hard fork and drop Babbage support, while substantial progress was made on the design of the incremental decommit feature. Collaboration with the MeshJS team led to the integration of Hydra-specific features in their SDK. The Hydra specification is being migrated to Markdown for easier accessibility. Community contributions include SundaeLabs' offline mode PR and TxPipe's Cardaminal wallet, aiming for Hydra compatibility.
 

--- a/blog/2024-01-03-2023-cardano-highlights/index.md
+++ b/blog/2024-01-03-2023-cardano-highlights/index.md
@@ -2,7 +2,7 @@
 slug: 2023-cardano-highlights
 title: "2023 Cardano Highlights"
 authors: [taptools]
-tags: [recap, development]
+tags: [development]
 ---
 
 In 2023, Cardano's ecosystem thrived with major innovations, protocol launches, and significant events, marking a year of substantial growth and development. Highlights include the launch of Liqwid Finance, the Valentine Hardfork, VyFinance DEX, and groundbreaking NFT initiatives, enhancing DeFi and NFT market presence. Additionally, Marlowe's release democratized smart contract creation, while Spectrum Finance introduced a decentralized DEX. Events like Rare Evo and NFTxLV 2023 showcased the community's vibrancy, with ADAmail and OrcFax Oracle further expanding Cardano's Web3 and oracle capabilities. The year concluded with Rosenbridge, facilitating Cardano-Ergo interoperability, setting a strong foundation for future innovation. 

--- a/blog/2024-01-03-2023-cardano-highlights/index.md
+++ b/blog/2024-01-03-2023-cardano-highlights/index.md
@@ -2,7 +2,7 @@
 slug: 2023-cardano-highlights
 title: "2023 Cardano Highlights"
 authors: [taptools]
-tags: [development]
+tags: [ecosystem]
 ---
 
 In 2023, Cardano's ecosystem thrived with major innovations, protocol launches, and significant events, marking a year of substantial growth and development. Highlights include the launch of Liqwid Finance, the Valentine Hardfork, VyFinance DEX, and groundbreaking NFT initiatives, enhancing DeFi and NFT market presence. Additionally, Marlowe's release democratized smart contract creation, while Spectrum Finance introduced a decentralized DEX. Events like Rare Evo and NFTxLV 2023 showcased the community's vibrancy, with ADAmail and OrcFax Oracle further expanding Cardano's Web3 and oracle capabilities. The year concluded with Rosenbridge, facilitating Cardano-Ergo interoperability, setting a strong foundation for future innovation. 

--- a/blog/2024-01-03-why-buidler-fest/index.md
+++ b/blog/2024-01-03-why-buidler-fest/index.md
@@ -2,7 +2,7 @@
 slug: why-buidler-fest
 title: "Why Buidler Fest?"
 authors: [builderfest]
-tags: [buidler fest, events, developers]
+tags: [development, events]
 ---
 
 The concept of a technical-focused Cardano event, Cardano Buidler Fest, was born from discussions among developers working on Hydra in 2023. Recognizing a gap in existing Cardano events, which cater to a broader audience, this fest aims to bridge the divide between developers on the Cardano platform and those building applications on it. It seeks to provide a technology-centric space for in-depth discussions, sharing, and learning, addressing the complex and evolving nature of Cardano's technology and ecosystem. The event encourages participation from the community to shape its content, fostering collaboration and knowledge exchange among Cardano technologists and beyond. 

--- a/blog/2024-01-08-community-digest/index.md
+++ b/blog/2024-01-08-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-01-08-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 The Cardano Foundation extends heartfelt New Year wishes to the entire Cardano Community, anticipating another successful year in furthering Cardano’s development. On December 24th, 2023, IAGON launched its decentralized shared storage platform on the Cardano mainnet, revolutionizing data processing and storage solutions. The Cardano Builder Fest, a 2-day event for tech-savvy Cardano builders, will be held in Toulouse, France, on April 23-24, 2024, focusing on demos, open source, project presentations, and live coding. The Rosen Bridge team announced the live bridge between the Ergo and Cardano blockchains, enabling users to send and receive ADA and supported tokens without deploying smart contracts on the destination chain. dcSpark updated their JS/Rust SDK, fixing memory leaks and adding new features. The Cardano Foundation partnered with Petrobras to provide blockchain education for employees. Intersect will now oversee the administration of core Cardano infrastructure. CNCLI v6.0.0 was released, supporting node version 8.7.3. Genius Yield launched their order book DEX on Cardano.

--- a/blog/2024-01-12-weekly-development-report/index.md
+++ b/blog/2024-01-12-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-01-12-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the core technology teams released node v.8.7.3, fixing an outbound-governor issue and enhancing query versioning. The Lace team released v.1.8 with bug fixes and new features. Plutus tools improved synchronization and memory usage for Marconi and added new primitives for Plutus v3. Hydra completed Conway support and enhanced off-chain code. Mithril enabled direct certificate verification and improved node communications. Voltaire development continued with governance and constitution preparations. Project Catalyst held its first town hall and progressed Fund11 through the community review stage. The education team planned yearly activities and Mastering Cardano publication options.

--- a/blog/2024-01-17-catalyst-working-groups/index.md
+++ b/blog/2024-01-17-catalyst-working-groups/index.md
@@ -2,7 +2,7 @@
 slug: catalyst-working-groups-a-proposal
 title: "Catalyst Working Groups - a proposal to the Cardano community and how to get involved!"
 authors: [catalyst]
-tags: [catalyst]
+tags: [governance]
 ---
 
 The Catalyst Team proposes Catalyst Working Groups to involve the Cardano community in shaping future funding rounds through data-driven analysis. This initiative emphasizes collaboration with the global community to foster innovation and decentralize the decision-making process for funding priorities. Fund11 voting will determine the community's interest in dedicating resources to this program, aiming to enhance Cardano's innovation funding by incorporating diverse insights and accelerating startup innovation. Successful proposals will kick off with Fund12 and include community-hosted events, with support and compensation provided to ensure active community participation in determining Cardano's funding objectives. 

--- a/blog/2024-01-19-qsig-exploring-opportunities-in-quantum-cryptography/index.md
+++ b/blog/2024-01-19-qsig-exploring-opportunities-in-quantum-cryptography/index.md
@@ -2,7 +2,7 @@
 slug: 2024-01-19-qsig-exploring-opportunities-in-quantum-cryptography
 title: "Exploring Opportunities in Quantum Cryptography"
 authors: [iog, cf]
-tags: [development, events]
+tags: [events]
 ---
 
 On January 26, 2024, the University of Edinburgh will host QSig, a research event bringing together academics and industry experts, including IOG’s professor Aggelos Kiayias and the Ethereum Foundation’s Justin Drake. The event will explore quantum computing’s applications in cryptography, blockchain science, and financial technology. QSig will highlight recent advancements in quantum cryptographic primitives that address longstanding blockchain security challenges. Discussions will cover the potential of quantum key distribution, encryption techniques, and one-shot signature schemes, focusing on their impact on blockchain technology and financial systems. Sponsored by Input Output, the Cardano Foundation, and the Ethereum Foundation, QSig aims to advance research in quantum-enhanced financial technologies.

--- a/blog/2024-01-19-weekly-development-report/index.md
+++ b/blog/2024-01-19-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-01-19-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Over the past few weeks, the ledger team added new features, improved transaction fee estimation, and fixed various bugs. The Marlowe team benchmarked contract lifecycles, added Merkleized contract examples, and updated the Marlowe Run web application. The Hydra team improved workflows, addressed schema consistency, and enhanced log schema tests. Mithril enabled direct certificate verification, supported Conway era, and upgraded infrastructure. Voltaire continued Conway era development and updated SanchoNet documentation. Project Catalyst concluded the moderation period for community review, with voting starting January 25. The education team planned activities and updated the Haskell Bootcamp course.

--- a/blog/2024-01-22-community-digest/index.md
+++ b/blog/2024-01-22-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-01-22-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 Derek, Co-Founder of VESPR Wallet, shares insights into the wallet’s innovative journey, focusing on user-friendly design, security measures, and responsiveness to feedback, making blockchain accessible for all. On January 20, 2024, a DRep workshop in Oslo, hosted by Thomas Lindseth and Eystein Hansen, focused on refining a Code of Conduct and discussing governance integration and educational content for DReps. IAMX partners with Klüh Multiservices to enhance service management using Cardano. Iagon expands globally with 197 nodes and a China patent. NEWM Studios launches blockchain-minted songs on Cardano Mainnet. Project Catalyst Fund11 voting starts January 25, 2024. Dex Hunter announces cross-chain integration. Marlowe website revamped.

--- a/blog/2024-01-22-january/index.md
+++ b/blog/2024-01-22-january/index.md
@@ -2,7 +2,7 @@
 slug: 2024-01-22-january-developer-portal
 title: "Interview: VESPR Wallet"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2024-01-26-weekly-development-report/index.md
+++ b/blog/2024-01-26-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-01-26-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the networking team integrated bootstrap peers and improved the tx-submission feature. The consensus team worked on Genesis and the second iteration of the ledger DB API for UTXO-HD. The Marlowe team added initial state commands, resolved balancing issues, and published validators on mainnet. Hydra prepared for version 0.15.0, polished hydra-chess, and enhanced testing. Mithril released a client NPM package, new distribution, and improved transaction certification. Project Catalyst started Fund11 voting, and the education team planned Cardano Days events and updated Haskell Bootcamp lessons.

--- a/blog/2024-01-31-monthly-report-cardano-scaling/index.md
+++ b/blog/2024-01-31-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2024-01-31-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 Since November 2023, the Hydra project has made significant progress. Version 0.15.0 was released, featuring offline mode and Conway support. The team also prepared for running Cardano nodes in P2P mode, with non-P2P relays shutting down in January 2024. Notable developments include API changes, removing JSON transactions in favor of CBOR encoding, and ongoing work on Hydra Chess to refine the DApp workflow. Additionally, the Hydra Explorer was initiated to track Hydra heads. The team is also involved in community events like the upcoming Cardano Buidler Fest and supporting Catalyst projects, including streaming API and Hydra auctions.
 

--- a/blog/2024-02-02-weekly-development-report/index.md
+++ b/blog/2024-02-02-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-02-02-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the DB Sync team tested a new version for mainnet and integrated Conway functionality. The Marlowe team optimized performance, resolved Wolfram oracle references, and updated security documents. Hydra conducted roadmapping and improved APIs. Mithril enhanced transaction certification and node communications. Voltaire enabled stake pool operator voting and fixed critical bugs. Project Catalyst continued Fund11 voting, and the education team planned developer training with ABC.

--- a/blog/2024-02-05-community-digest/index.md
+++ b/blog/2024-02-05-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-02-05-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 The Cardano Foundation published its 2023 Activity Report, highlighting key projects and operational resilience. The Voltaire Governance Parameter Survey invites community input on Cardano’s on-chain governance. AHLNET, led by Ola Ahlman, is featured in “Spotlight on Stake Pools.” Other news includes the DRep Workshop in Indianapolis, Project Catalyst Fund11 voting, cross-chain swaps by DexHunter, ERC20 token functionality, and the first Cardano Capture The Flag event.

--- a/blog/2024-02-09-weekly-development-report/index.md
+++ b/blog/2024-02-09-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-02-09-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the networking team integrated bootstrap peer changes, fixed CDDL errors, and improved tx-submission logic. The consensus team advanced UTXO-HD and epoch structure for Conway. Lace prepared for v.1.9 release. Plutus improved error reporting. Hydra and Mithril teams made significant progress, and SanchoNet updated governance features. Catalyst finished Fund11 voting.

--- a/blog/2024-02-16-weekly-development-report/index.md
+++ b/blog/2024-02-16-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-02-16-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the core technology teams released Cardano node v.8.8.0-pre, enabling Plutus V3 script testing on SanchoNet. DB-Sync began integration with the latest Cardano node version. The ledger team focused on fixes, testing, and developing the cuddle Haskell package for CDDL specification in Haskell. The Lace team addressed core API issues for an upcoming patch. The Plutus team improved the Plutus IR inliner, reducing script costs. The Hydra team worked on Conway support, deployed the Hydra explorer tool, and enhanced model-based testing. The Mithril team implemented a new data type for certifying transactions, upgraded the client library, and released a new Mithril network on SanchoNet. The release of Cardano node v.8.8.0-pre allows for experimentation with Plutus V3 on SanchoNet. Project Catalyst announced the results of Fund11, with 300 funded projects and a total of 1,647 projects in Catalyst history. The education team delivered the Cardano Developer Course with ABC and finalized the Marlowe Curriculum for Educators.

--- a/blog/2024-02-19-community-digest/index.md
+++ b/blog/2024-02-19-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-02-19-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 Messari’s ‘State of Cardano’ Q4 2023 report shows significant growth, moving from 34th to 11th in total value locked ranking, with notable stablecoin developments and infrastructure progress. Catalyst Fund 11 results revealed 300 projects funded from 8,000 wallets casting over 300,000 votes. The Cardano Foundation’s initiatives in education and research are highlighted in a recent blog. Rejuve’s Developer Blog discusses using AI and blockchain to address aging. Other news includes FINMA’s stance on staking protocols, Plutus V3 on SanchoNet, and Charles Hoskinson’s insights on the crypto industry.

--- a/blog/2024-02-19-february/index.md
+++ b/blog/2024-02-19-february/index.md
@@ -2,7 +2,7 @@
 slug: 2024-02-19-february-developer-portal
 title: "Interview: Rejuve.AI"
 authors: [devportal]
-tags: [development, developers]
+tags: [development]
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2024-02-23-weekly-development-report/index.md
+++ b/blog/2024-02-23-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-02-23-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the networking team integrated bootstrap peers with cardano-node for improved connectivity and enhanced the tx-submission logic. The consensus team addressed unnecessary block downloads, fixed a bug in the io-sim, and added support for configuring ledger state snapshots. The Hydra team advanced model-based testing, resolved validation issues, and integrated Haskell linting. The Mithril team developed a new data type for certifying Cardano transactions, enhanced browser verification with the WASM client, and deployed a new Mithril network on SanchoNet. SanchoNet focused on governance actions and tutorials. Project Catalyst announced a fun voting event to determine Fund12’s launch city and continued onboarding Fund11 projects. The education team delivered the Cardano Developer course and updated the Haskell Bootcamp course.

--- a/blog/2024-02-26-monthly-report-cardano-scaling/index.md
+++ b/blog/2024-02-26-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2024-02-26-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 The first joint report for Hydra and Mithril projects highlights progress since January 2024. Mithril released distribution 2408.0, with updates like SanchoNet network release and Cardano transaction certification. Enhanced support for Conway and SanchoNet was also implemented. Hydra saw roadmap changes, with significant updates including dropping JSON encoded transaction support, progress on the Hydra heads explorer, and work on incremental commit features. The team resolved a fanout bug discovered during hydra-chess development and deployed a Hydra explorer supporting multiple versions, though it currently supports only one version per network.
 

--- a/blog/2024-03-01-weekly-development-report/index.md
+++ b/blog/2024-03-01-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-03-01-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the ledger team added reference script support for Plutus V1 in Conway, addressed stake distribution inaccuracies, and improved tooling and tests. The Plutus team began implementing the contract blueprint for Plutus Tx and updated the quick start guide to recommend the IOGX Nix flake template. The Hydra team resolved the fanout bug, optimized fee estimation, and implemented transaction metadata. The Mithril team released distribution 2408.0 with significant updates, including improved stake distribution support, and continued developing transaction certification data types. The SanchoNet team launched a patch release, fixed BLS12-381 primitives issues, and brought the GovTool online with limited wallet support. Project Catalyst is onboarding 300 approved projects, emphasizing the Statement of Milestones for accountability, and preparing for a special voting event to decide Fund12's launch location. The education team updated advanced lessons in the Haskell Bootcamp course and practical scenarios in the Cardano Developer Course.

--- a/blog/2024-03-04-community-digest/index.md
+++ b/blog/2024-03-04-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-03-04-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 On March 1, 2024, at 15:13:47 CET, Cardano celebrated its 10 millionth block, minted by JAPAN4 pool. This milestone highlights the community's dedication since Shelley in 2020. The Edinburgh Decentralization Index (EDI) released dashboards showing Cardano's superior decentralization, with a Nakamoto coefficient of 58, compared to Bitcoin and Ethereum's 2. The Japanese Cardano community hosted a successful booth at Japan Web 3 Week Tokyo, with future events planned. Other news includes Rejuve’s decentralized aging research, IOG's new stablecoin XSY, CIP-1694 governance feature testing on SanchoNet, and Cryptoheadz's Cardano introduction event in California.

--- a/blog/2024-03-08-cardano-summit-2024-main-stage/index.md
+++ b/blog/2024-03-08-cardano-summit-2024-main-stage/index.md
@@ -2,7 +2,7 @@
 slug: 2024-03-08-cardano-summit-2024-main-stage
 title: "Cardano Summit 2024 Main Stage Location"
 authors: [cf]
-tags: [summit, events]
+tags: [events]
 ---
 
 The Cardano Foundation has announced that the Cardano Summit 2024 will be held in Dubai, UAE from 23 to 24 October. The Summit aims to foster connections and drive the use of blockchain technology into new frontiers, offering attendees opportunities to learn from experts, establish relationships, and find inspiration in how blockchain can solve real-world problems. Dubai’s reputation as a leading crypto hub makes it an ideal location for the event, building on the success of last year’s Summit. The 2023 edition saw over 10,000 attendees and 27 community events worldwide. Cardano Foundation CEO, Frederik Gregaard, highlighted the growing adoption of blockchain across various sectors and expressed excitement for hosting the Summit in Dubai again. Attendees can register their interest and learn more about the event’s agenda, speakers, and activities.

--- a/blog/2024-03-08-weekly-development-report/index.md
+++ b/blog/2024-03-08-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-03-08-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the networking team published several packages, including `ouroboros-network-0.12.0.0`, and fixed syncing in bootstrap mode. The consensus team updated production libraries for UTXO-HD, measured sync times, fixed a snapshot interval bug, and added UTXO size analysis. The Plutus team advanced CIP-57 implementation for contract blueprints. The Hydra team prepared for the Conway switch, added a UI to the Hydra explorer, and made off-chain protocol changes. The Mithril team worked on transaction certification, improved the explorer, and implemented Prometheus monitoring. The SanchoNet team updated documentation. Catalyst continued onboarding Fund11 projects and began retrospective discussions for Fund12. The education team updated the Haskell Bootcamp and Cardano Developer courses.

--- a/blog/2024-03-12-activity-report/index.md
+++ b/blog/2024-03-12-activity-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-03-15-Cardano Foundation Activity Report
 title: "Cardano Foundation Activity Report"
 authors: [cf]
-tags: [activity report, report]
+tags: [ecosystem]
 ---
 
 Reflecting on 2023, the Cardano Foundation has achieved significant milestones. At the Cardano Summit 2023, the importance of public trust was emphasized. The Foundation enhanced operational resilience through continuous network monitoring and collaboration with exchanges, contributing to network health. Educational initiatives included the Cardano Explorer and Academy. Adoption efforts showcased blockchain’s broader uses, such as in the Georgian wine industry. The Foundation developed tools like the Identity Wallet and Ledger Sync to drive adoption. Looking ahead, Cardano aims to strengthen trust and stability in blockchain infrastructure.

--- a/blog/2024-03-15-weekly-development-report/index.md
+++ b/blog/2024-03-15-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-03-15-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the core technology teams released node v.8.9.0, introducing Genesis Lite bootstrap peers and fixing a dynamic block forging bug. The Lace team started closed beta testing for DApp discovery. The Plutus team added Plutus contract blueprints in the 1.23.0.0 release. The Hydra team worked on the cardano-api-classy library, improved Hydra Head explorer UI, error reporting, and refactored protocol logic. The Mithril team certified Cardano transactions, improved the Mithril explorer UI, and optimized communications between Mithril and Cardano nodes. The ledger team focused on Conway functionality, testing, and code cleanup. Catalyst held a non-funding vote for Fund12’s launch location and conducted a retrospective on Fund11. The education team wrote content for Mastering Cardano and updated the Cardano Developer Course.

--- a/blog/2024-03-18-community-digest/index.md
+++ b/blog/2024-03-18-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-03-18-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 The Cardano Summit 2024 will be held in Dubai, UAE, from October 23-24, aiming to connect global blockchain enthusiasts and foster innovation. Cardano node version 8.9.0 has been released, introducing Genesis Lite and addressing the "Blocks from the Future" issue. The "Spotlight on Stake Pools" series features ABLE, led by Mike Hornan, highlighting its educational initiatives and contributions. Other news includes CEO Frederik Gregaard's reflections on 2023, a governance event in Tokyo, the Cardano Foundation's redesigned website, insights from the Aiken Team, and a Cardano Hackathon in Berlin on July 26-27.

--- a/blog/2024-03-22-weekly-development-report/index.md
+++ b/blog/2024-03-22-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-03-22-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Over the past few weeks, the SRE team deployed cardano-node v.8.9.0 across all environments and created a new profile-cardano-db-sync-snapshots nixosModule. The consensus team merged an alternative fs-api interface, implemented a new diffusion pipelining criterion, and released consensus packages for node v.8.9.1. The Plutus team optimized UPLC and improved documentation. The Hydra team aligned the specification with the incremental de-commit implementation, updated to cardano-api v.8.40, and tested against cardano-node v.8.9.0. The Mithril team focused on transaction certification, UI improvements, metadata provision, and low-latency transaction signing. SanchoNet resources were updated with compatible components. Project Catalyst shared results from the first non-funding vote and announced Fund12’s launch in Barcelona at the end of April. The education team resumed the Cardano Developer Course and supported Voltaire’s constitutional committee training plans.

--- a/blog/2024-03-28-monthly-report-cardano-scaling/index.md
+++ b/blog/2024-03-28-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2024-03-28-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 In March, Mithril saw an increase in SPO participation, reaching 230 pools with 4.6B₳ stake, representing 20% of the active stake. The release of Mithril distribution 2412.0 included support for Prometheus metrics, Pallas-based chain observer implementation, and the deprecation of the snapshot command. Hydra focused on incremental commits and decommits, Conway era support, and preparing for the 0.16.0 release. Significant progress was made on streaming plugins, with SundaeLabs contributing to a plugin architecture that enhances Hydra's extensibility for various external systems and scalable persistence methods.
 

--- a/blog/2024-03-29-weekly-development-report/index.md
+++ b/blog/2024-03-29-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-03-29-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the consensus team finalized integrating node v.8.10.0-pre for SanchoNet governance testing. The ledger team enhanced test frameworks and data quality, resolving issues and improving signal generation. The performance team conducted benchmarks for node v.8.9.1. The Lace team prepared for the release of Lace v.1.9. The Plutus team added a new guide on AsData functionality and optimized scripts. The Hydra team restored network test compatibility, fixed bugs, and prepared a new API format. The Mithril team released distribution 2412.0 with updates, continued transaction certification, and worked on a P2P network prototype. Voltaire & SanchoNet improved governance action handling and efficiency. Project Catalyst paused town halls until Fund12 launches on April 26 in Barcelona, introduced a formal cancellation policy, and planned for future accountability. The education team continued the Cardano Developer course and worked on Haskell Bootcamp Lesson 18.

--- a/blog/2024-04-02-community-digest/index.md
+++ b/blog/2024-04-02-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-04-02-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 Last week, the "Cardano Girls 59" video released on March 25, 2024, went viral, uniting the Cardano community and highlighting the importance of female participation and collaboration. A V2 of the series is also available. Cardano was nominated for ‘Layer-1 Solution of the Year’ at the Blockchain Life Awards 2024, with voting open until April 11. Project Catalyst Fund12 will launch in Barcelona on April 26, featuring workshops and a launch party, with online streaming available. Other news includes a spotlight on Stake Pool ABLE, a new bug bounty program with Immunefi, and a strategic partnership between Emurgo and Encryptus.

--- a/blog/2024-04-05-weekly-development-report/index.md
+++ b/blog/2024-04-05-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-04-05-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the consensus team improved LocalTxMonitor and HasTx functionalities, completed UTXO-HD tests, and addressed issues in the mempool-parallel test. They proposed a new testing framework for quickcheck-dynamic and prepared for node v.8.10 release. The Lace team released v.1.9 with multi-wallet and multi-account support. The Hydra team fixed a broken head situation, enhanced compatibility, and added decommits to the tutorial. The Mithril team worked on transaction certification, scaling, and a decentralized signer registration prototype. Catalyst Fund12 launches on April 26 in Barcelona. The education team continued the Cardano Developer course and prepared for constitutional committee training.

--- a/blog/2024-04-12-weekly-development-report/index.md
+++ b/blog/2024-04-12-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-04-12-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Over the past two weeks, the ledger team enhanced conformance tests and infrastructure, fixed node v.8.10 issues, and updated tooling. The Lace team released Lace v.1.10 with simpler onboarding, improved DApp-wallet interaction, and enhanced staking views. The Plutus team updated the Plutus Tx compiler for better short-circuiting, to be released in v1.26.0.0. The Hydra team released v.0.16.0, supporting cardano-node v.8.9.0, and updated Hydra clients. The Mithril team focused on transaction certification, scaling, and decentralizing signer registration. Voltaire & SanchoNet added Conway-related tests and ToJSON instances. Catalyst Fund12 launched in Barcelona on April 26. The education team supported Voltaire training and published Haskell Bootcamp Lesson 18.

--- a/blog/2024-04-15-community-digest/index.md
+++ b/blog/2024-04-15-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-04-15-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 Node version 8.10.0-pre is live on SanchoNet, including governance changes, Plutus v3 support, and updates for the Constitution Committee. This version should only be used on SanchoNet, which was recently respun. Frederik Gregaard highlights blockchain’s transformative potential, emphasizing five enablers: decentralized identities, zero-knowledge proofs, oracles, secure bridges, and smart legal contracts. Ha Nguyen, a Vietnamese Meetup Organizer, joins as an Ambassador, enhancing Cardano community engagement. Important updates include Project Catalyst’s new cancellation policy and various Cardano-related events.

--- a/blog/2024-04-17-infrastructure-survey/index.md
+++ b/blog/2024-04-17-infrastructure-survey/index.md
@@ -2,7 +2,7 @@
 slug: 2024-04-17-infrastructure-survey
 title: "Infrastructure Survey 2024"
 authors: [cf]
-tags: [survey, spo]
+tags: [governance]
 ---
 
 The Infrastructure Survey 2024, conducted by the Cardano Foundation from April 2-8, gathered insights from 141 responses representing 239 stake pools, including four major CEXs. This survey aims to understand the needs and challenges of stake pool operators (SPOs) to enhance Cardano’s operational resilience. The findings, which account for 27% of the total active stake, highlight SPO roles in network security and resilience. The Foundation plans to conduct this survey annually to continuously improve the Cardano ecosystem.

--- a/blog/2024-04-19-weekly-development-report/index.md
+++ b/blog/2024-04-19-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-04-19-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the core technology teams released node v.8.9.2, resolving a peer-sharing issue. The SRE team made various environment improvements, including re-spinning the Voltaire private chain and updating SanchoNet. The networking team advanced Genesis support, and the consensus team implemented a new diffusion pipelining criterion. The Hydra team fixed a bug, refactored network functions, and prepared a cardano-api branch. The Mithril team worked on transaction certification, memory leak investigation, and signer registration decentralization. Voltaire & SanchoNet updated documentation and tutorials. Fund12 launched in Barcelona on April 26, with proposal submissions starting April 30. The education team wrapped up the ABC Cardano Developer course and developed new Aiken content.

--- a/blog/2024-04-22-launch-of-pragma/index.md
+++ b/blog/2024-04-22-launch-of-pragma/index.md
@@ -2,7 +2,7 @@
 slug: 2024-04-22-launch-of-pragma
 title: "The Launch of PRAGMA"
 authors: [cf]
-tags: [mbo, development]
+tags: [governance, development]
 ---
 
 The Cardano Foundation, along with Blink Labs, dcSpark, Sundae Labs, and TxPipe, announced the launch of PRAGMA, a not-for-profit open-source association for blockchain software projects. PRAGMA aims to foster an open-source ecosystem for Cardano and other blockchains, focusing on projects like Amaru and Aiken. Membership will open to broader developers in 2025, supporting the creation of innovative, enterprise-focused technologies.

--- a/blog/2024-04-26-weekly-development-report/index.md
+++ b/blog/2024-04-26-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-04-26-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the performance and tracing team concluded benchmarking nodes v.8.9.2 and v.8.10.0, designed quick queries for the analysis pipeline, and enhanced Prometheus output for better accessibility. The Plutus team unified command line tools into a single executable and added features. The Mithril team focused on transaction certification, memory issue fixes, and signer registration decentralization, while the Hydra team prepared for versioned network protocols and added property tests. The ledger team updated PlutusV3 in the genesis file, fixed bugs, and improved data generation for the Conway era. The Catalyst team launched Fund12 in Barcelona and began proposal submissions. The education team reviewed capstone projects and planned DRep training with the Voltaire tribe and Intersect team.

--- a/blog/2024-04-29-community-digest/index.md
+++ b/blog/2024-04-29-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-04-29-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 The Cardano Foundation, with Blink Labs, dcSpark, Sundae Labs, and TxPipe, launched PRAGMA, an open-source association for blockchain software development, aiming to support Cardano projects. The “Spotlight on Stake Pools” features ZW3RK, led by Haskell expert Moritz, contributing to the Cardano ecosystem. Ambassador Stories highlights Tim Brückmann, a marketing expert behind IAMX. Other news includes BuilderFest in Toulouse, DRep and Fund12 Workshops, a Cardano Foundation survey on SPO activities, Frederik Gregaard’s discussion on Cardano’s Interim Constitution, and IOG’s X Space on decentralization and cross-chain interoperability.

--- a/blog/2024-05-02-monthly-report-cardano-scaling/index.md
+++ b/blog/2024-05-02-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-02-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 In April, the Mithril project focused on increasing SPO participation, reaching 258 registered signers, representing 22% of Cardano’s active stake. Key updates included a pre-release of distribution 2418.1 and decentralization experiments for the signer registration process. The Hydra project updated its roadmap, emphasizing incremental commits and decommits, and introduced enhancements to the /commit endpoint. The Cardano Buidler Fest featured significant contributions, including the integration of Mithril into Cardano’s IBC protocol and Sundae Labs’ development of the Gummiworm fork for enhanced security in Hydra heads. Logo designs for both projects were also refreshed.
 

--- a/blog/2024-05-03-weekly-development-report/index.md
+++ b/blog/2024-05-03-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-03-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Over the past few weeks, the SRE team deployed Cardano node v.8.9.2 to various environments and v.8.10.1-pre to SanchoNet, rewriting the ouroboros-network-ops cluster. The consensus team reworked database arguments for UTXO-HD, reviewed the Peras innovation report, and supported networking work on big ledger peers. The Mithril team prepared distribution 2418.1-pre with broader CPU support, implemented transaction certification, and worked on signature and proof generation. They also started a global configuration file and investigated error logs. The node and CLI team released v.8.10.1-pre to SanchoNet, improved CI pipelines, and implemented build-estimate for transaction balancing. Fund12 entered the submissions phase with a deadline of May 13. The education team developed the DRep Pioneer program curriculum and attended the Cardano Buidler fest and Catalyst Fund12 launch.

--- a/blog/2024-05-08-ouroboros-genesis-design-update/index.md
+++ b/blog/2024-05-08-ouroboros-genesis-design-update/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-08-ouroboros-genesis-design-update
 title: "Ouroboros Genesis Design Update"
 authors: [iog]
-tags: [development, Ouroboros]
+tags: [development, research]
 ---
 
 Ouroboros Genesis, the latest enhancement to Cardano’s consensus protocol, addresses the vulnerabilities of nodes joining or rejoining the network. It introduces concepts like ledger peers, lightweight checkpointing, limits on eagerness (LoE) and patience (LoP), and Genesis density disconnections (GDD). These measures prevent long-range and eclipse attacks, ensuring nodes can securely sync with the blockchain. The first Genesis-capable implementation is expected by Q3 2024, with ongoing optimizations to handle increased peer counts.

--- a/blog/2024-05-10-weekly-development-report/index.md
+++ b/blog/2024-05-10-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-10-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the performance team analyzed Conway era benchmarks with DReps, improved error reporting, and supported the new CLI command for testnet data. Node metrics were expanded, and UTXO scaling benchmarks were completed. The networking team enhanced peer-sharing, worked on Genesis APIs, resolved bootstrap peer issues, and synchronized churn with outbound governor. The Plutus team improved fixed point operators for efficiency. The Hydra team refactored network protocols and made workflow fixes. Voltaire & SanchoNet finalized Conway era features, updated Plutus CostModels, and improved CI setups. Fund12 in Catalyst is ongoing with approaching deadlines. The education team launched the DRep Pioneer Program, published Haskell Bootcamp lesson 19, and continued work on Mastering Cardano.

--- a/blog/2024-05-11-buidler-fest-recap/index.md
+++ b/blog/2024-05-11-buidler-fest-recap/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-11-buidler-fest-recap
 title: "Buidler Fest #1: A Quick Retrospective"
 authors: [builderfest]
-tags: [buidler fest, events, developers]
+tags: [development, events]
 ---
 
 The first Cardano Buidler Fest was exhilarating and intense, yet enjoyable for attendees. It featured engaging presentations, lively discussions, and joyful dinners. With 102 participants, 53 proposed sessions, and 29 additional sessions, the event was packed with activities. Despite being sold out early, a participant from Peru managed to join. Feedback highlighted the perfect size, great venue, and excellent food, though improvements are needed in diversity and space for coding. Overall, the event fostered positive interactions and valuable insights.

--- a/blog/2024-05-13-community-digest/index.md
+++ b/blog/2024-05-13-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-13-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 The Project Catalyst Fund12 proposal submission phase ended on May 13, 2024, with over 1200 proposals. Cardano Use Cases and Open categories can adjust proposals until May 16, with Community Review until June 6. Cardano Partners category proposals are due by June 6. The Cardano Foundation partnered with the Dubai Blockchain Center to launch a certification program on Cardano’s blockchain technology. Genius Yield’s Developer Blog highlights their Cardano-based DEX project. Other updates include #CardanoGirls, Cardano Builder Fest recap, governance actions, DRep Pioneer Program, and Cardano Summit 2024 early bird tickets.

--- a/blog/2024-05-17-weekly-development-report/index.md
+++ b/blog/2024-05-17-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-17-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the consensus team released node v.8.11, improving Praos chain order, leader schedule statistics, and node robustness. They also updated on Ouroboros Genesis design and setup a consensus technical working group. The performance team completed UTXO-HD benchmarks, and the Lace team launched Lace v.1.11 with enhanced NFT functionality and Trezor T integration. The Hydra team upgraded node networking, fixed transaction parsing, and experimented with reliability layer changes. The Mithril team released distribution 2418.1, supported broader CPU use, improved memory allocation, and optimized signature generation. Voltaire & SanchoNet added CLI commands for hard forks, adjusted protocol versions, and tested CIP-1694. Catalyst Fund12 received 1,283 proposals, with community review starting May 23. The education team worked on Voltaire explainers and Mastering Cardano content.

--- a/blog/2024-05-18-media-governance-workshop-san-diego/index.md
+++ b/blog/2024-05-18-media-governance-workshop-san-diego/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-18-media-governance-workshop-san-diego
 title: Governance Workshop San Diego with Adam Dean
 authors: [community]
-tags: [media, governance]
+tags: [governance, ecosystem]
 ---
 
 Video of the Governance Workshop held in San Diego, focusing on best practices and strategies for effective governance in organizations. Key topics include the importance of transparency, stakeholder engagement, and the implementation of robust governance frameworks. The workshop also covers case studies and real-world examples to illustrate successful governance practices. The session aims to provide actionable insights for enhancing governance in various organizational contexts.

--- a/blog/2024-05-24-weekly-development-report/index.md
+++ b/blog/2024-05-24-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-24-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the ledger team focused on conformance testing, completing tests for CERT and RATIFY rules and improving the constraint-generators framework. They also fixed the stake pool operator stake distribution calculation for voting. The Plutus team developed guardrail scripts for Conway governance actions, fine-tuned the PlutusV3 cost model, and collaborated with MLabs on new bitwise primitives. The Mithril team worked on Cardano transaction certification, scaling proof generation, low-latency certification, and a new explorer page for SPOs. They upgraded the testing network and removed deprecated commands. Work continued on SanchoNet documentation and the DRep Pioneer program with Intersect. Fund12 reached the proposal finalization stage, and development on Hermes and Catalyst voices progressed well. The education team is planning the next Cardano Developer course, advancing the Mastering Cardano series, and preparing an educational video about the constitutional committee.

--- a/blog/2024-05-27-community-digest/index.md
+++ b/blog/2024-05-27-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-27-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 On May 23, 2024, Cardano’s SanchoNet achieved a historic milestone by initiating its first hard fork using CIP-1694 governance. Intersect seeks community input for drafting the Cardano Constitution with workshops worldwide. The Cardano Foundation introduced the MACS algorithm for efficient coin selection on UTxO blockchains at the IEEE conference. Other news includes updates from Dr. Lars Brünjes, CNTools, RealFi, leaderlogs, Catalyst Working Group, and SanchoNet.

--- a/blog/2024-05-27-community-digest/index.md
+++ b/blog/2024-05-27-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-27-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 On May 23, 2024, Cardano’s SanchoNet achieved a historic milestone by initiating its first hard fork using CIP-1694 governance. Intersect seeks community input for drafting the Cardano Constitution with workshops worldwide. The Cardano Foundation introduced the MACS algorithm for efficient coin selection on UTxO blockchains at the IEEE conference. Other news includes updates from Dr. Lars Brünjes, CNTools, RealFi, leaderlogs, Catalyst Working Group, and SanchoNet.

--- a/blog/2024-05-29-monthly-report-cardano-scaling/index.md
+++ b/blog/2024-05-29-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-29-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 In May, the Mithril project released distribution 2418.1, which included critical updates like changes to the certificate chain structure and memory optimizations. Significant progress was made in Cardano transaction certification, achieving a 100x improvement in throughput and reducing storage requirements. The Hydra project released version 0.17.0 with breaking changes to the /commit endpoint, new HTTP endpoints, and focused on incremental decommits. Testing and optimization efforts continued, and several Hydra-related Catalyst proposals were discussed, exploring diverse use cases and alternative scaling approaches.
 

--- a/blog/2024-05-31-weekly-development-report/index.md
+++ b/blog/2024-05-31-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-05-31-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team advanced the UTXO-HD project using simple diffs, improving mempool benchmarks. They released quickcheck-state-machine library v0.10.0 and rebased UTXO-HD on node v8.11. Technical working groups under Intersect were established, with Plutus and consensus meetings set for early June. Updates on UTXO-HD and Ouroboros Peras were provided. The Hydra team released node v0.17.0, featuring new commit transaction mechanisms and networking upgrades. The Mithril team released a protocol insights dashboard, updated the explorer page, and improved transaction certification. SanchoNet invites community testing for on-chain governance as per CIP-1694, with updated documentation. Project Catalyst hosted town hall 164, with the community review stage ongoing and Fund12 voting registration open. The education team is preparing lectures for the Cardano Developer Course, supporting the DRep Pioneer program, and writing content for Mastering Cardano.

--- a/blog/2024-06-07-weekly-development-report/index.md
+++ b/blog/2024-06-07-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-07-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team enhanced the CDDL specification and improved safety by restricting certain protocol parameter types, introduced tools for controlling test case distribution, worked on UTXO predicate failure tests, enabled retrying of flaky tests in nightly CI, and made further improvements. The Lace team released v1.12, adding a fiat on-ramp with Banxa and enabling multi-delegation for supported hardware wallets. The Plutus team released version 1.29.0.0 of the Plutus libraries, which includes CIP-69 and CIP-117 implementations. The Mithril team improved the throughput of the prover route, transitioned to a chain point-based beacon for faster transaction signing, and prepared a threat modeling explainer for the documentation website. The ledger team continued testing the Conway era and fixed several bugs related to DRep expiry and committee voting thresholds. Intersect updates included interim constitutional committee elections and joining Hyperledger and the Linux Foundation. In Catalyst, town hall 165 shared updates, including the end of the community review period for LV0s and LV1s, and the start of LV2 moderation on June 13. The alternative voting mechanism achieved milestone 1 and was presented during town hall 165. The education team continued working on Mastering Cardano, supporting the DRep Pioneer Program, and preparing for the next Cardano Developer course.

--- a/blog/2024-06-10-community-digest/index.md
+++ b/blog/2024-06-10-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-10-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 Today, June 10, 2024, is the final day to register for the Interim Constitutional Committee, which will uphold the interim Constitution during the Chang upgrade. The committee includes representatives from IOG, the Cardano Foundation, EMURGO, Intersect, and three community seats. Charles Hoskinson confirmed Cardano Node v9’s release this month, preceding the Chang Hard Fork. The “Spotlight on Stake Pools” series features Dmytro Stashenko of STAT stake pool. Other Cardano news includes updates from Vietnam Blockchain Week, MAV growth, and the Crypto Valley Conference.

--- a/blog/2024-06-10-community-digest/index.md
+++ b/blog/2024-06-10-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-10-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 Today, June 10, 2024, is the final day to register for the Interim Constitutional Committee, which will uphold the interim Constitution during the Chang upgrade. The committee includes representatives from IOG, the Cardano Foundation, EMURGO, Intersect, and three community seats. Charles Hoskinson confirmed Cardano Node v9’s release this month, preceding the Chang Hard Fork. The “Spotlight on Stake Pools” series features Dmytro Stashenko of STAT stake pool. Other Cardano news includes updates from Vietnam Blockchain Week, MAV growth, and the Crypto Valley Conference.

--- a/blog/2024-06-14-media-understanding-leios-with-pi-lanningham-arnaud-bailly/index.md
+++ b/blog/2024-06-14-media-understanding-leios-with-pi-lanningham-arnaud-bailly/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-14-media-understanding-leios-with-pi-lanningham-arnaud-bailly
 title: Understanding Leios, with Pi Lanningham & Arnaud Bailly
 authors: [community]
-tags: [media, development, Ouroboros]
+tags: [development, research, ecosystem]
 ---
 
 The roundtable discussion features Pi Lanningham and Arnaud Bailly exploring the intricacies of `Ouroboros Leios`, a blockchain-based technology aimed at enhancing decentralized systems. They delve into `Leios`'s architecture, its potential applications in the tech industry, and the innovative solutions it offers for scalability and security. The conversation also covers the implications of `Ouroboros Leios` for developers and businesses, highlighting its unique approach to consensus and transaction processing. This insightful dialogue provides a comprehensive understanding of how `Leios` could revolutionize blockchain technology and its real-world applications.

--- a/blog/2024-06-14-weekly-development-report/index.md
+++ b/blog/2024-06-14-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-14-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team enhanced the CDDL specification and improved safety by restricting certain protocol parameter types, introduced tools for controlling test case distribution, worked on UTXO predicate failure tests, enabled retrying of flaky tests in nightly CI, and made further improvements. The Lace team released v1.12, adding a fiat on-ramp with Banxa and enabling multi-delegation for supported hardware wallets. The Plutus team released version 1.29.0.0 of the Plutus libraries, which includes CIP-69 and CIP-117 implementations. The Mithril team improved the throughput of the prover route, transitioned to a chain point-based beacon for faster transaction signing, and prepared a threat modeling explainer for the documentation website. The ledger team continued testing the Conway era and fixed several bugs related to DRep expiry and committee voting thresholds. Intersect updates included interim constitutional committee elections and joining Hyperledger and the Linux Foundation. In Catalyst, town hall 165 shared updates, including the end of the community review period for LV0s and LV1s, and the start of LV2 moderation on June 13. The alternative voting mechanism achieved milestone 1 and was presented during town hall 165. The education team continued working on Mastering Cardano, supporting the DRep Pioneer Program, and preparing for the next Cardano Developer course.

--- a/blog/2024-06-21-weekly-development-report/index.md
+++ b/blog/2024-06-21-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-21-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the ledger team implemented CIP-0069, enhancing PlutusV3 functionality by making spending datums optional and enforcing single arguments for scripts. They also fixed script execution and delegation bugs. The Lace team prepares for v.1.13 release. The Plutus team released version 1.30.0.0, featuring CIP-0122 and ledger API refactoring. The Mithril team improved transaction certification and throughput. Voltaire & SanchoNet updates include member-experience improvements and upcoming votes. Catalyst town hall 167 marked the end of community moderation for Fund12, with voting starting June 27. The education team prepares for next month’s Cardano Developer course.

--- a/blog/2024-06-24-media-cardano-interim-constitution-explained-lloyd-duhon/index.md
+++ b/blog/2024-06-24-media-cardano-interim-constitution-explained-lloyd-duhon/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-24-media-cardano-interim-constitution-explained-lloyd-duhon
 title: Cardano's Interim Constitution Explained
 authors: [community]
-tags: [media, governance]
+tags: [governance, ecosystem]
 ---
 
 Lloyd Duhon breaks down the Cardano Blockchain Interim Constitution, covering its preamble, core principles, community members’ rights and responsibilities, and the transition plan to the Final Constitution. Discover how this document paves the way for a fully decentralized, community-governed blockchain. Essential insights for Cardano enthusiasts, blockchain developers, and those curious about crypto governance.

--- a/blog/2024-06-25-community-digest/index.md
+++ b/blog/2024-06-25-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-25-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 The Interim Constitution was released on June 21, 2024, serving as a temporary document until the Final Constitution is ratified by ada holders by early 2025. Drafting of the final constitution will involve global workshops and a Constitutional Convention. The Interim Constitutional Committee election ended on June 24, 2024, with results expected on June 26 after an audit. The Aiken team reports surpassing 1 million Mainnet transactions with Aiken smart contracts, contributing to 25% of all smart contract traffic. MinSwap completed its final audit on their new Aiken-based implementation, anticipating increased activity. A new full-time engineer, Riley, joins the team, with new libraries and features like property-based testing and backpassing being showcased in projects like Merkle-Patricia Forestry and Fortuna.

--- a/blog/2024-06-25-community-digest/index.md
+++ b/blog/2024-06-25-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-25-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 The Interim Constitution was released on June 21, 2024, serving as a temporary document until the Final Constitution is ratified by ada holders by early 2025. Drafting of the final constitution will involve global workshops and a Constitutional Convention. The Interim Constitutional Committee election ended on June 24, 2024, with results expected on June 26 after an audit. The Aiken team reports surpassing 1 million Mainnet transactions with Aiken smart contracts, contributing to 25% of all smart contract traffic. MinSwap completed its final audit on their new Aiken-based implementation, anticipating increased activity. A new full-time engineer, Riley, joins the team, with new libraries and features like property-based testing and backpassing being showcased in projects like Merkle-Patricia Forestry and Fortuna.

--- a/blog/2024-06-25-monthly-report-cardano-scaling/index.md
+++ b/blog/2024-06-25-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-25-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 The Mithril project in June saw the release of distribution 2423.0, including critical updates like removing the deprecated snapshot command and improving transaction certification performance. Work on Cardano integration progressed, focusing on decentralizing signature diffusion. The Hydra project made significant strides with incremental decommits, updating the protocol's specification, and fixing a critical bug in the decommit feature. They also made breaking changes to the hydra-node API and enhanced the system's security and efficiency, with a planned release in the near future.
 

--- a/blog/2024-06-28-media-cardano-survives-a-distributed-denial-of-service-attack-lloyd-duhon/index.md
+++ b/blog/2024-06-28-media-cardano-survives-a-distributed-denial-of-service-attack-lloyd-duhon/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-28-media-cardano-survives-a-distributed-denial-of-service-attack-lloyd-duhon
 title: Cardano Survives a Denial of Service Attack
 authors: [community]
-tags: [governance, ecosystem]
+tags: [ecosystem]
 ---
 
 Lloyd Duhon discusses the recent attack on Cardano. Despite the attack, the network only slowed down slightly, with most services unaffected. The attacker used spam transactions, but Cardano’s structure made it complex and costly. A flaw in the attacker’s contract allowed Phil from Anastasia Labs to counter with a “deregistration attack,” stopping the hacker and retrieving ada. Staked ada was never at risk. Cardano’s design ensures resilience, requiring significant resources to sustain such attacks. The community’s quick response and Cardano’s robust design minimized the impact.

--- a/blog/2024-06-28-media-cardano-survives-a-distributed-denial-of-service-attack-lloyd-duhon/index.md
+++ b/blog/2024-06-28-media-cardano-survives-a-distributed-denial-of-service-attack-lloyd-duhon/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-28-media-cardano-survives-a-distributed-denial-of-service-attack-lloyd-duhon
 title: Cardano Survives a Denial of Service Attack
 authors: [community]
-tags: [media, governance]
+tags: [governance, ecosystem]
 ---
 
 Lloyd Duhon discusses the recent attack on Cardano. Despite the attack, the network only slowed down slightly, with most services unaffected. The attacker used spam transactions, but Cardano’s structure made it complex and costly. A flaw in the attacker’s contract allowed Phil from Anastasia Labs to counter with a “deregistration attack,” stopping the hacker and retrieving ada. Staked ada was never at risk. Cardano’s design ensures resilience, requiring significant resources to sustain such attacks. The community’s quick response and Cardano’s robust design minimized the impact.

--- a/blog/2024-06-28-weekly-development-report/index.md
+++ b/blog/2024-06-28-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-06-28-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team optimized db-truncater for speed, supported debugging for bootstrap nodes, and released benchmarks for node v.8.12.0. They also merged a performance fix for node v.8.11, worked on governance action workload, and updated automations for Conway features and the Plutus cost model. The Plutus team overviewed the cost model, designed faster pattern matching, and improved documentation. The Mithril team released a threat modeling explainer, worked on Cardano transaction certification, and improved WASM client documentation. Catalyst released a shortlist of tier-one companies for voting, and the education team updated the Mastering Cardano series and prepared for next month’s developer course.

--- a/blog/2024-07-02-cardano-foundation-brings-mica-compliance-to-the-cardano-network/index.md
+++ b/blog/2024-07-02-cardano-foundation-brings-mica-compliance-to-the-cardano-network/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-02-cardano-foundation-brings-mica-compliance-to-the-cardano-network
 title: Cardano Foundation brings MiCA compliance to the Cardano network
 authors: [cf]
-tags: [development]
+tags: [ecosystem]
 ---
 
 Cardano Foundation and Crypto Carbon Ratings Institute (CCRI) released MiCA-compliant sustainability indicators for the Cardano network. This ensures compliance with upcoming EU Markets in Crypto-Assets (MiCA) regulation. Key findings include Cardano's energy-efficient protocol, annual electricity consumption of 704.91 MWh, carbon footprint of 250.73 tCO2e, and marginal power demand per TPS of 0.192 W. The report, developed using scientific methodologies, aims to enhance transparency and sustainability, setting a benchmark for blockchain networks. Leaders from both organizations emphasized the importance of sustainability and regulatory compliance in the crypto sector.

--- a/blog/2024-07-05-weekly-development-report/index.md
+++ b/blog/2024-07-05-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-05-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Last week, core technology teams released Cardano node v.8.12.2, enhancing bootstrap peer networking. The ledger team worked on testing and updates, while Lace v.1.13 improved Trezor Safe 3 compatibility. Mithril advanced transaction certification, fixed bugs, and supported node v.8.12. Conway ledger improvements included credential restrictions and a new pricing model. Town hall 169 reported over 1bn ada in voting power. The education team prepared for the Cardano Developer course in Buenos Aires and updated content for Voltaire and Mastering Cardano.

--- a/blog/2024-07-08-community-digest/index.md
+++ b/blog/2024-07-08-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-08-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 Community voting for Catalyst Fund 12 is active, with 4,800 wallets casting over 180,000 votes, representing 1.6 billion ada. Voting ends on July 11, 2024, at 11:00 AM UTC. The Cardano Foundation published a beginner’s guide to blockchain on July 3, covering its basics, history, types, applications, and regulatory landscape. The “A Spotlight on Stake Pools” series features C3ETH, a pool focused on community and decentralization in the eastern hemisphere. The latest Developer Blog features an interview with Daniel Friedman, CEO of zenGate Global, discussing their platform Palmyra, which tokenizes commodities for transparency in trading. Other news includes confirmed global Constitution Workshop locations, the tentative agenda for the Cardano Summit 2024 in Dubai, Cardano’s adoption of the IBC Protocol for interoperability, and the latest Catalyst newsletter and Essential Cardano development update.

--- a/blog/2024-07-08-community-digest/index.md
+++ b/blog/2024-07-08-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-08-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 Community voting for Catalyst Fund 12 is active, with 4,800 wallets casting over 180,000 votes, representing 1.6 billion ada. Voting ends on July 11, 2024, at 11:00 AM UTC. The Cardano Foundation published a beginner’s guide to blockchain on July 3, covering its basics, history, types, applications, and regulatory landscape. The “A Spotlight on Stake Pools” series features C3ETH, a pool focused on community and decentralization in the eastern hemisphere. The latest Developer Blog features an interview with Daniel Friedman, CEO of zenGate Global, discussing their platform Palmyra, which tokenizes commodities for transparency in trading. Other news includes confirmed global Constitution Workshop locations, the tentative agenda for the Cardano Summit 2024 in Dubai, Cardano’s adoption of the IBC Protocol for interoperability, and the latest Catalyst newsletter and Essential Cardano development update.

--- a/blog/2024-07-09-media-dreps-and-the-future-of-blockchain-governance-lloyd-duhon/index.md
+++ b/blog/2024-07-09-media-dreps-and-the-future-of-blockchain-governance-lloyd-duhon/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-09-media-dreps-and-the-future-of-blockchain-governance-lloyd-duhon
 title: DReps and the Future of Blockchain Governance with Lloyd Duhon
 authors: [community]
-tags: [media, governance]
+tags: [governance, ecosystem]
 ---
 
 Discover the future of Cardano governance with Lloyd Duhon, covering the Chang upgrade, Delegated Representatives (DReps), and the DRep Pioneer Workshop Leaders Program. Learn how these innovations will empower ada holders in decision-making, from protocol parameters to treasury management. A comprehensive guide to Cardano’s Voltaire era and decentralized blockchain governance.

--- a/blog/2024-07-10-aiken-a-new-way-to-build-dapps-on-cardano/index.md
+++ b/blog/2024-07-10-aiken-a-new-way-to-build-dapps-on-cardano/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-10-aiken-a-new-way-to-build-dapps-on-cardano
 title: Aiken, a New Way to Build dApps on Cardano
 authors: [emurgo]
-tags: [development, developers]
+tags: [development]
 ---
 
 Decentralized applications (dApps) use programmable smart contracts on blockchain to provide accessible services without central authority. Unlike traditional apps with centralized backends, dApps run on open-source, decentralized networks like Cardano, offering transparency and security. Cardano, a third-generation blockchain, supports scalable, secure, and interoperable dApp development. Aiken simplifies dApp development on Cardano by offering familiar syntax, an easy compiler, and clear error handling. It’s used by popular Cardano dApps like Minswap, Sundae Swap, LenFi, and JPG Store, facilitating faster and more efficient dApp creation.

--- a/blog/2024-07-12-weekly-development-report/index.md
+++ b/blog/2024-07-12-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-12-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This week, the teams released node version 9.0.0, enabling the Conway ledger era with CIP-1694, Plutus V1 reference scripts, and CIP-69 support. The performance team released benchmarks for node v.8.12.0 and conducted DRep benchmarks. The consensus team supported the 9.0 release with security audits and NoThunks tests. The Plutus team improved contract blueprints and documentation. The Lace team focused on bug fixes. Mithril supported node v.9.0.0, worked on a new distribution, and fixed REST API bugs. Town Hall 170 and Fund12 voting concluded with 1.5bn ada used. The education team prepared for the Cardano Developer course and Voltaire training.

--- a/blog/2024-07-19-weekly-development-report/index.md
+++ b/blog/2024-07-19-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-19-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team focuses on testing for the Chang upgrade. Lace v.1.14 is upcoming. Hydra updated for node v.9.0.0 and simplified the demo setup. Mithril released distribution 2428.0, supported node v.9.0.0, fixed bugs, and optimized certification. Node users should upgrade to v.9.0.0. Fund12 results announced 258 new projects, with Town Hall 171 celebrating winners. Catalyst completed 900+ projects and allocated over 100M ADA. The education team is in Buenos Aires for the Cardano Developer course.

--- a/blog/2024-07-23-community-digest/index.md
+++ b/blog/2024-07-23-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-23-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 The Cardano Foundation participated in Project Catalyst Fund 12, where 258 projects received funding, highlighting the community-driven development of the Cardano ecosystem. Cardano-node 9.0.0 was released, adding on-chain governance, Plutus v1 reference scripts, and enhanced smart contract security. EMURGO announced the relaunch of the USDA stablecoin under Encryptus. Cardano Ambassador Lloyd Duhon discussed future governance innovations, including DReps and the Voltaire era. Additional updates include the release of Cardano Wallet v2024-07-19, support for Cardano Native Tokens by Tangem, and the launch of Cardano Codex 2024.

--- a/blog/2024-07-23-community-digest/index.md
+++ b/blog/2024-07-23-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-23-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 The Cardano Foundation participated in Project Catalyst Fund 12, where 258 projects received funding, highlighting the community-driven development of the Cardano ecosystem. Cardano-node 9.0.0 was released, adding on-chain governance, Plutus v1 reference scripts, and enhanced smart contract security. EMURGO announced the relaunch of the USDA stablecoin under Encryptus. Cardano Ambassador Lloyd Duhon discussed future governance innovations, including DReps and the Voltaire era. Additional updates include the release of Cardano Wallet v2024-07-19, support for Cardano Native Tokens by Tangem, and the launch of Cardano Codex 2024.

--- a/blog/2024-07-24-monthly-report-cardano-scaling/index.md
+++ b/blog/2024-07-24-monthly-report-cardano-scaling/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-24-monthly-report-cardano-scaling
 title: "Monthly Cardano Scaling Report"
 authors: [scaling]
-tags: [development, scaling]
+tags: [development, research]
 ---
 
 This monthly report on Cardano's Hydra and Mithril scaling projects provides an insightful overview of the latest advancements and plans. Notably, the Mithril team released a new distribution (2428.0) with critical updates, prepared for upcoming distributions supporting Cardano node 9.1.0, and showcased a transaction verification demo in the Nami wallet. Meanwhile, Hydra's roadmap saw significant progress with the completion of incremental decommits, integration of an SDK for wallet developers, and ongoing efforts towards defining Hydra Head V1. The July 2024 stakeholder meeting featured engaging presentations, including Blockfrost's Mithril certificate demo and discussions on enhancing Hydra's functionality, reflecting the community's growing interest and collaboration in Cardano's scaling solutions.

--- a/blog/2024-07-26-weekly-development-report/index.md
+++ b/blog/2024-07-26-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-26-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Cardano node v.9.1.0 has been released, featuring critical updates for the upcoming Chang upgrade, including a Conway genesis file, CLI enhancements, and CIP compatibility. Performance benchmarks for node v.9.0.0 showed significant improvements. The networking team advanced tx-submission design and reviewed Genesis pull requests. The Lace team is preparing for version 1.14, and Plutus TX has been rebranded as Plinth. The Hydra and Mithril teams made progress on network reliability and transaction certification. The education team is in Argentina teaching a Cardano Developer course.

--- a/blog/2024-07-30-6-things-to-look-forward-intersect/index.md
+++ b/blog/2024-07-30-6-things-to-look-forward-intersect/index.md
@@ -2,7 +2,7 @@
 slug: 2024-07-30-6-things-to-look-forward-intersect
 title: 6 Things to Look Forward to From Intersect
 authors: [emurgo]
-tags: [education, governance]
+tags: [governance, education]
 ---
 
 In 2024, Cardano is transitioning to a fully community-run governance structure, with Intersect playing a crucial supporting role. Six key developments to expect include:

--- a/blog/2024-08-01-first-release-of-the-partner-chains-toolkit/index.md
+++ b/blog/2024-08-01-first-release-of-the-partner-chains-toolkit/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-01-first-release-of-the-partner-chains-toolkit
 title: "First release of the Cardano Partner Chains Toolkit"
 authors: [iog]
-tags: [development, interoperability]
+tags: [development]
 ---
 
 Input Output Global has launched the alpha v1 release of partner chains, enabling new blockchain networks to bootstrap security by leveraging Cardano's stake pool operators (SPOs). This release introduces innovations like shared security, mixed validator committees, and consensus model flexibility, allowing partner chains to benefit from Cardano's extensive network. While this release is not for live production, it marks a significant milestone in realizing Charles' vision. Midnight will be the first partner chain to use this technology, with further developments and feedback expected in the coming months.

--- a/blog/2024-08-01-media-intersects-structure-lloyd-duhon/index.md
+++ b/blog/2024-08-01-media-intersects-structure-lloyd-duhon/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-01-media-intersects-structure-lloyd-duhon
 title: The Structure of Intersect with Lloyd Duhon
 authors: [community]
-tags: [media, governance]
+tags: [governance, ecosystem]
 ---
 
 Intersect’s organizational structure is crucial to the Cardano ecosystem, featuring seven key committees: Budget, Cardano Civics, Marketing, Membership & Community, Open Source, Parameters, and Technology Steering. These committees manage various aspects of Cardano’s development and governance. They collaborate with Working Groups and Special Interest Groups (SIGs) to ensure efficient and decentralized network management. This episode provides a detailed overview of each committee’s responsibilities and their contributions to Cardano’s growth.

--- a/blog/2024-08-02-weekly-development-report/index.md
+++ b/blog/2024-08-02-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-02-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team focused on Conway features and fixed a bug affecting functionality post-bootstrap. Hydra worked on network reliability, upgraded the Hydra head for node compatibility, and introduced a technical writing guide. Mithril released distribution 2430.0, supporting Cardano node 9.1.0, activated transaction certification in test networks, and continued CIP drafting. Catalyst's onboarding is progressing, with Town Hall 173 marking Fund12's end. The education team completed a Cardano Developer course in Buenos Aires and organized a graduation event for smart contract developers.

--- a/blog/2024-08-06-community-digest/index.md
+++ b/blog/2024-08-06-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-06-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 Cardano is strengthening its presence in Argentina through key initiatives, including developer workshops, the ADN event, and discussions with government officials. The ALBA program at UTN is advancing blockchain education, and a recent workshop led by IOG culminated in a graduation event attended by Charles Hoskinson. The ADN event showcased blockchain innovations, while government talks explored blockchain's potential in Argentina. Additionally, Cardano's first community-driven Constitutional Workshop was held in Argentina. These activities highlight Cardano's commitment to local engagement and blockchain innovation. The Cardano Foundation also launched the SSI Wallet Alpha Program, inviting users to test and contribute to its development.

--- a/blog/2024-08-06-community-digest/index.md
+++ b/blog/2024-08-06-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-06-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 Cardano is strengthening its presence in Argentina through key initiatives, including developer workshops, the ADN event, and discussions with government officials. The ALBA program at UTN is advancing blockchain education, and a recent workshop led by IOG culminated in a graduation event attended by Charles Hoskinson. The ADN event showcased blockchain innovations, while government talks explored blockchain's potential in Argentina. Additionally, Cardano's first community-driven Constitutional Workshop was held in Argentina. These activities highlight Cardano's commitment to local engagement and blockchain innovation. The Cardano Foundation also launched the SSI Wallet Alpha Program, inviting users to test and contribute to its development.

--- a/blog/2024-08-09-weekly-development-report/index.md
+++ b/blog/2024-08-09-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-09-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team began work on Q3 2024 goals, focusing on `db-truncater` behavior, EmptySlot error details, new trace messages, and UTXO-HD feature branch updates. Lace is prepared for the Chang upgrade and DRep registration on the mainnet. Plutus completed testing bitwise primitives, now improving Plinth documentation. Hydra made progress on bug fixes and Agda transition, while Mithril worked on stake distribution certification and nearly completed a CIP draft. Catalyst Fund12 onboarding is progressing, and the education team wrapped up a successful course in Argentina, preparing for the upcoming Cardano Days event in Wyoming.

--- a/blog/2024-08-16-running-doom-on-cardano-hydra/index.md
+++ b/blog/2024-08-16-running-doom-on-cardano-hydra/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-16-running-doom-on-cardano-hydra
 title: "Running Doom on Cardano Hydra"
 authors: [iog]
-tags: [development, scaling]
+tags: [development, research]
 ---
 
 Doom (1993) remains a cultural icon, now demonstrated on Cardano's blockchain using Hydra heads. By leveraging Hydra's ability to handle complex operations off-chain, the game runs in real-time through smart contracts validating deterministic game states. While running Doom on a blockchain is impractical, this tech demo highlights Hydra's potential, offering open-source components and innovative approaches that could inspire new blockchain applications.

--- a/blog/2024-08-16-weekly-development-report/index.md
+++ b/blog/2024-08-16-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-16-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team added minor features like ledger state queries for voting on proposals and transaction size computations, while focusing on Conway testing and conformance tests. The Lace team released version 1.14 with CIP-95 support and bug fixes. Hydra released version 0.18.0, addressing a Conway fork issue and adding incremental decommits. GovTool is active on preview and SanchoNet, with 67% of stake upgraded to node v.9.1.0 for the Chang upgrade. Catalyst released the Catalyst Horizons report and is preparing for engagements at Rare Evo. The education team is reviewing the Cardano Developer course and updating "Mastering Cardano".

--- a/blog/2024-08-19-community-digest/index.md
+++ b/blog/2024-08-19-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-19-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [research, events, community]
+tags: [community, research, events]
 ---
 
 Las Vegas hosted the RareEvo blockchain conference from August 15-17, attracting projects and community members from Cardano and other blockchain ecosystems. Highlights included keynotes from Charles Hoskinson, a live Hydra Doom demonstration, and an interview with presidential candidate Robert F. Kennedy Jr. The Hydra team showcased Cardano’s layer 2 solution by running one local game of Doom with 35 transactions per second, processing over 86 million transactions by August 19. RareEvo proved to be a significant event, demonstrating Cardano's scalability and innovation potential. More insights and impressions can be found by searching #rareevo24 on X.

--- a/blog/2024-08-19-community-digest/index.md
+++ b/blog/2024-08-19-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-19-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, scaling, events]
+tags: [research, events, community]
 ---
 
 Las Vegas hosted the RareEvo blockchain conference from August 15-17, attracting projects and community members from Cardano and other blockchain ecosystems. Highlights included keynotes from Charles Hoskinson, a live Hydra Doom demonstration, and an interview with presidential candidate Robert F. Kennedy Jr. The Hydra team showcased Cardano’s layer 2 solution by running one local game of Doom with 35 transactions per second, processing over 86 million transactions by August 19. RareEvo proved to be a significant event, demonstrating Cardano's scalability and innovation potential. More insights and impressions can be found by searching #rareevo24 on X.

--- a/blog/2024-08-23-weekly-development-report/index.md
+++ b/blog/2024-08-23-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-23-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The performance and tracing team released node v.9.1 benchmarks, improved resource trace emission, and integrated non-systemd Linux support in cardano-tracer. The consensus team enhanced `ChainSync` client testing and reviewed the final Genesis statement of work. The Lace team is reviewing feedback from Rare Evo 2024 for future updates. Plutus team updated Plinth documentation, while Hydra launched the Hydra Doom project. Mithril completed stake distribution certification and drafted a CIP for signature diffusion. The Chang hard fork is set for late August, marking Cardano's entry into the Conway ledger era. Fund13 preparation continues, and the education team is gathering feedback and updating content.

--- a/blog/2024-08-30-weekly-development-report/index.md
+++ b/blog/2024-08-30-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-08-30-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The `ledger` team focused on conformance tests, improving the ledger test suite, and preparing for the upcoming hard fork by documenting changes affecting DApp developers. The `SRE` team upgraded the pre-production network to the Conway era and made various infrastructure improvements. The `Lace` team is set to release version 1.15 with enhanced governance capabilities. The `Mithril` team is decentralizing signature orchestration and optimizing memory use. The `Voltaire` team prepared for the Chang #1 hard fork on September 1. `Catalyst` advanced Fund12 onboarding and achieved progress in the Hermes project, while the `education` team preps for Cardano Days.

--- a/blog/2024-09-02-community-digest/index.md
+++ b/blog/2024-09-02-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-02-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 The Chang #1 Hard Fork on September 1, 204, marks a key milestone for Cardano, initiating a new governance era. The first phase introduces an Interim Constitutional Committee (ICC) to oversee governance with limited powers, while Stake Pool Operators retain approval rights for protocol changes. The second phase, Chang Upgrade #2, expected in 90 days, will fully activate on-chain governance per CIP-1694. As Cardano enters the Conway era, the new Delegated Representatives (DReps) role is vital for governance, allowing ada holders to influence decisions. Early DRep registration requires a 500 ada refundable deposit.

--- a/blog/2024-09-02-community-digest/index.md
+++ b/blog/2024-09-02-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-02-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 The Chang #1 Hard Fork on September 1, 204, marks a key milestone for Cardano, initiating a new governance era. The first phase introduces an Interim Constitutional Committee (ICC) to oversee governance with limited powers, while Stake Pool Operators retain approval rights for protocol changes. The second phase, Chang Upgrade #2, expected in 90 days, will fully activate on-chain governance per CIP-1694. As Cardano enters the Conway era, the new Delegated Representatives (DReps) role is vital for governance, allowing ada holders to influence decisions. Early DRep registration requires a 500 ada refundable deposit.

--- a/blog/2024-09-06-media-chang-hardfork-impact-on-spo-operations/index.md
+++ b/blog/2024-09-06-media-chang-hardfork-impact-on-spo-operations/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-06-media-chang-hardfork-impact-on-spo-operations
 title: "Chang Hard Fork Impact on SPO Operations"
 authors: [community]
-tags: [media, spo, governance]
+tags: [governance, ecosystem]
 ---
 
 Join us for the first edition of the SPO Table Talk with domain experts, where we dive into the latest topics on Cardano stake pools and infrastructure. This session covers a range of topics, from changes in SPO leader logs post-Chang hard fork to the refined VRF tiebreaker rule, block diffusion pipelining, and more. We also explore the evolving role of stake pool operators in Cardano’s governance era, featuring insights from  Andrew Westberg, Martin Lang, Samuel Leathers, Alexander Esgen, Markus Gufler and Denicio Bute. 

--- a/blog/2024-09-06-weekly-development-report/index.md
+++ b/blog/2024-09-06-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-06-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Cardano's core teams released node v.9.1.1 to fix replay issues in the Conway era and introduced a snapshot-converter for UTXO-HD. Governance for hardware wallets improved, Plutus advanced built-in functions, and Hydra enhanced network resilience. Mithril progressed decentralization, Voltaire emphasized community governance, and Catalyst focused on Fund12 onboarding. Education supported Plutus updates and prepared for Cardano Days events.

--- a/blog/2024-09-13-weekly-development-report/index.md
+++ b/blog/2024-09-13-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-13-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team introduced a Conway feature restricting reward withdrawals without DRep delegation post-bootstrap, fixed bugs, and improved testing. Performance benchmarks for node v.9.1.1 were released, setting a new baseline. Mithril advanced decentralization and transaction handling. Voltaire's committee applications are open, Catalyst prepped Fund13 categories, and Fund12 onboarding nears completion. Education updated 'Mastering Cardano' and prepared content for Cardano Days events.

--- a/blog/2024-09-16-community-digest/index.md
+++ b/blog/2024-09-16-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-16-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2024-09-16-community-digest/index.md
+++ b/blog/2024-09-16-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-16-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2024-09-19-media-real-worl-assets-cswap-imax-storm/index.md
+++ b/blog/2024-09-19-media-real-worl-assets-cswap-imax-storm/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-19-media-real-worl-assets-cswap-imax-storm
 title: "Roundtable Talk: Real World Assets, with Jon Kravetz, Tim Brückmann & Nicola Massella"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 In a Roundtable Talk, Jon Kravetz of CSWAP DEX, Tim Brückmann of IAMX, and Nicola Massella of STORM Partners discussed Real World Assets (RWAs) on Cardano. They explored the definition and types of RWAs, the benefits and legal challenges of tokenization, and fractional ownership models. The conversation also covered the role of tokenized assets and stablecoins within the DeFi ecosystem and the future use cases for bringing real-world value on-chain.

--- a/blog/2024-09-20-weekly-development-report/index.md
+++ b/blog/2024-09-20-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-20-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team optimized ledger snapshots, bandwidth, and UTXO-HD benchmarks. Plutus updated user documentation and contract blueprints. Hydra v.0.19.0 added Conway ledger support, while Mithril advanced decentralized signature orchestration. Intersect progressed the Chang upgrade, with elections ongoing. Catalyst previewed Fund13 in town hall 175, set to launch next week.

--- a/blog/2024-09-27-weekly-development-report/index.md
+++ b/blog/2024-09-27-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-27-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Cardano node v.9.1.1 resolved Conway-era replay issues. A snapshot-converter tool addressed UTXO-HD deserialization and memory leaks. Lace enhanced governance for hardware wallets, Plutus finalized functions for the next hard fork, and Hydra improved network resilience. Mithril advanced decentralization, Voltaire emphasized community governance, and Catalyst neared Fund12 onboarding completion. Education prepared for Cardano Days and supported Plutus Core updates.

--- a/blog/2024-09-30-community-digest/index.md
+++ b/blog/2024-09-30-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-30-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2024-09-30-community-digest/index.md
+++ b/blog/2024-09-30-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-09-30-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2024-10-04-weekly-development-report/index.md
+++ b/blog/2024-10-04-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-10-04-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team set performance goals, rebased UTXO-HD, and improved robustness. Plutus revamped user guides and submitted CIPs on arrays and maps. Hydra advanced incremental commits, Blockfrost integration, and tested Raft networking. Mithril decentralized signature orchestration and prepared for node v.9.2.1. Intersect held annual meetings, and Catalyst opened Fund13 proposals. Education prepped for Cardano Days in Santander and attended the Constitution event in Oslo.

--- a/blog/2024-10-11-weekly-development-report/index.md
+++ b/blog/2024-10-11-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-10-11-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The DB Sync team resolved off-chain data issues and improved memory management. Node v.9.2 benchmarks advanced, and cardano-tracer-0.3 was released. Mithril progressed decentralization, and Intersect elections close October 20. Chang #2 hard fork planning aligns with CIP-1694. Catalyst Fund13 submissions finalize with reviews ongoing. Community contributions to Cardano core rose to 45.97%. The education team preps for the Cardano Summit in Argentina and December constitution events.

--- a/blog/2024-10-14-community-digest/index.md
+++ b/blog/2024-10-14-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-10-14-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2024-10-14-community-digest/index.md
+++ b/blog/2024-10-14-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-10-14-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2024-10-16-media-cardano-community-events-digi-atrium-hosky/index.md
+++ b/blog/2024-10-16-media-cardano-community-events-digi-atrium-hosky/index.md
@@ -2,7 +2,7 @@
 slug: 2024-10-16-media-cardano-community-events-digi-atrium-hosky
 title: "Roundtable Talk: Cardano Community Events with Big Pey, Farid, Hosky and Rick McCracken"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk on October 16, 2024, featured a discussion on Cardano Community Events with Big Pey (Atrium Lab), Farid (Dapp Central), Hosky (ICC/DRep), and Rick McCracken (SPO). The live event focused on the importance, organization, and impact of community-led initiatives. It was part of an ongoing series designed to empower community members and foster meaningful dialogue on key ecosystem topics.

--- a/blog/2024-10-18-weekly-development-report/index.md
+++ b/blog/2024-10-18-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-10-18-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team released updated packages, improved IOSim, and reduced header clock skew. The ledger team added protections against deposit loss, updated delegation rules, and refined SPO vote thresholds. Plutus enhanced user guides, Hydra progressed incremental commits with Aiken integration, and Mithril prepared for the Pythagoras era. Intersect elections and Chang #2 upgrade planning continue. The education team held a Madrid meetup and preps for the Cardano Summit in Argentina.

--- a/blog/2024-10-25-media-cardano-summit-2024-day1/index.md
+++ b/blog/2024-10-25-media-cardano-summit-2024-day1/index.md
@@ -2,7 +2,7 @@
 slug: 2024-10-25-media-cardano-summit-2024-day1
 title: "Cardano Summit 2024 - Day 1 Highlights"
 authors: [cf]
-tags: [media, summit, events]
+tags: [events, ecosystem]
 ---
 
 An amazing first day at the Cardano Summit 2024 in Dubai! Keynotes: Unveiling the latest in blockchain innovation and envisioning Cardano’s future. Panels: Delving into real-world applications with insights from industry leaders and experts. Cardano Market: Exploring groundbreaking projects, startups, and connecting with the vibrant Cardano community. Community: Meeting passionate people from all corners of the world, exchanging ideas and experiences.

--- a/blog/2024-10-25-weekly-development-report/index.md
+++ b/blog/2024-10-25-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-10-25-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team finalized protocol 10.0 changes, advanced Conway testing, and refined conformance tests. Performance benchmarking for node v.10.0 began, and Mithril released distribution 2442.0, supporting the Pythagoras era with enhanced metrics. Intersect completed elections, onboarding new members in late October. Catalyst Fund13 entered community review, nearing 1,000 completed projects. The education team supported the Cardano Summit in Argentina and updated the 'Mastering Cardano' book.

--- a/blog/2024-10-26-media-cardano-summit-2024-day2/index.md
+++ b/blog/2024-10-26-media-cardano-summit-2024-day2/index.md
@@ -2,7 +2,7 @@
 slug: 2024-10-26-media-cardano-summit-2024-day2
 title: "Cardano Summit 2024 - Day 2 Highlights"
 authors: [cf]
-tags: [media, summit, events]
+tags: [events, ecosystem]
 ---
 
 Explore the highlights, major announcements, and engaging discussions from day two of the Cardano Summit 2024.

--- a/blog/2024-11-01-weekly-development-report/index.md
+++ b/blog/2024-11-01-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-01-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The core technology teams released node v.10.1.1 for the Chang #2 upgrade, enhancing governance with SPO delegation and auto-abstain DRep votes. Lace v.1.17 introduced shared wallets in beta. Plutus conducted end-to-end testing for new primitives, and Hydra advanced incremental commits and on-chain validators. Mithril released CIP-137 for decentralized message queues and added Prometheus-based metrics.

--- a/blog/2024-11-08-weekly-development-report/index.md
+++ b/blog/2024-11-08-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-08-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The core technology teams released node v.10.1.2, while DB Sync v.13.6.0.0 nears mainnet testing. The ledger team improved code quality and added stake pool vote queries. Performance benchmarks advanced decentralized submission via `cardano-cli`. Mithril pre-released distribution 2445.0-pre and explored signer registration solutions. Voltaire refined node v.10.1.2, Catalyst celebrated 1,000+ completed projects, and voter registration continues, with Catalyst Voices focusing on core improvements.

--- a/blog/2024-11-11-community-digest/index.md
+++ b/blog/2024-11-11-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-11-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2024-11-11-community-digest/index.md
+++ b/blog/2024-11-11-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-11-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2024-11-15-weekly-development-report/index.md
+++ b/blog/2024-11-15-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-15-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The core technology teams assessed Ouroboros Leios feasibility and integrated `ouroboros-network` for Mithril. Non-P2P support will end post-next hard fork. The consensus team reviewed UTXO-HD and hard fork combinator updates, while Plutus advanced compilation tools and ScriptContext API. Mithril released distribution 2445.0, supporting node v.10.1. Hydra progressed on incremental commits and validator rewrites. Intersect's budget committee prepares Cardano treasury allocations for 2025.

--- a/blog/2024-11-22-weekly-development-report/index.md
+++ b/blog/2024-11-22-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-22-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The core technology teams released components compatible with the latest Cardano node, including DB Sync and Cardano wallet updates. The ledger team shared the ImpSpec framework, while performance teams enhanced benchmarking and locli analysis. Mithril prepared for the Pythagoras era, and Hydra's Doom tournament qualifiers start December 3. The Constitutional Convention will vote on the Cardano constitution, and the community may rename Chang #2 to the Plomin hard fork.

--- a/blog/2024-11-25-media-cardano-constitution-draft/index.md
+++ b/blog/2024-11-25-media-cardano-constitution-draft/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-25-media-cardano-constitution-draft
 title: "Roundtable Talk: Cardano Constitution Draft"
 authors: [community]
-tags: [ecosystem]
+tags: [governance]
 ---
 
 A Roundtable Talk, streamed live on November 25, 2024, featured a discussion on the drafts of the Cardano Constitution. Key ecosystem actors delved into the document's core ideas and its role in guiding community governance. The conversation served as a constructive forum to share insights and align on the community's vision ahead of the subsequent ratification process in Buenos Aires.

--- a/blog/2024-11-25-media-cardano-constitution-draft/index.md
+++ b/blog/2024-11-25-media-cardano-constitution-draft/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-25-media-cardano-constitution-draft
 title: "Roundtable Talk: Cardano Constitution Draft"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk, streamed live on November 25, 2024, featured a discussion on the drafts of the Cardano Constitution. Key ecosystem actors delved into the document's core ideas and its role in guiding community governance. The conversation served as a constructive forum to share insights and align on the community's vision ahead of the subsequent ratification process in Buenos Aires.

--- a/blog/2024-11-26-community-digest/index.md
+++ b/blog/2024-11-26-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-26-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2024-11-26-community-digest/index.md
+++ b/blog/2024-11-26-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-26-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2024-11-29-weekly-development-report/index.md
+++ b/blog/2024-11-29-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-11-29-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team refined Praos documentation and addressed chain growth violations. DB Sync v.13.6.0.2 improved rollbacks, Lace v.1.17.5 enhanced syncing, and Hydra advanced API filtering. Mithril introduced a one-line installer and new certifications. Catalyst Fund13 voting began on November 28, and the Constitutional Convention on December 4–6 will address the Cardano constitution. A proposal suggests renaming Chang #2 to the Plomin hard fork.

--- a/blog/2024-12-04-media-cardano-constitutional-convention-delegate-discussions/index.md
+++ b/blog/2024-12-04-media-cardano-constitutional-convention-delegate-discussions/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-04-media-cardano-constitutional-convention-delegate-discussions
 title: "Cardano Constitutional Convention 2024 - Day 1 Delegate Discussions"
 authors: [intersect]
-tags: [media, governance, events]
+tags: [governance, events, ecosystem]
 ---
 
 The Cardano Constitutional Convention began with global participants collaborating to shape the ecosystem’s governance principles. Delegates in Nairobi and Buenos Aires engaged in thoughtful discussions to refine the draft constitution, balancing ideals of decentralization, inclusivity, and practicality. Keynotes from Charles Hoskinson and Dr. Silvia Nonna inspired a shared vision for Cardano’s future, setting the stage for a pivotal weekend in blockchain governance.

--- a/blog/2024-12-05-media-cardano-constitutional-convention-delegate-voting/index.md
+++ b/blog/2024-12-05-media-cardano-constitutional-convention-delegate-voting/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-05-media-cardano-constitutional-convention-delegate-voting
 title: "Cardano Constitutional Convention 2024 - Day 2 Delegate Voting"
 authors: [intersect]
-tags: [media, governance, events]
+tags: [governance, events, ecosystem]
 ---
 
 Day 2 marked a historic moment as delegates concluded their discussions and participated in the voting process on the Cardano constitution. Key decisions were made through transparent, democratic deliberation, culminating in a voting ceremony that underscored the community's collective commitment to decentralized governance. The day's outcome highlighted the unity and determination of Cardano’s global ecosystem.

--- a/blog/2024-12-06-media-cardano-constitutional-convention-signing-ceremony/index.md
+++ b/blog/2024-12-06-media-cardano-constitutional-convention-signing-ceremony/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-06-media-cardano-constitutional-convention-signing-ceremony
 title: "Cardano Constitutional Convention 2024 - Day 3 Signing Ceremony"
 authors: [iog]
-tags: [media, governance, events]
+tags: [governance, events, ecosystem]
 ---
 
 The final day celebrated the signing of the Cardano constitution, a milestone in decentralized governance. The event featured a governance exhibition and media highlights. Delegates formalized the constitution, symbolizing Cardano’s commitment to transparent and inclusive decision-making. The day concluded with a sense of accomplishment, paving the way for a resilient and decentralized future.

--- a/blog/2024-12-06-weekly-development-report/index.md
+++ b/blog/2024-12-06-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-06-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The SRE team released Cardano node v.10.1.3 and DB Sync updates, improving mainnet bootstraps and dashboards. The ledger team fixed a bug in protocol version 10 and added a query for DRep voting stake distribution. Mithril advanced incremental certification and enhanced certificate verification. The Constitutional Convention in Buenos Aires and Nairobi ratified a new Cardano constitution. Catalyst Fund13 voting continues until December 12, with over 1.5 billion ada in voting power. The education team held Cardano Days sessions and demonstrated live node use with a mobile SPO learning lab.

--- a/blog/2024-12-11-community-digest/index.md
+++ b/blog/2024-12-11-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-11-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2024-12-11-community-digest/index.md
+++ b/blog/2024-12-11-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-11-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2024-12-13-weekly-development-report/index.md
+++ b/blog/2024-12-13-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-13-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The December 13, 2024, development report concludes the year, with updates resuming January 10, 2025. The networking team, in collaboration with the Cardano Foundation, noted 98.4% of transactions are included within two blocks, showing minimal congestion. The consensus team advanced UTXO-HD and reviewed low participation handling. Daedalus v.7.0.2 launched, enabling users to delegate voting power to DReps or select automatic voting options, enhancing governance participation.

--- a/blog/2024-12-17-media-catalyst13-large-voters-defi-protocols/index.md
+++ b/blog/2024-12-17-media-catalyst13-large-voters-defi-protocols/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-17-media-catalyst13-large-voters-defi-protocols
 title: "Roundtable Talk: Large Voters and DeFi Protocols in Catalyst F13"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk on December 17, 2024, explored the role of large voters and DeFi protocols in Project Catalyst F13. The discussion featured insights on how major stakeholders like Minswap, Liqwid, and the Cardano Foundation evaluate and vote on proposals. It delved into the challenges and impact of stake-based governance and DeFi protocols borrowing voting power, examining the lessons shaping Cardano's one-ada-one-vote framework.

--- a/blog/2024-12-17-media-catalyst13-large-voters-defi-protocols/index.md
+++ b/blog/2024-12-17-media-catalyst13-large-voters-defi-protocols/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-17-media-catalyst13-large-voters-defi-protocols
 title: "Roundtable Talk: Large Voters and DeFi Protocols in Catalyst F13"
 authors: [community]
-tags: [ecosystem]
+tags: [governance]
 ---
 
 A Roundtable Talk on December 17, 2024, explored the role of large voters and DeFi protocols in Project Catalyst F13. The discussion featured insights on how major stakeholders like Minswap, Liqwid, and the Cardano Foundation evaluate and vote on proposals. It delved into the challenges and impact of stake-based governance and DeFi protocols borrowing voting power, examining the lessons shaping Cardano's one-ada-one-vote framework.

--- a/blog/2024-12-23-community-digest/index.md
+++ b/blog/2024-12-23-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-23-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2024-12-23-community-digest/index.md
+++ b/blog/2024-12-23-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2024-12-23-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-01-05-merkle-patricia-tries/index.md
+++ b/blog/2025-01-05-merkle-patricia-tries/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-05-merkle-patricia-tries
 title: "Merkle Patricia Tries: A Deep Dive into Data Structure Security"
 authors: [cf]
-tags: [education, ]
+tags: [education]
 ---
 
 Merkle Patricia Tries (MPTs) are advanced data structures that enhance blockchain efficiency and security by enabling rapid verification and modification of data entries. They combine the benefits of tries, Patricia tries, and Merkle trees to allow efficient addition, deletion, and verification of key-value pairs, ensuring data integrity. MPTs are fundamental in decentralized networks, supporting dynamic data storage and secure transaction processing.

--- a/blog/2025-01-06-community-digest/index.md
+++ b/blog/2025-01-06-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-06-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-01-06-community-digest/index.md
+++ b/blog/2025-01-06-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-06-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-01-08-six-reasons-why-eutxo-wins/index.md
+++ b/blog/2025-01-08-six-reasons-why-eutxo-wins/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-08-six-reasons-why-eutxo-wins
 title: "Six reasons why EUTXO wins"
 authors: [iog]
-tags: [education, research]
+tags: [research, education]
 ---
 
 Cardano's EUTXO model provides six key benefits over account-based systems: predictable transactions, ensuring no fees for failed transactions; predictable costs, allowing accurate calculation of fees and resources; enhanced concurrency for simultaneous transaction processing; improved security through determinism and reduced attack vectors; flexibility for innovative decentralized applications; and compatibility with zero-knowledge proofs, enabling complex off-chain computations with verifiable on-chain results. These advantages make EUTXO a scalable, secure, and versatile framework for blockchain applications. For more, read the full article.

--- a/blog/2025-01-10-weekly-development-report/index.md
+++ b/blog/2025-01-10-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-10-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Cardano node v.10.1.4 has been released, featuring mempool safeguards in preparation for the Plomin hard fork. The consensus team improved time management and block-fetch synchronization, while Plutus Core is finalizing the data-backed ScriptContext API to enhance script performance. Hydra has advanced incremental commits and explorer support, and Mithril released distribution 2450.0 to support node v.10.1.3.

--- a/blog/2025-01-17-presenting-the-yaci-devkit/index.md
+++ b/blog/2025-01-17-presenting-the-yaci-devkit/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-17-presenting-the-yaci-devkit
 title: "Presenting the yaci-devkit"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 This 12th installment of the Cardano Developer Office Hours is presented by Satya Ranjan, Senior Enterprise Architect at the Cardano Foundation. In this session, Satya discusses how the yaci-devkit simplifies building and testing on a local Cardano dev network, helping developers iterate faster and avoid public testnet limitations. The session highlights key features such as customizable block times, integrated tools, and Blockfrost-compatible APIs. A live demo shows easy setup using Docker and NPM distributions.

--- a/blog/2025-01-17-presenting-the-yaci-devkit/index.md
+++ b/blog/2025-01-17-presenting-the-yaci-devkit/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-17-presenting-the-yaci-devkit
 title: "Presenting the yaci-devkit"
 authors: [cf]
-tags: [ecosystem]
+tags: [development]
 ---
 
 This 12th installment of the Cardano Developer Office Hours is presented by Satya Ranjan, Senior Enterprise Architect at the Cardano Foundation. In this session, Satya discusses how the yaci-devkit simplifies building and testing on a local Cardano dev network, helping developers iterate faster and avoid public testnet limitations. The session highlights key features such as customizable block times, integrated tools, and Blockfrost-compatible APIs. A live demo shows easy setup using Docker and NPM distributions.

--- a/blog/2025-01-17-weekly-development-report/index.md
+++ b/blog/2025-01-17-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-17-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The January 17, 2025, development report focuses on final preparations for the Plomin hard fork, including bug fixes and code simplifications. Stake pool operators are urged to upgrade to node v.10.1.4. Lace v.1.18.2 improved crash recovery and fixed CIP-95 bugs. Mithril certified stake distribution on the mainnet and upgraded to node v.10.1.4. The Ouroboros Leios project progressed simulations to enhance network throughput. Voting for the Plomin hard fork continues.

--- a/blog/2025-01-20-community-digest/index.md
+++ b/blog/2025-01-20-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-20-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-01-20-community-digest/index.md
+++ b/blog/2025-01-20-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-20-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-01-23-explainer-the-plomin-hard-fork/index.md
+++ b/blog/2025-01-23-explainer-the-plomin-hard-fork/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-23-explainer-the-plomin-hard-fork
 title: "Explainer: The Plomin Hard Fork"
 authors: [emurgo]
-tags: [education, governance]
+tags: [governance, education]
 ---
 
 The Plomin hard fork is a key upgrade for Cardano, enabling full decentralized governance under the Voltaire era. It allows ada holders to delegate voting power to DReps for decisions on protocol updates, treasury withdrawals, and hard forks. SPOs must upgrade their nodes and achieve a 51% majority vote for activation. With 78% of nodes upgraded as of January 22, 2025, Plomin marks a milestone for community-driven control.

--- a/blog/2025-01-24-weekly-development-report/index.md
+++ b/blog/2025-01-24-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-24-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The January 24, 2025, development report highlights consensus team progress on security, documentation, and Peras workstream improvements. The UTXO-HD branch achieved successful local chain synchronization. The performance team benchmarked node v.10.1.4 and introduced a tracing Discord channel. Plutus added the `Fix` construct and CLI tool guides. Hydra completed custom ledger experiments and restored `hydra-explorer`. Mithril advanced incremental database certification. The Leios team benchmarked efficient VRF cryptography.

--- a/blog/2025-01-29-whats-next-for-cardano/index.md
+++ b/blog/2025-01-29-whats-next-for-cardano/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-29-whats-next-for-cardano
 title: "What's next for Cardano?"
 authors: [iog]
-tags: [education, research]
+tags: [research, education]
 ---
 
 Cardano is transitioning into a community-governed blockchain, emphasizing scalability, usability, and interoperability. The roadmap focuses on advanced scaling solutions like Hydra state channels, layer 2 rollups, and the Ouroboros Leios and Peras protocols to support billions of users by 2030. Enhancements in usability aim to improve the developer experience and broaden decentralized application capabilities. Interoperability efforts include integrating partner chains and sidechains to foster a diverse ecosystem. Community involvement is crucial in shaping this future.

--- a/blog/2025-01-30-chang-upgrade-completed/index.md
+++ b/blog/2025-01-30-chang-upgrade-completed/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-30-chang-upgrade-completed
 title: "Chang upgrade completed - Plomin hard fork achieved!"
 authors: [intersect]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-01-30-media-celebrating-plomin-hard-fork/index.md
+++ b/blog/2025-01-30-media-celebrating-plomin-hard-fork/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-30-media-celebrating-plomin-hard-fork
 title: "Roundtable Talk: Celebrating Plomin Hard Fork"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk on January 30, 2025, celebrated the Plomin Hard Fork, a milestone marking the full realization of decentralized governance in Cardano's Voltaire era. Key stakeholders gathered to discuss the significance of this achievement and reflect on the network's journey from Byron to Voltaire. The session explored the new opportunities for community-driven innovation and ecosystem growth unlocked by the decentralized treasury and on-chain governance framework.

--- a/blog/2025-01-31-weekly-development-report/index.md
+++ b/blog/2025-01-31-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-01-31-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The January 31, 2025, development report highlights the successful implementation of the Plomin hard fork, marking the completion of the Conway ledger era. The ledger team made minor improvements, including removing dependencies and optimizing data structures. The Lace team released version 1.19.0, introducing a DApp explorer and performance enhancements. The Mithril team progressed on incremental certification of the Cardano database and prepared for the upcoming 'Pythagoras' era transition. The Leios team advanced both Haskell and Rust implementations to enhance performance and simulation fidelity.

--- a/blog/2025-02-04-community-digest/index.md
+++ b/blog/2025-02-04-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-04-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-02-04-community-digest/index.md
+++ b/blog/2025-02-04-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-04-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-02-05-java-implementation-on-rosetta/index.md
+++ b/blog/2025-02-05-java-implementation-on-rosetta/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-05-java-implementation-on-rosetta
 title: "Java Implementation on Rosetta"
 authors: [cf]
-tags: [ecosystem]
+tags: [development]
 ---
 
 This 13th installment of the Cardano Developer Office Hours is presented by Thomas Kammerlocher, Senior Full Stack Developer at the Cardano Foundation. Thomas discusses the Java implementation of Rosetta, a tool developed by Coinbase for exchanges to integrate with Cardano. Rosetta simplifies multi-chain support with its blockchain-agnostic API, and the transition from TypeScript to Java enhances performance and reduces resource consumption. Upcoming updates include support for staking rewards tracking, off-chain data integration, and more improvements to scalability and efficiency.

--- a/blog/2025-02-05-java-implementation-on-rosetta/index.md
+++ b/blog/2025-02-05-java-implementation-on-rosetta/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-05-java-implementation-on-rosetta
 title: "Java Implementation on Rosetta"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 This 13th installment of the Cardano Developer Office Hours is presented by Thomas Kammerlocher, Senior Full Stack Developer at the Cardano Foundation. Thomas discusses the Java implementation of Rosetta, a tool developed by Coinbase for exchanges to integrate with Cardano. Rosetta simplifies multi-chain support with its blockchain-agnostic API, and the transition from TypeScript to Java enhances performance and reduces resource consumption. Upcoming updates include support for staking rewards tracking, off-chain data integration, and more improvements to scalability and efficiency.

--- a/blog/2025-02-07-weekly-development-report/index.md
+++ b/blog/2025-02-07-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-07-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The network has benchmarked node v.10.2, alongside UTXO-HD and Genesis performance updates. The consensus team removed EBBs and fixed block replay issues, while the Plutus team rebranded Plutus Tx to Plinth and refined the script context API. Hydra v.0.20.0 improved memory usage, and Mithril prepared for the Pythagoras era at epoch 539. Additionally, the Leios team enhanced efficiency by reducing certificate sizes.

--- a/blog/2025-02-11-serial-monopoly-blockchain/index.md
+++ b/blog/2025-02-11-serial-monopoly-blockchain/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-11-serial-monopoly-blockchain
 title: "Serial Monopoly on Blockchain with Quasi-patient Users"
 authors: [cf]
-tags: [education,research ]
+tags: [research, education]
 ---
 
 The Cardano Foundation's recent research paper, "Serial Monopoly on Blockchain with Quasi-Patient Users," co-authored with IOG Research, examines transaction fee mechanisms and their influence on validator incentives. Accepted for presentation at the 29th International Financial Cryptography and Data Security 2025 conference, the study introduces a model bridging impatient and patient users, termed "quasi-patient" users. This approach analyzes how users' varying tolerance for transaction delays impacts fee strategies and blockchain security, offering insights into optimizing transaction fee mechanisms to balance cost efficiency and timely inclusion.

--- a/blog/2025-02-14-inter-blockchain-communication/index.md
+++ b/blog/2025-02-14-inter-blockchain-communication/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-14-inter-blockchain-communication
 title: "Inter-Blockchain Communication"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 This installment of the Cardano Developer Office Hours explores the Cosmos-Cardano Inter-Blockchain Communication (IBC) bridge project. The session provides an overview of the architecture, current development, and key components driving the project. Topics include the IBC protocol, blockchain interoperability, and the integration of Cosmos SDK with Cardano. A live demo showcases how to send messages between the Cosmos network and a local Cardano node. The session also covers real-world use cases like token transfers, cross-chain swaps, and more.

--- a/blog/2025-02-14-inter-blockchain-communication/index.md
+++ b/blog/2025-02-14-inter-blockchain-communication/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-14-inter-blockchain-communication
 title: "Inter-Blockchain Communication"
 authors: [cf]
-tags: [ecosystem]
+tags: [development]
 ---
 
 This installment of the Cardano Developer Office Hours explores the Cosmos-Cardano Inter-Blockchain Communication (IBC) bridge project. The session provides an overview of the architecture, current development, and key components driving the project. Topics include the IBC protocol, blockchain interoperability, and the integration of Cosmos SDK with Cardano. A live demo showcases how to send messages between the Cosmos network and a local Cardano node. The session also covers real-world use cases like token transfers, cross-chain swaps, and more.

--- a/blog/2025-02-14-weekly-development-report/index.md
+++ b/blog/2025-02-14-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-14-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ecosystem has reached 1,985 projects, 10.68 million native tokens, and 106.19 million transactions. The ledger team optimized Plutus script computations, reducing memory usage for better performance. Mithril activated the 'Pythagoras' era at epoch 539, advancing incremental database certification. Leios focused on cryptography benchmarking, while the interim council voted to officially adopt the Cardano Constitution.

--- a/blog/2025-02-17-cardano-economic-parameters/index.md
+++ b/blog/2025-02-17-cardano-economic-parameters/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-17-cardano-economic-parameters
 title: "A Deep Dive into Cardano’s Economic Parameters"
 authors: [cf]
-tags: [education,research ]
+tags: [research, education]
 ---
 
 The Cardano Foundation released the "Cardano Economic Parameters" whitepaper by Professor Massimo Morini, analyzing how parameters like k (desired pool count) and a₀ (pledge influence) shape stake pool rewards. It explores the impact of pool size, pledge, and ecosystem reserves while clarifying reserve distribution between rewards and the treasury. The paper provides insights for stake pool operators and governance participants to support informed decision-making on Cardano’s long-term sustainability.

--- a/blog/2025-02-17-community-digest/index.md
+++ b/blog/2025-02-17-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-17-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-02-17-community-digest/index.md
+++ b/blog/2025-02-17-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-17-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-02-21-weekly-development-report/index.md
+++ b/blog/2025-02-21-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-21-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 

--- a/blog/2025-02-25-media-cardano-budget-process/index.md
+++ b/blog/2025-02-25-media-cardano-budget-process/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-25-media-cardano-budget-process
 title: "Roundtable Talk: Cardano Budgeting Process"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk on February 25, 2025, focused on the Cardano budgeting process and the implications of the proposed Net Change Limit. The session aimed to educate the community on this treasury governance mechanism, which sets a yearly withdrawal cap. Experts discussed the risks of allocating budgets without a predefined limit and fostered an open discussion to empower community members in shaping structured and sustainable on-chain financial governance.

--- a/blog/2025-02-25-media-cardano-budget-process/index.md
+++ b/blog/2025-02-25-media-cardano-budget-process/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-25-media-cardano-budget-process
 title: "Roundtable Talk: Cardano Budgeting Process"
 authors: [community]
-tags: [ecosystem]
+tags: [governance]
 ---
 
 A Roundtable Talk on February 25, 2025, focused on the Cardano budgeting process and the implications of the proposed Net Change Limit. The session aimed to educate the community on this treasury governance mechanism, which sets a yearly withdrawal cap. Experts discussed the risks of allocating budgets without a predefined limit and fostered an open discussion to empower community members in shaping structured and sustainable on-chain financial governance.

--- a/blog/2025-02-28-presenting-reeve/index.md
+++ b/blog/2025-02-28-presenting-reeve/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-28-presenting-reeve
 title: "Presenting Reeve"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 This installment of the Cardano Developer Office Hours explores Reeve, a next-generation accountability tool for delivering tamper-proof and transparent financial insights. Reeve integrates traditional accounting systems with blockchain technology, ensuring transparency, immutability, and security for financial records. Built on Cardano, the platform offers a decentralized approach to financial data management. Designed for accountants, auditors, non-profits, and enterprises, Reeve helps streamline audits, improve efficiency, and build trust in financial processes. The session provides an overview of the project, its architecture, and current development.

--- a/blog/2025-02-28-weekly-development-report/index.md
+++ b/blog/2025-02-28-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-02-28-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights Cardano’s growth, with 1,987 projects building on the network, 1.324 million delegated wallets, and 10.70 million native tokens issued. Smart contracts expanded to 127,114 Plutus scripts, and on-chain transactions grew to 108.80 million. Governance engagement remains strong with 1,147 DReps. Iagon and Andamio Platform joined the Cardano Foundation’s Venture Hub, Carlos Souza introduced ‘Xander,’ an Elixir library for node connections, and Butane Synthetics is launching Cardano’s first distributed, fault-resistant oracle.

--- a/blog/2025-03-04-advantages-blockchains-for-enterprises/index.md
+++ b/blog/2025-03-04-advantages-blockchains-for-enterprises/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-04-advantages-blockchains-for-enterprises
 title: "Advantages of Public Blockchains for Enterprises"
 authors: [cf]
-tags: [education,research ]
+tags: [research, education]
 ---
 
 Public blockchains offer enterprises transparency, security, and decentralization, reducing reliance on intermediaries while ensuring data integrity. They enhance trust through verifiable transactions, improve efficiency by automating processes with smart contracts, and enable interoperability for seamless data exchange. Unlike private blockchains, public networks provide broader security through decentralized validation. These benefits make public blockchains an ideal choice for businesses seeking innovation, cost efficiency, and greater trust in their operations.

--- a/blog/2025-03-04-advantages-blockchains-for-enterprises/index.md
+++ b/blog/2025-03-04-advantages-blockchains-for-enterprises/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-04-advantages-blockchains-for-enterprises
 title: "Advantages of Public Blockchains for Enterprises"
 authors: [cf]
-tags: [research, education]
+tags: [education]
 ---
 
 Public blockchains offer enterprises transparency, security, and decentralization, reducing reliance on intermediaries while ensuring data integrity. They enhance trust through verifiable transactions, improve efficiency by automating processes with smart contracts, and enable interoperability for seamless data exchange. Unlike private blockchains, public networks provide broader security through decentralized validation. These benefits make public blockchains an ideal choice for businesses seeking innovation, cost efficiency, and greater trust in their operations.

--- a/blog/2025-03-04-community-digest/index.md
+++ b/blog/2025-03-04-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-04-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-03-04-community-digest/index.md
+++ b/blog/2025-03-04-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-04-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-03-07-weekly-development-report/index.md
+++ b/blog/2025-03-07-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-07-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The March 7, 2025, development report highlights 1,988 projects on Cardano, 1.326 million delegated wallets, and 10.71 million native tokens. Smart contracts grew to 127,578 Plutus scripts, with 107.21 million on-chain transactions. Governance expanded to 1,185 DReps, including 905 active. Updates include Begin wallet’s DRep delegation, USDM’s beta launch, Emurgo’s DRep registration, Intersect’s roadmap proposal, the Cardano Foundation running nodes for Oraclecharli3 and Orcfax, and a five-week builder residency in Silicon Valley with Draper University.

--- a/blog/2025-03-14-weekly-development-report/index.md
+++ b/blog/2025-03-14-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-14-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights 1.327 million delegated wallets, 10.71 million native tokens, and 129,108 Plutus scripts. On-chain transactions reached 107.52 million, with governance engagement growing to 1,205 DReps. The Hoskinson Family Office invested $1.5 million in W3i Software, Cardano won Blockchain Project of the Year at Crypto Expo EU, and Sebastien Guillemot introduced Starstream, a zkVM for UTXO smart contracts. Lace integrated with Wanchain Bridge, and Mithril advanced aggregator prototypes. The performance team enhanced benchmarking, while the ledger team focused on serialization improvements.

--- a/blog/2025-03-17-community-digest/index.md
+++ b/blog/2025-03-17-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-17-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-03-17-community-digest/index.md
+++ b/blog/2025-03-17-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-17-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-03-21-weekly-development-report/index.md
+++ b/blog/2025-03-21-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-21-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report highlights Cardano’s growth with 1.328 million delegated wallets, 10.72 million native tokens, and 130,507 Plutus scripts. On-chain transactions reached 107.98 million. Governance participation expanded to 1,215 DReps. Notable updates include new Ouroboros Genesis simulations, Lace's integration with USDM for payments, and Mithril’s progress on aggregator resilience. The Hydra team released version 0.21.0, focusing on improved data handling. Cardano Foundation's Venture Hub welcomed new members, including Yolo Finance and Metaverse Labs.

--- a/blog/2025-03-24-java-tooling-dapps/index.md
+++ b/blog/2025-03-24-java-tooling-dapps/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-24-java-tooling-dapps
 title: "Java Tooling for dApps Development"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 Satya Ranjan, Lead Blockchain Architect at the Cardano Foundation, presents Java tools for building on Cardano. The session covers cardano-client-lib, writing off-chain code, building transactions, and integrating governance and staking. Satya also demos Yaci DevKit for local dev environments, Yaci Store for indexing, and shows how to build lightweight apps using tailored data. Ideal for developers and exchanges exploring Java’s role in Cardano infrastructure.

--- a/blog/2025-03-25-introduction-pos-blockchain-systems/index.md
+++ b/blog/2025-03-25-introduction-pos-blockchain-systems/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-25-introduction-pos-blockchain-systems
 title: "An Introduction to Proof of Stake Blockchain Systems"
 authors: [cf]
-tags: [education,research ]
+tags: [research, education]
 ---
 
 The article "An Introduction to Proof of Stake Blockchain Systems" from the Cardano Foundation explains how proof-of-stake (PoS) consensus mechanisms offer a more energy-efficient and decentralized alternative to proof-of-work (PoW) systems. In PoS, validators are selected based on the amount of cryptocurrency they hold and are willing to "stake" as collateral, reducing the need for energy-intensive computations. The article discusses various PoS models, including Cardano's Ouroboros protocol, which uses a verifiable random function to ensure fairness and security. It also highlights how different PoS systems balance decentralization, security, and scalability to meet diverse blockchain needs. 

--- a/blog/2025-03-28-ecosystem-engineering/index.md
+++ b/blog/2025-03-28-ecosystem-engineering/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-28-ecosystem-engineering
 title: "Cardano Ecosystem Engineering"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 Giovanni Gargiulo, Senior Software Engineer at the Cardano Foundation, shares how ecosystem engineering supports Cardano’s growth. The session covers DevOps practices behind scalability, security, and uptime, along with challenges of running decentralized infrastructure. Giovanni also touches on infrastructure evolution, global adoption, and what’s ahead for Cardano engineering.

--- a/blog/2025-03-28-weekly-development-report/index.md
+++ b/blog/2025-03-28-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-28-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The March 28, 2025, development report highlights Cardano’s growth with 1.329 million delegated wallets, 10.73 million native tokens, and 131,200 Plutus scripts. On-chain transactions reached 108.35 million. Governance participation includes 1,220 DReps. Notable updates include Lace's release of version 1.21.0, Hydra's advancements in multi-party state channels, and Mithril's work on enhanced aggregator decentralization. The Cardano Foundation continues expanding its Venture Hub, onboarding projects like BlockSmith Labs and GreenChain.

--- a/blog/2025-03-31-community-digest/index.md
+++ b/blog/2025-03-31-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-31-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-03-31-community-digest/index.md
+++ b/blog/2025-03-31-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-03-31-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-04-04-weekly-development-report/index.md
+++ b/blog/2025-04-04-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-04-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights Cardano’s continued growth, with 1,991 projects building on the network, 1.329 million delegated wallets, and 10.77 million native tokens issued. Smart contracts reached 130,036 Plutus scripts, and on-chain transactions totaled 108.10 million. Governance engagement expanded to 1,230 DReps, including 927 active. Notable updates include Input Output's participation in Paris Blockchain Week, Turn Protocol's public testnet launch for privacy DeFi, LCX's submission of the first MiCA-compliant white paper for Cardano, and the upcoming release of Cexplorer 2.0 with a new backend and refreshed design.

--- a/blog/2025-04-08-understanding-net-change-limit/index.md
+++ b/blog/2025-04-08-understanding-net-change-limit/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-08-understanding-net-change-limit
 title: "Understanding Cardano’s Net Change Limit"
 authors: [cf]
-tags: [research, education]
+tags: [education]
 ---
 
 The Cardano Foundation published an article explaining the Net Change Limit (NCL), a constitutional parameter within Cardano's governance framework. The NCL defines the maximum amount of ada that can be withdrawn from the treasury over a specific period, typically annually. This mechanism serves as a crucial safeguard for fiscal responsibility and long-term treasury sustainability, balancing ecosystem funding needs with monetary stability. Ratification of the NCL via DRep vote is a required step before budget proposals and treasury withdrawals can proceed.

--- a/blog/2025-04-08-understanding-net-change-limit/index.md
+++ b/blog/2025-04-08-understanding-net-change-limit/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-08-understanding-net-change-limit
 title: "Understanding Cardano’s Net Change Limit"
 authors: [cf]
-tags: [education,research ]
+tags: [research, education]
 ---
 
 The Cardano Foundation published an article explaining the Net Change Limit (NCL), a constitutional parameter within Cardano's governance framework. The NCL defines the maximum amount of ada that can be withdrawn from the treasury over a specific period, typically annually. This mechanism serves as a crucial safeguard for fiscal responsibility and long-term treasury sustainability, balancing ecosystem funding needs with monetary stability. Ratification of the NCL via DRep vote is a required step before budget proposals and treasury withdrawals can proceed.

--- a/blog/2025-04-11-ouroboros-peras/index.md
+++ b/blog/2025-04-11-ouroboros-peras/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-11-ouroboros-peras
 title: "Ouroboros Peras: accelerating transaction settlement on Cardano"
 authors: [iog]
-tags: [development, Ouroboros]
+tags: [development, research]
 ---
 
 IOG introduces Ouroboros Peras, an upgrade to the Ouroboros Praos protocol aimed at accelerating transaction settlement on Cardano. Peras reduces settlement times to around two minutes, increasing confidence in transaction finality. It introduces a voting-based chain selection process and certificate system to reach rapid consensus while maintaining security and decentralization. This advancement supports Cardano’s scalability and responsiveness to network demands.

--- a/blog/2025-04-11-scalus-development-platform/index.md
+++ b/blog/2025-04-11-scalus-development-platform/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-11-scalus-development-platform
 title: "Scalus DApp Development Platform"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 Alex Nemish and Oleksii Khodakivskyi from Lantr introduce Scalus, a smart contract framework built with Scala 3. They walk through the vision, roadmap, and show how it simplifies development on Cardano, including a live demo of a payment splitter contract. This session is ideal for devs exploring new tools to build on Cardano.

--- a/blog/2025-04-11-weekly-development-report/index.md
+++ b/blog/2025-04-11-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-11-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The April 11, 2025, development report highlights Cardano’s steady growth with 1,990 projects, 1.33 million delegated wallets, and 10.75 million native tokens. Smart contracts reached 130,282 Plutus and 6,217 Aiken scripts, with 108.36 million total transactions. Governance participation expanded to 1,238 DReps. Highlights include Charles Hoskinson’s keynote at Paris Blockchain Week, a node diversity workshop, and Draper University selecting 20 builders for its residency. Zekret Protocol will build on Cardano, and Eternl wallet launched a new version with UI upgrades and multi-sig support.

--- a/blog/2025-04-14-community-digest/index.md
+++ b/blog/2025-04-14-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-14-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-04-14-community-digest/index.md
+++ b/blog/2025-04-14-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-14-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-04-15-media-learnings-interim-constitutional-committee/index.md
+++ b/blog/2025-04-15-media-learnings-interim-constitutional-committee/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-15-media-learnings-interim-constitutional-committee
 title: "Roundtable Talk: Learnings From The Interim Constitutional Committee"
 authors: [community]
-tags: [ecosystem]
+tags: [governance]
 ---
 
 A Roundtable Talk on April 15, 2025, reflected on the learnings from the Interim Constitutional Committee (iCC) following its eight-month term. The discussion reviewed the iCC's crucial role in upholding the Cardano Constitution since the Chang Hard Fork in September 2024. This session provided insights into the committee's foundational experiences and challenges, setting the stage for the new elections scheduled for May 2025.

--- a/blog/2025-04-15-media-learnings-interim-constitutional-committee/index.md
+++ b/blog/2025-04-15-media-learnings-interim-constitutional-committee/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-15-media-learnings-interim-constitutional-committee
 title: "Roundtable Talk: Learnings From The Interim Constitutional Committee"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk on April 15, 2025, reflected on the learnings from the Interim Constitutional Committee (iCC) following its eight-month term. The discussion reviewed the iCC's crucial role in upholding the Cardano Constitution since the Chang Hard Fork in September 2024. This session provided insights into the committee's foundational experiences and challenges, setting the stage for the new elections scheduled for May 2025.

--- a/blog/2025-04-17-advancing-ouroboros/index.md
+++ b/blog/2025-04-17-advancing-ouroboros/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-17-advancing-ouroboros
 title: "Advancing Ouroboros: Leios as the next leap in scalability"
 authors: [iog]
-tags: [development, Ouroboros]
+tags: [development, research]
 ---
 
 Input Output Global (IOG) published an update on Ouroboros Leios, presented as a major redesign of Cardano's consensus protocol aimed at significantly increasing transaction throughput and scalability. The post explains how Leios utilizes a novel concurrent structure with specialized block types (input, endorsement, ranking) to enable parallel processing while preserving the security and decentralization of Ouroboros Praos. Currently in the research and development phase, Leios is positioned as a transformative upgrade for Cardano's long-term capacity.

--- a/blog/2025-04-18-weekly-development-report/index.md
+++ b/blog/2025-04-18-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-18-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report highlights core technology advancements, including consensus team progress on Genesis testing and collaboration with the Ouroboros Phalanx team. Networking focused on transaction submission features, while performance benchmarked node v.10.3.1. The Plutus team delivered several improvements to Plinth, enhancing the smart contract compiler and libraries. Work also continued across scaling solutions, wallet development, and governance features.

--- a/blog/2025-04-25-weekly-development-report/index.md
+++ b/blog/2025-04-25-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-25-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report highlights core technology updates, including ledger team work preparing for future eras and the pre-release of node v.10.3.1 focusing on performance improvements and lightweight checkpointing support. Ecosystem growth continued, and key updates include DRep delegation going live on Yoroi Wallet, Kinka minting its first XNK tokens on Cardano, a new EMURGO partnership announcement, and the launch of ChadSwap.

--- a/blog/2025-04-28-community-digest/index.md
+++ b/blog/2025-04-28-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-28-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-04-28-community-digest/index.md
+++ b/blog/2025-04-28-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-04-28-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-05-01-blockchain-sustainability/index.md
+++ b/blog/2025-05-01-blockchain-sustainability/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-01-blockchain-sustainability
 title: "Blockchain for Sustainability: Empowering Ecological and Humanitarian Efforts"
 authors: [cf]
-tags: [education,research ]
+tags: [research, education]
 ---
 
 The Cardano Foundation's blog post "Blockchain for Sustainability" explores how blockchain technology can enhance ecological and humanitarian efforts. It details applications in improving supply chain transparency, such as verifying ethically sourced products like fair-trade coffee. The post also covers promoting circular economy models by tracking product lifecycles and recycled content, exemplified by projects like Plastiks on Cardano. Furthermore, it discusses blockchain's role in the renewable energy sector through peer-to-peer energy trading and supporting microgrids, fostering verifiable and transparent sustainable practices.

--- a/blog/2025-05-01-blockchain-sustainability/index.md
+++ b/blog/2025-05-01-blockchain-sustainability/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-01-blockchain-sustainability
 title: "Blockchain for Sustainability: Empowering Ecological and Humanitarian Efforts"
 authors: [cf]
-tags: [research, education]
+tags: [education]
 ---
 
 The Cardano Foundation's blog post "Blockchain for Sustainability" explores how blockchain technology can enhance ecological and humanitarian efforts. It details applications in improving supply chain transparency, such as verifying ethically sourced products like fair-trade coffee. The post also covers promoting circular economy models by tracking product lifecycles and recycled content, exemplified by projects like Plastiks on Cardano. Furthermore, it discusses blockchain's role in the renewable energy sector through peer-to-peer energy trading and supporting microgrids, fostering verifiable and transparent sustainable practices.

--- a/blog/2025-05-02-weekly-development-report/index.md
+++ b/blog/2025-05-02-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-02-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report highlights the pre-release of Node v.10.4.1 with a production-ready UTXO-HD backend and consensus team advancements in testing models. Lace wallet v.1.22 launched, introducing Firefox browser support and Bitcoin integration (beta). Smart contract updates included strictness analysis for UPLC and PIR. The ecosystem saw continued growth in projects and DRep participation, with TapTools launching the Cardano Builder DAO and Metera mainnet going live.

--- a/blog/2025-05-09-decentralizing-open-source/index.md
+++ b/blog/2025-05-09-decentralizing-open-source/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-09-decentralizing-open-source
 title: "Decentralizing Open-Source Development"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 In this session of the Cardano Developer Office Hours, the team presents PoP (Proof of Provenance), a project to decentralize open-source development on Cardano. They cover risks of centralized infrastructure, using Cardano for verifiable software metadata, Merkle trees, and on-chain tracking. A live demo shows PoP in action. Use cases include secure versioning, on-chain test management, SPOs as decentralized oracles, and decentralized package tools.

--- a/blog/2025-05-09-native-tokens-eutxo/index.md
+++ b/blog/2025-05-09-native-tokens-eutxo/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-09-native-tokens-eutxo
 title: "Native tokens in the extended UTXO model"
 authors: [iog]
-tags: [development, Ouroboros]
+tags: [development, research]
 ---
 
 Input Output Global (IOG) published a blog post, detailing native tokens within Cardano's Extended UTXO (EUTXO) model. The post explains how these tokens function without requiring smart contracts for creation or transfer, unlike account-based systems like Ethereum. This design offers enhanced security and reduced transaction fees for users. The article contrasts Cardano's approach with traditional ERC-20 tokens, emphasizing the inherent advantages of its native token implementation.

--- a/blog/2025-05-09-weekly-development-report/index.md
+++ b/blog/2025-05-09-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-09-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report information, largely reflected in Intersect's update, highlights significant progress in governance processes. This includes the upcoming submission of a budget info action with 39 proposals for DRep voting in epoch 557, and the opening of candidate registration for the Constitutional Committee, running until May 31st. The report also noted a strong voter turnout for Q1 committee elections and an increase in DRep statistics. Additionally, community contributions such as the Lucid Evolution off-chain framework and the Midgard Protocol L2 solution were mentioned.

--- a/blog/2025-05-13-community-digest/index.md
+++ b/blog/2025-05-13-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-13-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-05-13-community-digest/index.md
+++ b/blog/2025-05-13-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-13-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-05-16-weekly-development-report/index.md
+++ b/blog/2025-05-16-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-16-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report highlights consensus team fixes for Genesis and progress on Cardano Blueprint CDDL validation. Brave and IO are partnering to integrate Cardano into the Brave wallet. Plutus team advanced formal methods and modular-exponentiation testing. Scaling work included Leios simulations reaching 1,000 TPS and Mithril DMQ node advancements. The Cardano budget proposal was submitted on-chain as an info action, and FluidTokens launched Babel fees.

--- a/blog/2025-05-19-mithril-powering-lightweight-access/index.md
+++ b/blog/2025-05-19-mithril-powering-lightweight-access/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-19-mithril-powering-lightweight-access
 title: "Mithril: powering lightweight access to the Cardano blockchain"
 authors: [iog]
-tags: [development, Ouroboros]
+tags: [development, research]
 ---
 
 Input Output Global (IOG) explains how its Mithril protocol provides lightweight access to the Cardano blockchain. Mithril allows users and applications to verify the state of the chain quickly and securely without downloading its entire history. This is achieved through a stake-based multi-signature scheme where a quorum of stakeholders certifies snapshots of the blockchain. This significantly lowers resource usage, making it ideal for light wallets, mobile applications, and layer 2 solutions.

--- a/blog/2025-05-23-weekly-development-report/index.md
+++ b/blog/2025-05-23-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-23-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report highlights the release of Cardano node v.10.4.1, introducing the UTXO-HD feature for flexible UTXO set storage. Ecosystem updates include Flow DeFi releasing its litepaper and integrating with Strike Finance, Trust Wallet enabling in-app DRep delegation, Emurgo announcing it will no longer use genesis ada for governance, and a new Liqwid Labs integration with Begin Wallet. Growth continued in projects, transactions, and smart contract deployment.

--- a/blog/2025-05-26-community-digest/index.md
+++ b/blog/2025-05-26-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-26-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-05-26-community-digest/index.md
+++ b/blog/2025-05-26-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-26-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-05-30-weekly-development-report/index.md
+++ b/blog/2025-05-30-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-05-30-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report highlights the bridging of Bitcoin Ordinals to Cardano via BitVMX and a new partnership between the Cardano Foundation and UNHCR for a crypto-backed ETP supporting refugees. Core technology work focused on performance benchmarks and preparing for the LSM-tree storage layer. The consensus team onboarded to the Leios simulator and patched several CDDL specifications. Smart contract work included enhancing CEK-machine diagnostics and expanding documentation.

--- a/blog/2025-06-06-cardano-node-evolution/index.md
+++ b/blog/2025-06-06-cardano-node-evolution/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-06-cardano-node-evolution
 title: "Cardano node's evolution towards diversity and modular design"
 authors: [iog]
-tags: [development, Ouroboros]
+tags: [development, research]
 ---
 
 A blog post by Input Output Global (IOG), details the evolution of the Cardano node from a monolithic application into a modular framework. This transformation breaks the node into smaller, independent components for aspects like consensus, ledger, and networking. The post explains that this modular design enhances flexibility for developers, simplifies updates, and critically, fosters client diversity. By enabling the creation of alternative node clients, this evolution aims to improve the overall resilience of the Cardano network.

--- a/blog/2025-06-06-weekly-development-report/index.md
+++ b/blog/2025-06-06-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-06-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report highlights the release of Lace wallet v.1.23, which features a more accurate pricing feed for Cardano native tokens in response to community feedback. On the scaling front, the Mithril team delivered support for node v.10.4.1 and UTXO-HD in their tools and advanced the development of the DMQ node. The Leios team finalized an analysis of overcollateralization models and progressed on their Rust-based simulation framework for evaluating transaction duplication and conflict likelihood.

--- a/blog/2025-06-11-community-digest/index.md
+++ b/blog/2025-06-11-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-11-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-06-11-community-digest/index.md
+++ b/blog/2025-06-11-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-11-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-06-12-originate-for-verifiable-authenticity/index.md
+++ b/blog/2025-06-12-originate-for-verifiable-authenticity/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-12-originate-for-verifiable-authenticity
 title: "Cardano Foundation Introduces Originate for Verifiable Authenticity"
 authors: [cf]
-tags: [research, education]
+tags: [ecosystem]
 ---
 
 The Cardano Foundation has launched Originate, an open-source traceability solution built on the Cardano blockchain. It enables businesses to verify product authenticity and support certifications, enhancing supply chain transparency and combating counterfeiting. A successful case study in the Georgian wine industry demonstrated its effectiveness in fighting counterfeit products. Originate provides a secure, scalable, and cost-effective way for industries like luxury goods and pharmaceuticals to increase consumer trust. The code is available on GitHub for community contribution.

--- a/blog/2025-06-12-originate-for-verifiable-authenticity/index.md
+++ b/blog/2025-06-12-originate-for-verifiable-authenticity/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-12-originate-for-verifiable-authenticity
 title: "Cardano Foundation Introduces Originate for Verifiable Authenticity"
 authors: [cf]
-tags: [education,research ]
+tags: [research, education]
 ---
 
 The Cardano Foundation has launched Originate, an open-source traceability solution built on the Cardano blockchain. It enables businesses to verify product authenticity and support certifications, enhancing supply chain transparency and combating counterfeiting. A successful case study in the Georgian wine industry demonstrated its effectiveness in fighting counterfeit products. Originate provides a secure, scalable, and cost-effective way for industries like luxury goods and pharmaceuticals to increase consumer trust. The code is available on GitHub for community contribution.

--- a/blog/2025-06-13-media-cardano-developer-office-hours/index.md
+++ b/blog/2025-06-13-media-cardano-developer-office-hours/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-13-media-cardano-developer-office-hours
 title: "Transforming Verification with UVerify"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 In this session of the Cardano Developer Office Hours, Fabian Bormann, Team Lead of Ecosystem Engineering at the Cardano Foundation, presents UVerify, a lightweight tool for certifying and verifying data on Cardano without tokens or NFTs. He covers datums as an alternative to metadata, SDKs and white-label tools for devs, and real-world use cases like documents, credentials, and oracles. A live demo shows UVerify in action. The roadmap explores frictionless integrations and future opportunities for verifiable interactions across ecosystems.

--- a/blog/2025-06-13-weekly-development-report/index.md
+++ b/blog/2025-06-13-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-13-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report highlights the release of Lace wallet v.1.23, which features a more accurate pricing feed for Cardano native tokens in response to community feedback. On the scaling front, the Mithril team delivered support for node v.10.4.1 and UTXO-HD in their tools and advanced the development of the DMQ node. The Leios team finalized an analysis of overcollateralization models and progressed on their Rust-based simulation framework for evaluating transaction duplication and conflict likelihood.

--- a/blog/2025-06-20-understanding-cardano/index.md
+++ b/blog/2025-06-20-understanding-cardano/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-20-understanding-cardano
 title: "Understanding Cardano: introducing the Cardano Blueprint"
 authors: [iog]
-tags: [development, Ouroboros]
+tags: [development, research]
 ---
 
 Input Output Global (IOG) introduced the Cardano Blueprint, a comprehensive, open-source reference guide to the platform. This living document is designed to be a single source of truth, detailing Cardano's core components, architecture, protocols, and design principles. The Blueprint aims to enhance transparency and accessibility for developers, researchers, and the wider community. By providing a standardized technical reference, it seeks to improve the onboarding process and foster a deeper understanding of Cardano's intricacies.

--- a/blog/2025-06-20-weekly-development-report/index.md
+++ b/blog/2025-06-20-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-20-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The report highlights significant work by the ledger team to modernize the codebase and prepare for an upcoming intra-era hard fork. This included enhancing CDDL specifications, reducing technical debt, and conducting preliminary work on nested transactions. The report also touched upon future node improvements like log-structured merge (LSM) trees and revised stake pool incentives. Governance participation continued to grow, with an increase in the number of registered DReps.

--- a/blog/2025-06-24-community-digest/index.md
+++ b/blog/2025-06-24-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-24-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-06-24-community-digest/index.md
+++ b/blog/2025-06-24-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-24-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-06-25-media-constitutional-committee-election/index.md
+++ b/blog/2025-06-25-media-constitutional-committee-election/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-25-media-constitutional-committee-election
 title: "Roundtable Talk: Constitutional Committee Election"
 authors: [community]
-tags: [media,ambassadors]
+tags: [community, ecosystem]
 ---
 
 A Roundtable Talk on June 25, 2025, provided a platform for candidates in the Constitutional Committee election. The session allowed individuals and groups to introduce their background, vision, and motivation for the role. Each candidate answered the same set of questions in a timed format, ensuring a fair and structured showcase for DReps and the community to make informed voting decisions before the June 30 deadline.

--- a/blog/2025-06-27-media-cardano-developer-office-hours/index.md
+++ b/blog/2025-06-27-media-cardano-developer-office-hours/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-27-media-cardano-developer-office-hours
 title: "Token Registry API v2"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 In this session of the Cardano Developer Office Hours, Giovanni Gargiulo, Senior Software Engineer, DevOps at the Cardano Foundation, presents the new Token Registry API v2 with full CIP-68 support. He demonstrates API endpoints, explains best practices for using the query_priority parameter, and covers support for tokens under both CIP-26 and CIP-68. A live demo shows practical use cases and integration opportunities for developers.

--- a/blog/2025-06-27-weekly-development-report/index.md
+++ b/blog/2025-06-27-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-06-27-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights continued ecosystem growth, with the number of projects building on Cardano reaching 2,004. The consensus team enhanced the Leios simulator and improved resource management in UTXO-HD. The Lace team released v.1.24 with multichain and user-centric upgrades. Mithril focused on the DMQ network, while Hydra released v.0.22.0. The community also voted in favor of the Intersect budget info action, paving the way for treasury withdrawals.

--- a/blog/2025-07-03-cardano-developer-friendly/index.md
+++ b/blog/2025-07-03-cardano-developer-friendly/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-03-cardano-developer-friendly
 title: "Breaking down the walls: making Cardano more developer-friendly"
 authors: [iog]
-tags: [development, Ouroboros]
+tags: [development, research]
 ---
 
 Project Acropolis is an initiative to enhance developer accessibility. While the robust security of Cardano is acknowledged, the steep learning curve has hindered ecosystem growth. Acropolis aims to transition the Cardano node from a monolithic to a modular architecture, enabling developers to build applications using familiar tools directly within the node. This evolution is intended to lower entry barriers and foster innovation without compromising high-security standards.

--- a/blog/2025-07-04-weekly-development-report/index.md
+++ b/blog/2025-07-04-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-04-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights continued ecosystem growth, with 2,005 active projects now building on Cardano. The ledger team defined PlutusV4 for the Dijkstra era, fixed a serialization bug, and implemented hard fork triggers. Scaling work saw the Mithril team complete the implementation of the publisher and consumer for the DMQ network, while the Hydra team worked on their 2025-2026 roadmap and Glacier-drop support. Ecosystem news includes MuesliSwap’s launch of MidStarterApp and Flow DeFi confirming USDA stablecoin support.

--- a/blog/2025-07-07-media-economic-sustainability-of-cardano/index.md
+++ b/blog/2025-07-07-media-economic-sustainability-of-cardano/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-07-media-economic-sustainability-of-cardano
 title: "Roundtable Talk: Economic Sustainability of Cardano"
 authors: [community]
-tags: [media,ambassadors]
+tags: [community, ecosystem]
 ---
 
 A Roundtable Talk, features a discussion from the Cardano Berlin Hackathon on the ecosystem's economic sustainability. Participants discussed why sustainability matters, how transaction fees are earned, and the role of the Net Change Limit. The conversation also covered the challenges of empowering developers and the "skin-in-the-game" approach to using treasury funds to ensure Cardano's long-term viability.

--- a/blog/2025-07-08-community-digest/index.md
+++ b/blog/2025-07-08-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-08-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest, governance]
+tags: [governance, community]
 ---
 
 

--- a/blog/2025-07-08-community-digest/index.md
+++ b/blog/2025-07-08-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-08-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [governance, community]
+tags: [community, governance]
 ---
 
 

--- a/blog/2025-07-08-reeve-enterprise-financial-reporting/index.md
+++ b/blog/2025-07-08-reeve-enterprise-financial-reporting/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-08-reeve-enterprise-financial-reporting
 title: "Cardano Foundation Unveils Reeve for Enterprise Financial Reporting"
 authors: [cf]
-tags: [development]
+tags: [ecosystem]
 ---
 
 

--- a/blog/2025-07-11-media-cardano-developer-office-hours/index.md
+++ b/blog/2025-07-11-media-cardano-developer-office-hours/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-11-media-cardano-developer-office-hours
 title: "Reeve Accountability Tools for Cardano"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 In this session of the Cardano Developer Office Hours, Thomas Kammerlocher, Senior Full Stack Developer, and Marco Russo, Integration Tools Team Lead at the Cardano Foundation, present Reeve, a new solution for financial reporting and transparency. They cover how Reeve simplifies reporting, supports verifiable and tamper-proof data, and builds trust across ecosystems. A live walkthrough demonstrates current features, how to run it, and future roadmap directions.

--- a/blog/2025-07-11-weekly-development-report/index.md
+++ b/blog/2025-07-11-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-11-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights continued ecosystem growth, with 2,005 projects now building on Cardano. The consensus team introduced mempool optimizations and added node-to-node CDDL specifications. The Plutus Core team merged support for case analysis on booleans and integers, while the Plinth team introduced a new compiler optimization. Other notable updates include the Cardano Foundation launching Reeve, Intersect partnering with SundaeSwap, and Vespr Wallet open-sourcing its SDKs.

--- a/blog/2025-07-18-weekly-development-report/index.md
+++ b/blog/2025-07-18-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-18-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights the ledger team's focus on preparing for the Dijkstra era, including integrating it into consensus and reducing technical debt. Scaling work saw the Mithril team complete certificate chain synchronization and the Leios team achieve milestones in protocol analysis, including successful high-throughput experiments. Ecosystem news includes Emurgo launching the Cardano Card, Intersect forming an oversight committee for treasury management, and Blockchain.com's DeFi wallet adding support for ada.

--- a/blog/2025-07-21-media-followup-to-nested-transactions/index.md
+++ b/blog/2025-07-21-media-followup-to-nested-transactions/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-21-media-followup-to-nested-transactions
 title: "Roundtable Talk: A Followup to Nested Transactions"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk, features a deep-dive discussion on the evolution and implementation of Nested Transactions within the Cardano ledger. Participants discussed the technical readiness of the protocol, the potential for Babel fees, and the introduction of new programmability layers. The conversation also addressed risks regarding system complexity and censorship resistance, emphasizing the role of community consensus in navigating alternative paths for Cardano’s future governance and technical direction.

--- a/blog/2025-07-22-community-digest/index.md
+++ b/blog/2025-07-22-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-22-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2025-07-25-media-cardano-developer-office-hours/index.md
+++ b/blog/2025-07-25-media-cardano-developer-office-hours/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-25-media-cardano-developer-office-hours
 title: "Simplifying Indexing with Yaci Store"
 authors: [cf]
-tags: [media]
+tags: [ecosystem]
 ---
 
 In this session of the Cardano Developer Office Hours, Satya Ranjan, Lead Blockchain Architect at the Cardano Foundation, presents Yaci Store, a pluggable indexing solution for Cardano. The talk covers out-of-the-box indexers, feature toggling, plugins for customization, and an API overview for easy querying. Satya highlights how Yaci Store simplifies indexing for Java and non-Java developers alike, with integration possibilities that go beyond Java.

--- a/blog/2025-07-25-weekly-development-report/index.md
+++ b/blog/2025-07-25-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-07-25-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights the release of node v.10.5.1, featuring networking enhancements and tracing metric fixes. The consensus team is integrating the Dijkstra era and advancing the Haskell Leios simulator. Lace wallet v.1.25 introduced a partnership with NFTPrintLab and support for Bitcoin transaction metadata. The Plutus Core team expanded functionality by introducing case analysis on lists and refined the Plutus Core specification.

--- a/blog/2025-08-01-weekly-development-report/index.md
+++ b/blog/2025-08-01-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-08-01-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights a major refactoring of the ledger codebase's reward account state, removing pointers in the Conway era to improve performance and pave the way for future features like the Leios protocol. This update also introduced a feature for reporting the pre-image of script integrity hashes on validation failures. Ecosystem news includes the launch of the Cardano Foundation's Tool Compass and the release of Midnight's tokenomics whitepaper.

--- a/blog/2025-08-04-cardanos-governance-journey/index.md
+++ b/blog/2025-08-04-cardanos-governance-journey/index.md
@@ -2,7 +2,7 @@
 slug: 2025-08-04-cardanos-governance-journey
 title: "Cardano's governance journey: a timeline for decentralized democracy"
 authors: [iog]
-tags: [development]
+tags: [governance]
 ---
 
 The journey toward decentralized governance has spanned three years, marking a transition from foundational community workshops to a fully autonomous, on-chain democratic system. Key milestones included the establishment of the Constitution and the introduction of elected representatives. This framework empowers ADA holders to shape the protocol's future through direct participation and voting.

--- a/blog/2025-08-04-community-digest/index.md
+++ b/blog/2025-08-04-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-08-04-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2025-08-08-weekly-development-report/index.md
+++ b/blog/2025-08-08-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-08-08-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights the full mainnet release of Cardano node v.10.5.1. The consensus team advanced on multiple fronts, including LSM-tree integration and drafting mini-protocols for Linear Leios. The Plutus team is expanding case analysis support and preparing all built-in functions for the next hard fork. Ecosystem news includes partnerships for Midnight Network with Blockchain.com and Wanchain's bridge to the SUI Network.

--- a/blog/2025-08-15-weekly-development-report/index.md
+++ b/blog/2025-08-15-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-08-15-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights the ledger team beginning work on CIP-112, known as 'Required Guards,' and refactoring the stake pool state. The performance team released benchmarks for Cardano node v.10.5. On the scaling front, the Leios team advanced its CIP documentation and demonstrated Linear Leios performance under various Plutus workloads, resolving key simulation discrepancies.

--- a/blog/2025-08-20-community-digest/index.md
+++ b/blog/2025-08-20-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-08-20-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2025-08-22-weekly-development-report/index.md
+++ b/blog/2025-08-22-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-08-22-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights the Lace wallet v.1.26 release, which includes performance improvements and bug fixes. The consensus team focused on LSM-tree backend integration and continued Leios prototyping. The Mithril team completed the mock DMQ node implementation, and ecosystem growth reached 2,008 projects. Midnight announced a partnership with Block-rewards, and Liqwid Labs launched a new UI.

--- a/blog/2025-08-29-weekly-development-report/index.md
+++ b/blog/2025-08-29-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-08-29-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team is focused on enforcing stake pool VRF key uniqueness and integrating Plutus V4 into the Dijkstra era. Plutus Core has added support for built-in lists, while Midnight partnered with Copper for institutional custody of the NIGHT token. Additionally, the Governance Education Working Group has launched, and the Halo2-Plutus verifier is now available to support on-chain zero-knowledge proofs, primarily for the Midnight-Cardano zk-bridge.

--- a/blog/2025-09-01-community-digest/index.md
+++ b/blog/2025-09-01-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-01-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2025-09-01-media-developers-tooling-on-cardano/index.md
+++ b/blog/2025-09-01-media-developers-tooling-on-cardano/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-01-media-developers-tooling-on-cardano
 title: "Roundtable Talk: Developers Tooling on Cardano"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk, features a discussion from the Cardano Berlin Hackathon on the evolution of developer tooling. Participants discussed the shift from early limitations to modern solutions like Aiken and open-source SDKs. The conversation also covered the role of the Plutus Pioneer Program and the importance of developer onboarding in securing Cardano’s long-term accessibility and global adoption.

--- a/blog/2025-09-05-weekly-development-report/index.md
+++ b/blog/2025-09-05-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-05-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights the consensus team's work on the first public draft of the Leios CIP, LSM-tree support, and KES agent integration. The Plutus team improved the evaluator and deserializer and added support for built-in units and pairs. In ecosystem news, MLabs launched feeswap.io, the Cardano Foundation rebuilt the Developer Portal, and World Mobile Chain's $WMTX token began trading on KrakenFX.

--- a/blog/2025-09-07-constitutional-committee-elections/index.md
+++ b/blog/2025-09-07-constitutional-committee-elections/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-07-constitutional-committee-elections
 title: "Constitutional Committee Elections 2025"
 authors: [intersect]
-tags: [education]
+tags: [governance]
 ---
 
 The first community-led Constitutional Committee election has concluded, with seven members elected via an on-chain vote by DReps and SPOs. The process utilized a one-lovelace-one-vote system to select representatives responsible for upholding the Cardano Constitution for the upcoming term. This milestone establishes a decentralized governance framework and marks the full transition of constitutional power to the community.

--- a/blog/2025-09-12-weekly-development-report/index.md
+++ b/blog/2025-09-12-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-12-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team's progress on CIP-112 and features for the next intra-era hard fork. A major Voltaire milestone was reached with the first fully community-elected constitutional committee now in place. In scaling, the Mithril team updated the DMQ protocol CIP. Ecosystem news includes the release of Yoroi Extension v.5.13.0 and new partnerships for Sundial Protocol and Midnight Network.

--- a/blog/2025-09-15-community-digest/index.md
+++ b/blog/2025-09-15-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-15-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2025-09-19-weekly-development-report/index.md
+++ b/blog/2025-09-19-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-19-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team drafting an architectural design for Leios (CIP-0164). The Plutus team progressed on implementing the Value built-in type (CIP-0153) and merged multi-scalar multiplication primitives for the next hard fork. In scaling, the Mithril team created a new pre-release, supported Cardano node v.10.5.1, and completed a SNARK proving circuit prototype. IOG also kicked off its 2025 Asia tour.

--- a/blog/2025-09-20-media-cardano-culture/index.md
+++ b/blog/2025-09-20-media-cardano-culture/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-20-media-cardano-culture
 title: "Roundtable Talk: Cardano Culture"
 authors: [community]
-tags: [media,ambassadors]
+tags: [community, ecosystem]
 ---
 
 A Roundtable Talk, features a discussion from Rare Evo Las Vegas on the values and spirit of Cardano Culture. Participants discussed the evolution of community voices, the impact of grassroots funding, and the importance of IRL presence. The conversation also addressed intentional culture shaping and inclusivity to ensure a resilient and welcoming environment for the global ecosystem.

--- a/blog/2025-09-22-media-community-expertise-in-action/index.md
+++ b/blog/2025-09-22-media-community-expertise-in-action/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-22-media-community-expertise-in-action
 title: "Roundtable Talk: Community Expertise in Action"
 authors: [community]
-tags: [media,ambassadors]
+tags: [community, ecosystem]
 ---
 
 A Roundtable Talk, features a discussion on the Fund 14 Representative Pilot and the evolution of Project Catalyst. Participants discussed shifting from popularity-based voting toward systematic, expertise-driven decision-making. The conversation also compared evaluation frameworks to help DReps prioritize quality and fairness, ensuring a more informed and transparent governance process for Fund 15 and beyond.

--- a/blog/2025-09-23-cardano-foundation-roadmap/index.md
+++ b/blog/2025-09-23-cardano-foundation-roadmap/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-23-cardano-foundation-roadmap
 title: "Cardano Foundation Roadmap"
 authors: [cf]
-tags: [development]
+tags: [ecosystem]
 ---
 
 

--- a/blog/2025-09-26-weekly-development-report/index.md
+++ b/blog/2025-09-26-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-26-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team is auditing the KES agent and refactoring the hard fork combinator for Peras-awareness. The Plutus team is enabling sums-of-products and built-in functions for the upcoming intra-era hard fork. Meanwhile, IOG and zkFold have partnered for a trustless ETH-Cardano bridge, and Minswap's "Wen" token generator is now live.

--- a/blog/2025-09-29-community-digest/index.md
+++ b/blog/2025-09-29-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-29-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2025-09-30-intersect-2025-board-elections-results/index.md
+++ b/blog/2025-09-30-intersect-2025-board-elections-results/index.md
@@ -2,7 +2,7 @@
 slug: 2025-09-30-intersect-2025-board-elections-results
 title: "Intersect Announces Results of 2025 Board Elections"
 authors: [intersect]
-tags: [development]
+tags: [governance]
 ---
 
 Intersect board election results have been announced, with Adam Rusch and Jack Briggs elected as new members. This milestone marks the first time a majority of the board is directly elected by its members, achieved with a 26% voter turnout to reinforce decentralized, community-led governance.

--- a/blog/2025-10-02-media-community-expertise-in-action-2/index.md
+++ b/blog/2025-10-02-media-community-expertise-in-action-2/index.md
@@ -2,7 +2,7 @@
 slug: 2025-10-02-media-community-expertise-in-action-2
 title: "Roundtable Talk: Community Expertise in Action - part 2"
 authors: [community]
-tags: [media,ambassadors]
+tags: [community, ecosystem]
 ---
 
 A Roundtable Talk, features a discussion for the Eastern Hemisphere on the Fund 14 Representative Pilot. Participants focused on shifting from popularity-based voting toward systematic, expertise-driven evaluations. The session explored how structured frameworks can guide DReps to improve the quality and fairness of future governance decisions.

--- a/blog/2025-10-03-weekly-development-report/index.md
+++ b/blog/2025-10-03-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-10-03-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Progress continues on CIP-112 and features for the next intra-era hard fork. The first fully community-elected constitutional committee is now in place, and the Mithril team has updated the DMQ protocol CIP. Additionally, Yoroi Extension v.5.13.0 has been released, alongside new partnerships for Sundial Protocol and Midnight Network.

--- a/blog/2025-10-10-weekly-development-report/index.md
+++ b/blog/2025-10-10-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-10-10-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ecosystem has reached 114.56 million transactions and an increase in active DReps, while the Asia tour concluded in Tokyo. Yoroi v6.0 launched, integrating DexHunter and Minswap. Additionally, Midnight Network partnered with CSWAP for privacy-first DeFi solutions, and the Hydra-node v1.0.0 pre-release is now available.

--- a/blog/2025-10-13-community-digest/index.md
+++ b/blog/2025-10-13-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-10-13-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2025-10-17-cardano-foundation-q3-2025-report/index.md
+++ b/blog/2025-10-17-cardano-foundation-q3-2025-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-10-17-cardano-foundation-q3-2025-report
 title: "Cardano Foundation Quarterly: Q3 2025"
 authors: [cf]
-tags: [development]
+tags: [ecosystem]
 ---
 
 

--- a/blog/2025-10-17-weekly-development-report/index.md
+++ b/blog/2025-10-17-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-10-17-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The development report highlights the Hydra team's release of version 1.0.0. The consensus team advanced the Leios CIP, while the performance team benchmarked node v.10.6 and the LSM-tree backend. The Plutus team finalized the implementation of CIP-0153, introducing the Value built-in type. In the ecosystem, Project Catalyst Fund14 voting concluded, and the Cardano Foundation launched its Summit 2025 PR campaign.

--- a/blog/2025-10-24-weekly-development-report/index.md
+++ b/blog/2025-10-24-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-10-24-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ecosystem has reached a milestone of 2,014 projects, while applications are being prepared for .ada and .cardano gTLDs. Wanchain has launched a bridge to Sonic, and technical progress continues with Mithril's work on incremental snapshots and configuration decentralization. Furthermore, committee election voting is opening for the community, and Project Catalyst Fund15 is set to launch.

--- a/blog/2025-10-27-community-digest/index.md
+++ b/blog/2025-10-27-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-10-27-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2025-10-31-weekly-development-report/index.md
+++ b/blog/2025-10-31-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-10-31-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The Hydra team announced the launch of v1, marking the protocol as production-ready. The ledger team finalized CIP-118, introducing nested transactions and Babel fees, while IOG published a deep dive on Ouroboros Phalanx to deter grinding attacks. Additionally, the consensus team showcased a Leios prototype, Intersect committee elections are currently underway, and Project Catalyst Fund15 is preparing for its official launch.

--- a/blog/2025-11-06-pulse-of-cardano-marketing/index.md
+++ b/blog/2025-11-06-pulse-of-cardano-marketing/index.md
@@ -2,7 +2,7 @@
 slug: 2025-11-06-pulse-of-cardano-marketing
 title: "The pulse of Cardano marketing: what the ecosystem is telling us"
 authors: [intersect]
-tags: [development]
+tags: [community]
 ---
 
 In a blog post, Intersect's Growth and Marketing Committee shared key findings from their first community-wide marketing survey. The results highlight a strong demand for unified messaging and increased support for developers and founders. Respondents prioritized DeFi and real-world use cases, advocating for treasury-backed liquidity programs. While grassroots efforts are effective, there is a clear call for better storytelling tools and a cohesive long-term vision to guide Cardano's growth.

--- a/blog/2025-11-07-weekly-development-report/index.md
+++ b/blog/2025-11-07-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-11-07-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The Plutus team hosted UPLC 2025 and introduced the scaleValue primitive for the upcoming hard fork. Scaling advancements include the Mithril 2543.0 distribution and the Hydra v1.1.0 release, while Intersect concluded its committee election voting. Additionally, the Ouroboros Phalanx upgrade was introduced alongside a new Compact DApps category for Project Catalyst Fund15.

--- a/blog/2025-11-10-community-digest/index.md
+++ b/blog/2025-11-10-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-11-10-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest,ambassadors]
+tags: [community]
 ---
 
 

--- a/blog/2025-11-11-cardano-summit-2025-day-zero/index.md
+++ b/blog/2025-11-11-cardano-summit-2025-day-zero/index.md
@@ -2,7 +2,7 @@
 slug: 2025-11-11-cardano-summit-2025-day-zero
 title: "Cardano Summit 2025: Day Zero Recap"
 authors: [cf]
-tags: [events,ambassadors]
+tags: [events, community]
 ---
 
 

--- a/blog/2025-11-14-weekly-development-report/index.md
+++ b/blog/2025-11-14-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-11-14-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team addressed 'bufferbloat' issues and enhanced resource management following the Leios demo. Scaling updates include Mithril hotfix 2543.1 and Hydra's introduction of the 'SafeClose' safety feature alongside improved partial fanout. Intersect announced its election results following a high voter turnout, while Project Catalyst Fund15 launched with a new "Midnight: Compact DApps" category. Additionally, the education team is currently conducting a developer course in Buenos Aires.

--- a/blog/2025-11-21-weekly-development-report/index.md
+++ b/blog/2025-11-21-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-11-21-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The November 21 incident involved a mainnet chain partition caused by a malformed transaction, which was resolved with the hotfix node v.10.5.3. The ledger team defined sub-transactions for the Dijkstra era, while the Plutus team finalized costing for Value primitives for the upcoming hard fork. Lace v.1.31 was released with in-wallet token swaps and Bitcoin wallet support, and Mithril completed the first phase of decentralizing configuration parameters.

--- a/blog/2025-11-24-community-digest/index.md
+++ b/blog/2025-11-24-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-11-24-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest,ambassadors]
+tags: [community]
 ---
 
 

--- a/blog/2025-11-28-weekly-development-report/index.md
+++ b/blog/2025-11-28-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-11-28-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The Leios development tracker was launched to provide a consolidated view of the protocol's global progress. The networking team focused on Cardano node v.10.6, resolving cardano-tracer issues and preparing for P2P-only networking. Project Catalyst Fund15 proposal submissions have closed, and Intersect is preparing for its 24-hour virtual Annual Members' Meeting in the Virtual Hub.

--- a/blog/2025-12-02-what-is-cardano-net-change-limit/index.md
+++ b/blog/2025-12-02-what-is-cardano-net-change-limit/index.md
@@ -2,7 +2,7 @@
 slug: 2025-12-02-what-is-cardano-net-change-limit
 title: "What is Cardano’s Net Change Limit?"
 authors: [intersect]
-tags: [development]
+tags: [governance]
 ---
 
 

--- a/blog/2025-12-05-weekly-development-report/index.md
+++ b/blog/2025-12-05-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-12-05-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 

--- a/blog/2025-12-08-community-digest/index.md
+++ b/blog/2025-12-08-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-12-08-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2025-12-12-weekly-development-report/index.md
+++ b/blog/2025-12-12-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-12-12-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The final development report for 2025, dated December 12, highlights the approval of the Pyth Lazer oracle integration and Serviceplan Group joining Intersect as an enterprise member. The consensus team completed LSM-tree work, slated for integration in node v.10.7. Mithril made progress on its SNARK-friendly STM library and Bitcoin DeFi prover prototype. In governance, a critical vote is underway to restore the Constitutional Committee to full capacity, while Project Catalyst Fund15's community review period closes on December 15. The Midnight Redemption portal is live, and the NIGHT token is now trading on exchanges like Kraken.

--- a/blog/2025-12-16-media-Pathways-to-longterm-treasury-sustainability/index.md
+++ b/blog/2025-12-16-media-Pathways-to-longterm-treasury-sustainability/index.md
@@ -2,7 +2,7 @@
 slug: 2025-12-16-media-Pathways-to-longterm-treasury-sustainability
 title: "Cross Ecosystem Roundtable Talk (Cardano-Polkadot): Pathways to Long-Term Treasury Sustainability"
 authors: [community]
-tags: [media,ambassadors]
+tags: [community, ecosystem]
 ---
 
 A Roundtable Talk, features the first Cross Ecosystem discussion between the Cardano and Polkadot Foundations on decentralized treasury sustainability. Participants discussed shared Web3 challenges and compared various approaches to long-term funding. The conversation highlighted the importance of economic stability and sustainable management strategies to support decentralized network growth across ecosystems.

--- a/blog/2025-12-22-community-digest/index.md
+++ b/blog/2025-12-22-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2025-12-22-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2025-12-30-cardano-foundation-q4-report/index.md
+++ b/blog/2025-12-30-cardano-foundation-q4-report/index.md
@@ -2,7 +2,7 @@
 slug: 2025-12-30-cardano-foundation-q4-report
 title: "Cardano Foundation Quarterly: Q4 2025"
 authors: [cf]
-tags: [report]
+tags: [ecosystem]
 ---
 
 

--- a/blog/2026-01-06-community-digest/index.md
+++ b/blog/2026-01-06-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2026-01-06-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2026-01-19-community-digest/index.md
+++ b/blog/2026-01-19-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2026-01-19-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest,ambassadors]
+tags: [community]
 ---
 
 

--- a/blog/2026-01-23-weekly-development-report/index.md
+++ b/blog/2026-01-23-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2026-01-23-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The updated Cardano constitution has been ratified and officially took effect on January 24, marking a pivotal step in decentralized governance. The ledger team finalized the design for nested transactions (CIP-118) and began implementing account address enhancements (CIP-159) for the upcoming Dijkstra era. Simultaneously, the Mithril team focused on SNARK-friendly libraries and prepared the infrastructure for the decentralized message queue (DMQ) network deployment.

--- a/blog/2026-01-28-media-your-art-your-rules/index.md
+++ b/blog/2026-01-28-media-your-art-your-rules/index.md
@@ -2,7 +2,7 @@
 slug: 2026-01-28-media-your-art-your-rules
 title: "Cardano Roundtable Talk - Your Art, Your Rules"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk, features a discussion from the NuLuna event in Barcelona on ownership and career paths for creators on Cardano. Participants explored how artists and musicians leverage Web3 for direct community coordination and sustainable business models. The conversation also addressed industry myths and practical strategies for building creative careers within the blockchain ecosystem.

--- a/blog/2026-01-30-weekly-development-report/index.md
+++ b/blog/2026-01-30-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2026-01-30-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Cardano node v.10.7 development and Leios endorsement block prototyping are advancing, pushing the network toward higher throughput. The Hydra team focused on performance optimizations and a Raspberry Pi demo, while Mithril prepared distribution 2603.1-pre with DMQ protocol support. Furthermore, Intersect is coordinating an intra-era upgrade to protocol version 11, laying the groundwork for enhanced governance and scalability features.

--- a/blog/2026-02-02-community-digest/index.md
+++ b/blog/2026-02-02-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-02-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits/index.md
+++ b/blog/2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits
 title: "SPO Table Talk: Understanding GA, Updates to Plutus execution limits"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk, features a discussion on increasing Plutus memory units to enhance throughput and developer flexibility. Participants addressed node performance, constitutional guardrails, and the vital role of SPO participation under CIP-1694. The session aimed to provide SPOs with the technical clarity needed for informed voting on protocol scaling.

--- a/blog/2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits/index.md
+++ b/blog/2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-03-media-understanding-ga-updates-to-plutus-execution-limits
 title: "SPO Table Talk: Understanding GA, Updates to Plutus execution limits"
 authors: [community]
-tags: [ecosystem]
+tags: [governance]
 ---
 
 A Roundtable Talk, features a discussion on increasing Plutus memory units to enhance throughput and developer flexibility. Participants addressed node performance, constitutional guardrails, and the vital role of SPO participation under CIP-1694. The session aimed to provide SPOs with the technical clarity needed for informed voting on protocol scaling.

--- a/blog/2026-02-06-weekly-development-report/index.md
+++ b/blog/2026-02-06-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-06-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The High Assurance team has launched an early access program for its automatic formal verification tool, inviting developers to help shape the future of smart contract security. In scaling updates, Mithril distribution 2603.1 is now available, featuring a decentralized message queue protocol and Blockfrost API integration. Furthermore, the IOG Research team officially closed Work Package 25 by submitting its comprehensive 2025 end-of-year reports to Intersect.

--- a/blog/2026-02-10-call-to-action-spo-parameter-changes/index.md
+++ b/blog/2026-02-10-call-to-action-spo-parameter-changes/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-10-call-to-action-spo-parameter-changes
 title: "Action Required: Vote on Plutus Execution Limit Changes"
 authors: [cf]
-tags: [spo]
+tags: [governance]
 ---
 
 

--- a/blog/2026-02-12-building-on-cardano-without-haskell/index.md
+++ b/blog/2026-02-12-building-on-cardano-without-haskell/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-12-building-on-cardano-without-haskell
 title: "Building on Cardano Without Haskell: Modern Paths for Developers"
 authors: [cf]
-tags: [developers]
+tags: [development]
 ---
 
 Developing on Cardano no longer requires Haskell proficiency thanks to on-chain languages like Aiken, Scalus, and Plu-ts. These tools offer mainstream syntax and efficient execution, significantly lowering the entry barrier for web2 developers. However, the primary learning curve remains mastering the Extended UTXO (EUTXO) model to ensure all decentralized applications are secure, deterministic, and optimized for the ledger's unique architecture.

--- a/blog/2026-02-13-weekly-development-report/index.md
+++ b/blog/2026-02-13-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-13-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Node v.10.5.4 has been released, introducing critical patches to enhance the robustness of the diffusion layer. The consensus team integrated network packages for the upcoming node v.10.7 and further advanced the Leios prototype. Meanwhile, the Mithril team implemented new succinct proofs and SNARK-friendly certificate chains. Simultaneously, the Leios team moved toward finalizing protocol parameter recommendations through extensive research and simulations to analyze network traffic under load.

--- a/blog/2026-02-17-community-digest/index.md
+++ b/blog/2026-02-17-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-17-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2026-02-20-weekly-development-report/index.md
+++ b/blog/2026-02-20-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-20-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Node v.10.6.2 is live, featuring structural enhancements and preparing the network for the version 11 hard fork. The ledger team progressed with nested transactions and account address improvements, while Hydra v.1.3 focuses on production adoption. Coinbase now accepts ada as loan collateral, and the Leios prototype successfully minted endorser blocks under load. Finally, Messari released the Q4 2025 report alongside Intersect's committee election announcement.

--- a/blog/2026-02-26-media-gap-in-supply-chain-management/index.md
+++ b/blog/2026-02-26-media-gap-in-supply-chain-management/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-26-media-gap-in-supply-chain-management
 title: "Understanding the Adoption Gap in Supply Chain Management"
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 A Roundtable Talk, features a discussion on supply chain resilience and the gap between blockchain’s promise and enterprise adoption. Participants explored how regulations like Digital Product Passports drive traceability needs while unpacking the barriers to large-scale implementation. The session focused on the practical shifts required to move blockchain from pilot projects to widespread utility.

--- a/blog/2026-02-27-weekly-development-report/index.md
+++ b/blog/2026-02-27-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2026-02-27-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 MoneyGram has joined the Midnight network as a federated node operator, while the Cardano Foundation officially assumed stewardship of Project Catalyst. Yoroi now supports dual rewards for ada and night tokens. Additionally, performance benchmarks for node v.10.5.4 and v.10.6.2 were released, and the Leios team demonstrated a working prototype capable of producing endorser blocks under high load. Mithril also advanced its development of succinct SNARK proofs.

--- a/blog/2026-03-03-cardano-summit-2025-journey-and-results/index.md
+++ b/blog/2026-03-03-cardano-summit-2025-journey-and-results/index.md
@@ -2,7 +2,7 @@
 slug: 2026-03-03-cardano-summit-2025-journey-and-results
 title: "Cardano Summit 2025: The Journey and the Results"
 authors: [cf]
-tags: [recap,report,events]
+tags: [events, ecosystem]
 ---
 
 

--- a/blog/2026-03-03-community-digest/index.md
+++ b/blog/2026-03-03-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2026-03-03-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest,ambassadors]
+tags: [community]
 ---
 
 

--- a/blog/2026-03-05-ada-now-accepted-at-spar-stores/index.md
+++ b/blog/2026-03-05-ada-now-accepted-at-spar-stores/index.md
@@ -2,7 +2,7 @@
 slug: 2026-03-05-ada-now-accepted-at-spar-stores
 title: "ADA Now Accepted at 137 SPAR Stores across Switzerland"
 authors: [cf]
-tags: [development]
+tags: [ecosystem]
 ---
 
 

--- a/blog/2026-03-06-weekly-development-report/index.md
+++ b/blog/2026-03-06-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2026-03-06-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Payments in 137 SPAR stores across Switzerland now support ada, highlighting significant real-world adoption. The ledger team advanced nested transactions and performance restructuring, while the Lace wallet integrated Midnight mainnet support and the LaceID identity feature. Furthermore, the Mithril team completed signer authentication for SNARK verification keys. Research breakthroughs also established formal models for geographic diversity and Sybil-proofness in decentralized restaking networks.

--- a/blog/2026-03-09-programmable-tokens-for-cardano/index.md
+++ b/blog/2026-03-09-programmable-tokens-for-cardano/index.md
@@ -2,7 +2,7 @@
 slug: 2026-03-09-programmable-tokens-for-cardano
 title: "Programmable Tokens for Cardano"
 authors: [cf]
-tags: [development, developers]
+tags: [development]
 ---
 
 

--- a/blog/2026-03-13-weekly-development-report/index.md
+++ b/blog/2026-03-13-weekly-development-report/index.md
@@ -2,7 +2,7 @@
 slug: 2026-03-13-weekly-development-report
 title: "Weekly Development Report"
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Binance listed the NIGHT token, and the Sandstone team released Torsten, a new Cardano node written in Rust. The consensus team progressed on the Ouroboros Leios prototype and updated the node-to-client protocol to version 23. Lace is preparing for the Midnight mainnet launch, while Mithril continues implementing succinct proofs (SNARKs). Additionally, Intersect announced that committee election applications will open on March 30.

--- a/blog/2026-03-16-community-digest/index.md
+++ b/blog/2026-03-16-community-digest/index.md
@@ -2,7 +2,7 @@
 slug: 2026-03-16-community-digest
 title: "Community Digest"
 authors: [cf]
-tags: [community digest,ambassadors]
+tags: [community]
 ---
 
 

--- a/blog/2026-03-18-media-debate-on-ncl/index.md
+++ b/blog/2026-03-18-media-debate-on-ncl/index.md
@@ -3,7 +3,7 @@ slug: 2026-03-18-media-debate-on-ncl
 title: "Cardano Governance - A Debate on NCL & Constitutional Clarity"
 description: "Panel debates Cardano's Net Change Limit and treasury sustainability: constitutional interpretations of fund approval and the Constitutional Committee's role."
 authors: [community]
-tags: [ecosystem]
+tags: [governance]
 ---
 
 This session explores the Net Change Limit (NCL) and its role in Cardano’s treasury sustainability. Participants discussed constitutional interpretations regarding fund approval and the role of the Constitutional Committee, focusing on clarifying governance rules to ensure responsible spending and transparency within the ecosystem.

--- a/blog/2026-03-18-media-debate-on-ncl/index.md
+++ b/blog/2026-03-18-media-debate-on-ncl/index.md
@@ -3,7 +3,7 @@ slug: 2026-03-18-media-debate-on-ncl
 title: "Cardano Governance - A Debate on NCL & Constitutional Clarity"
 description: "Panel debates Cardano's Net Change Limit and treasury sustainability: constitutional interpretations of fund approval and the Constitutional Committee's role."
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 This session explores the Net Change Limit (NCL) and its role in Cardano’s treasury sustainability. Participants discussed constitutional interpretations regarding fund approval and the role of the Constitutional Committee, focusing on clarifying governance rules to ensure responsible spending and transparency within the ecosystem.

--- a/blog/2026-03-20-weekly-development-report/index.md
+++ b/blog/2026-03-20-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-03-20-weekly-development-report
 title: "Weekly Development Report"
 description: "Cardano Node v10.7 packages ready for the intra-era hard fork to protocol v11. Hydra v1.3.0 ships partial fanout work; team prepares for the Dijkstra era."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team reached a major milestone by releasing all packages for cardano-node v.10.7, preparing for the intra-era hard fork to protocol version 11. Mithril advanced its SNARK circuit refactoring and published a blog on mainnet protocol changes. Meanwhile, Hydra version 1.3.0 was released, featuring progress on partial fanouts and fixes for high transaction loads. The team is now focusing on the upcoming Dijkstra era.

--- a/blog/2026-03-27-weekly-development-report/index.md
+++ b/blog/2026-03-27-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-03-27-weekly-development-report
 title: "Weekly Development Report"
 description: "Node v10.7.0 ships, Peras adds on-chain certificate tracking, Mithril completes Halo2 SNARK primitives, Aggelos Kiayias named 2026 IACR Fellow."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The networking and consensus teams supported the node v.10.7.0 release and progressed on the Peras protocol, including on-chain certificate tracking. Mithril completed the Halo2 circuit and SNARK aggregation primitives, while Hydra advanced the partial fanout and directly open heads features. Additionally, Professor Aggelos Kiayias was named a 2026 IACR Fellow for his cryptographic contributions.

--- a/blog/2026-03-31-community-digest/index.md
+++ b/blog/2026-03-31-community-digest/index.md
@@ -3,7 +3,7 @@ slug: 2026-03-31-community-digest
 title: "Community Digest"
 description: "Midnight mainnet launches ZK apps, FluidTokens runs the first native Bitcoin to Cardano atomic swap, Cardano Node 10.7.0 cuts RAM use from 24 GB to 8 GB."
 authors: [cf]
-tags: [community digest,ambassadors]
+tags: [community]
 ---
 
 

--- a/blog/2026-04-03-weekly-development-report/index.md
+++ b/blog/2026-04-03-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-04-03-weekly-development-report
 title: "Weekly Development Report"
 description: "Lace integrates Midnight mainnet for private assets, Mithril activates SNARK prover on devnet, tx-centrifuge benchmarks land for node v10.6.2."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The performance and benchmarking team ran benchmarks on node v.10.6.2 and began developing tx-centrifuge, a service for generating high network workloads. Lace reached a major milestone by integrating Midnight mainnet access, allowing users to manage private assets directly in the wallet. Mithril successfully activated the SNARK prover on a developer network, while Intersect opened applications for the 2026 committee elections, with seats available across seven standing committees until April 17.

--- a/blog/2026-04-07-draper-dragen-fund/index.md
+++ b/blog/2026-04-07-draper-dragen-fund/index.md
@@ -3,7 +3,7 @@ slug: 2026-04-07-draper-dragen-fund
 title: "Cardano and Draper Dragon Announce Initial Phase of Strategic $80M Ecosystem Fund"
 description: "Cardano Foundation and Draper Dragon launch the $80M Orion Fund for RWA, DeFi, and Bitcoin liquidity, with equity returns flowing to the Cardano treasury."
 authors: [cf]
-tags: [development]
+tags: [ecosystem]
 ---
 
 

--- a/blog/2026-04-10-weekly-development-report/index.md
+++ b/blog/2026-04-10-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-04-10-weekly-development-report
 title: "Weekly Development Report"
 description: "PlutusCoreBlaster brings Plutus Core into Lean 4. Plutus UPLC optimizations, Mithril SNARK CLI for Cardano blocks, Intersect committee deadline April 17."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The High Assurance team released PlutusCoreBlaster, a full formalization of Plutus Core in Lean 4 for enhanced smart contract verification. The Plutus team improved compiler usability and added UPLC optimizations to increase execution efficiency. Mithril completed the review of its recursive SNARK circuit prototype and finalized the client CLI for Cardano blocks. Lastly, Intersect noted only seven days remain for 2026 committee election applications, closing April 17.

--- a/blog/2026-04-13-media-state-of-cardano-defi/index.md
+++ b/blog/2026-04-13-media-state-of-cardano-defi/index.md
@@ -3,7 +3,7 @@ slug: 2026-04-13-media-state-of-cardano-defi
 title: "The State of Cardano DeFi"
 description: "Cardano DeFi panel on liquidity depth, stablecoin adoption, and trading UX. Practical paths to better incentive structures and ecosystem coordination."
 authors: [community]
-tags: [media,ambassadors]
+tags: [community, ecosystem]
 ---
 
 This session addresses Cardano’s DeFi growth, focusing on liquidity depth, stablecoin adoption, and user experience. Participants discussed trading efficiency and explored practical solutions like improved incentive structures and ecosystem coordination to unlock the next phase of DeFi.

--- a/blog/2026-04-14-community-digest/index.md
+++ b/blog/2026-04-14-community-digest/index.md
@@ -3,7 +3,7 @@ slug: 2026-04-14-community-digest
 title: "Community Digest"
 description: "Pragma opens infrastructure project applications, Gerolamo TypeScript node debuts, Cardano hits 120M transactions, Van Rossem hard fork on track for June."
 authors: [cf]
-tags: [community digest,ambassadors]
+tags: [community]
 ---
 
 

--- a/blog/2026-04-17-media-drep-votin-power-concentration/index.md
+++ b/blog/2026-04-17-media-drep-votin-power-concentration/index.md
@@ -3,7 +3,7 @@ slug: 2026-04-17-media-drep-votin-power-concentration
 title: "DRep Voting Power Concentration: The Path Forward"
 description: "How wallet design shapes DRep voting power on Cardano. Panel discusses delegation incentives, voter participation, and institutional DReps in governance."
 authors: [community]
-tags: [media,ambassadors]
+tags: [community, ecosystem]
 ---
 
 This session explores how wallet design influences delegation and voting power concentration in Cardano. Participants discussed DRep accountability, voter participation, and the role of institutional DReps, focusing on identifying healthy dynamics for a balanced and decentralized governance ecosystem.

--- a/blog/2026-04-17-weekly-development-report/index.md
+++ b/blog/2026-04-17-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-04-17-weekly-development-report
 title: "Weekly Development Report"
 description: "Treasury proposals finalized; Leios & Node v10.7 updates; new decentralized AI research lab in Greece; Intersect committee voting starts April 20."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Nine 2026 treasury proposals have been finalized, outlining the roadmap for Cardano’s core protocol and scaling initiatives. Technical teams successfully integrated Leios endorser blocks and optimized Node v10.7 for the upcoming Van Rossem hard fork. Innovation continues with a new decentralized AI and healthcare lab in Greece, while the Intersect committee elections move into the voting phase on April 20.

--- a/blog/2026-04-22-yoroi-wallet-is-evolving-into-secondfi/index.md
+++ b/blog/2026-04-22-yoroi-wallet-is-evolving-into-secondfi/index.md
@@ -3,7 +3,7 @@ slug: 2026-04-22-yoroi-wallet-is-evolving-into-secondfi
 title: "Yoroi Wallet Is Evolving Into SecondFi: What You Need to Know"
 description: "Yoroi evolves into SecondFi, a neofinance app for spending & earning. Assets and staking remain safe; the app updates automatically to the new platform."
 authors: [emurgo]
-tags: [development]
+tags: [ecosystem]
 ---
 
 Yoroi Wallet is rebranding to SecondFi, a neofinance platform bridging everyday spending with on-chain services like trading, earning, and global card payments. The transition is seamless: existing assets and staking remain safe, and the app updates automatically. While the platform evolves, the Yoroi brand will persist independently as a dedicated DRep to support Cardano governance.

--- a/blog/2026-04-24-weekly-development-report/index.md
+++ b/blog/2026-04-24-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-04-24-weekly-development-report
 title: "Weekly Development Report"
 description: "2026 Treasury proposals live; Leios & Mithril SNARK progress; Plutus UPLC reduces costs by 10%; Intersect committee voting open with 105 candidates."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 Nine 2026 treasury proposals from IO are now live, focusing on scalability and performance with DRep voting open until May 24. The consensus team advanced the Leios prototype by adding throughput metrics and investigating storage latency to ensure protocol stability. A significant update from the Plutus team introduced script optimizations for the UPLC executable, which can reduce execution costs by an average of 10%. Additionally, the Mithril team prepared for SNARK circuit production readiness, while Intersect committee elections are underway with 105 candidates competing for 37 seats.

--- a/blog/2026-04-28-community-digest/index.md
+++ b/blog/2026-04-28-community-digest/index.md
@@ -3,7 +3,7 @@ slug: 2026-04-28-community-digest
 title: "Community Digest"
 description: "Cardano joins x402 for AI; Blockfrost adds Filecoin; Van Rossem upgrade nears; JuLC for Java devs; new 21M ADA marketing proposal for enterprise growth."
 authors: [cf]
-tags: [community digest,ambassadors]
+tags: [community]
 ---
 
 

--- a/blog/2026-05-01-weekly-development-report/index.md
+++ b/blog/2026-05-01-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-05-01-weekly-development-report
 title: "Weekly Development Report"
 description: "IO’s 2026 treasury proposals live; Q4/Q1 delivery report published; Leios & Mithril SNARK progress; Intersect committee voting concludes today."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 This report marks the launch of IO’s 2026 treasury proposals on the official proposals website, accompanied by the Q4 2025 – Q1 2026 delivery report detailing recent technical milestones. The consensus team continues to advance the Ouroboros Leios prototype, while the Mithril team focuses on implementing succinct proofs (SNARKs) to enhance network scaling. In governance, the Intersect committee elections conclude their voting phase today, May 1, marking a key step in decentralized decision-making for the ecosystem.

--- a/blog/2026-05-04-media-drep-participation-in-focus/index.md
+++ b/blog/2026-05-04-media-drep-participation-in-focus/index.md
@@ -3,7 +3,7 @@ slug: 2026-05-04-media-drep-participation-in-focus
 title: "DRep Participation in Focus: Power Is One Thing. Participation Is Another"
 description: "Exploring DRep participation and accountability in Cardano governance to address fatigue and improve voting consistency."
 authors: [community]
-tags: [ecosystem]
+tags: [governance]
 ---
 
 This Roundtable examines DRep participation and accountability in Cardano governance. Discussants focused on overcoming inconsistency and "DRep fatigue" through better voting rationales and sustainable role definitions. The goal is a robust framework that keeps DReps active and accountable, ensuring long-term decentralized alignment.

--- a/blog/2026-05-04-media-drep-participation-in-focus/index.md
+++ b/blog/2026-05-04-media-drep-participation-in-focus/index.md
@@ -3,7 +3,7 @@ slug: 2026-05-04-media-drep-participation-in-focus
 title: "DRep Participation in Focus: Power Is One Thing. Participation Is Another"
 description: "Exploring DRep participation and accountability in Cardano governance to address fatigue and improve voting consistency."
 authors: [community]
-tags: [media]
+tags: [ecosystem]
 ---
 
 This Roundtable examines DRep participation and accountability in Cardano governance. Discussants focused on overcoming inconsistency and "DRep fatigue" through better voting rationales and sustainable role definitions. The goal is a robust framework that keeps DReps active and accountable, ensuring long-term decentralized alignment.

--- a/blog/2026-05-08-weekly-development-report/index.md
+++ b/blog/2026-05-08-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-05-08-weekly-development-report
 title: "Weekly Development Report"
 description: "Leios testnet active & Node v11.0 pre-released; Hydra optimizes high-volume benchmarks; Mithril SNARK tests finish; research proposal goes on-chain."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team advanced the Leios prototype by migrating flags to the Praos header, launching a dedicated testnet, and pre-releasing Cardano Node v11.0. In scaling, Hydra optimized benchmark performance for high transaction volumes, while Mithril completed data encoding and state transition tests for its recursive SNARK prototype. Additionally, the research team officially submitted their proposal on-chain.

--- a/blog/2026-05-11-community-digest/index.md
+++ b/blog/2026-05-11-community-digest/index.md
@@ -3,7 +3,7 @@ slug: 2026-05-11-community-digest
 title: "Community Digest"
 description: "Pyth Pro feeds live; Yoroi rebrands to SecondFi; Intersect confirms elections and Node v11.0.1 readiness; Cardano Foundation launches Brazil lab."
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2026-05-15-weekly-development-report/index.md
+++ b/blog/2026-05-15-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-05-15-weekly-development-report
 title: "Weekly Development Report"
 description: "Node v11.0.1 live for v11 hard fork; Dijkstra era prep continues; Plutus UPLC cuts costs by 10%; Hydra v2.1.0 lowers latency; Mithril finishes SNARK validations."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 IO's core teams released Cardano Node v11.0.1 to support the upcoming protocol version 11 intra-era hard fork, while the ledger team advanced preparations for the Dijkstra era. The Plutus team enhanced the UPLC command-line tool, introducing script optimizations that yield over 10% in execution cost savings. In scaling, Hydra v2.1.0 was launched with 7% lower snapshot latency and protocol v12+ compatibility, and Mithril finalized key SNARK circuit validations and standard Schnorr signatures.

--- a/blog/2026-05-22-weekly-development-report/index.md
+++ b/blog/2026-05-22-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-05-22-weekly-development-report
 title: "Weekly Development Report"
 description: "Leios prototype adds first voting features; Lace launches on iOS; Mithril completes SNARK circuit refactoring; legacy V1 LedgerDB removed."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team added initial voting capabilities to the Leios prototype and retired the legacy V1 LedgerDB to simplify the API and clear the way for on-disk tables. In wallets, Lace launched on iOS, wrapping up its multi-platform rollout. Additionally, the Mithril team finalized recursive circuit refactoring and off-circuit verification tests for its SNARK prototype.

--- a/blog/2026-05-26-community-digest/index.md
+++ b/blog/2026-05-26-community-digest/index.md
@@ -3,7 +3,7 @@ slug: 2026-05-26-community-digest
 title: "Community Digest"
 description: "Gimbalabs hosts public hackathon; Aiken v1.1.22 delivers compiler upgrades; revised Cardano Summit 2026 proposal features a 22% budget cut; new CIPs target mobile deep-linking."
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2026-05-29-weekly-development-report/index.md
+++ b/blog/2026-05-29-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-05-29-weekly-development-report
 title: "Weekly Development Report"
 description: "Leios funding approved with 88% support and certificate size reduced 40x; Plutus optimizations completed; Constitutional Committee registration opens."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The ledger team completed Plutus performance optimizations, while the Smart Contracts team secured funding to extend the "Blaster" verification tool into Aiken. For Leios, treasury funding was approved with 88% support, and a CIP-0164 update reduced certificate size by 40x. Additionally, candidate registration opened for the Constitutional Committee elections.

--- a/blog/2026-06-04-leios-roadmap-solving-blockchain-trilemma/index.md
+++ b/blog/2026-06-04-leios-roadmap-solving-blockchain-trilemma/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-04-leios-roadmap-solving-blockchain-trilemma
 title: "The Leios roadmap to solving the blockchain trilemma"
 description: "The Leios roadmap details how Cardano achieves horizontal scalability on consumer-grade hardware by combining decoupled transaction sequencing with SNARKs, DAS, and UTXO sharding."
 authors: [iog]
-tags: [development,ouroboros]
+tags: [development, research]
 ---
 
 The Ouroboros Leios architecture solves the blockchain trilemma by decoupling transaction diffusion from sequencing. This setup integrates advanced cryptography, including SNARKs for sublinear correctness verification, Data Availability Sampling (DAS) to verify blocks without full downloads, and Bloom filters to check data relevance. Finally, UTXO sharding distributes state maintenance across the network, enabling true horizontal scalability so that consumer-grade hardware nodes can participate securely without processing the entire blockchain.

--- a/blog/2026-06-05-weekly-development-report/index.md
+++ b/blog/2026-06-05-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-05-weekly-development-report
 title: "Weekly Development Report"
 description: "Lace 2.0.6 fixes DRep signing; Leios prototype advances to the Dijkstra era; Hydra removes UTXO head limits via partial fanout; Mithril optimizes SNARK circuit caching."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team advanced the Leios prototype toward the Dijkstra era and finalized the certificate size reduction to 200 bytes. In wallets, Lace 2.0.6 went live, fixing DRep ID message signing for mnemonic wallets and adopting the CIP-129 format. For scaling, Hydra merged its partial fanout feature to eliminate the UTXO limit per head, while Mithril completed circuit key caching for its SNARK library.

--- a/blog/2026-06-08-cardano-is-connecting-to-all-of-crypto/index.md
+++ b/blog/2026-06-08-cardano-is-connecting-to-all-of-crypto/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-08-cardano-is-connecting-to-all-of-crypto
 title: "Cardano is connecting to all of crypto"
 description: "Cardano is integrating LayerZero to allow over 800 tokens to move natively and securely into its ecosystem, with a phased rollout scheduled to complete by the end of 2026."
 authors: [iog]
-tags: [development,interoperability]
+tags: [development]
 ---
 
 The LayerZero integration connects Cardano to the wider crypto economy, enabling over 800 tokens to move natively onto the network. These assets will benefit from Cardano's built-in ledger security and deterministic smart contracts. The rollout will proceed in phases through 2026 launching endpoints, the Stargate liquidity layer, and developer tools with the goal of supporting any asset by year-end.

--- a/blog/2026-06-10-community-digest/index.md
+++ b/blog/2026-06-10-community-digest/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-10-community-digest
 title: "Community Digest"
 description: "Budget voting is live via Hydra; the Van Rossem hard fork is active on PreProd; new CIPs target pool pledges and L2 voting; the Cardano Foundation partners with the Brazilian Olympic Committee."
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2026-06-10-media-examining-cardano-critical/index.md
+++ b/blog/2026-06-10-media-examining-cardano-critical/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-10-media-examining-cardano-critical
 title: "Examining Cardano Critical Integrations V2 with the Pentad"
 description: "The CCI V2 Roundtable gathers Pentad representatives to objectively dissect a joint proposal for core infrastructure maintenance, explaining its strict scope, steering committee oversight, and treasury mechanisms."
 authors: [community]
-tags: [media]
+tags: [development]
 ---
 
 The CCI V2 Roundtable Talk gathers Pentad representatives to review a joint proposal focused strictly on maintaining critical core infrastructure and establishing an upgrade framework. The session covers the role of the new Steering Committee, treasury oversight, and how operational choices were prioritized. Notably, the proposal excludes funding for DApps, liquidity, or marketing, and serves as an objective, auto-dubbed review rather than a promotional event.

--- a/blog/2026-06-11-unifying-cardano-for-extra-impact/index.md
+++ b/blog/2026-06-11-unifying-cardano-for-extra-impact/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-11-unifying-cardano-for-extra-impact
 title: "Unifying Cardano for Extra Impact"
 description: "The unified marketing campaign by the Cardano Foundation, EMURGO, and Rare Network maximized global brand footprint across 20 events, giving 76 ecosystem projects a stage and sparking key institutional connections."
 authors: [cf]
-tags: [adoption]
+tags: [events]
 ---
 
 

--- a/blog/2026-06-12-weekly-development-report/index.md
+++ b/blog/2026-06-12-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-12-weekly-development-report
 title: "Weekly Development Report"
 description: "A smart contract testing beta was launched, Mithril finalized its SNARK genesis certificate, the Constitutional Committee called for more election candidates, and the Cardano Vision 2026 proposal passed."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The High Assurance team launched a smart contract testing beta tool, while the Mithril team completed its SNARK-friendly genesis certificate and optimized recursive scaling primitives. Under Voltaire, a critical call for candidates was issued for the upcoming Constitutional Committee election to ensure a competitive process. Finally, the Research team had its Cardano Vision 2026 proposal officially ratified by the community with 74.96% DRep approval.

--- a/blog/2026-06-19-cardano-vision-2026/index.md
+++ b/blog/2026-06-19-cardano-vision-2026/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-19-cardano-vision-2026
 title: "Cardano Vision 2026"
 description: "The first R&D session of 2026 unveiled the Cardano Vision 2026 research program, spanning post-quantum security, multi-layer scalability, decentralized identity, and zero-knowledge verification"
 authors: [iog]
-tags: [development]
+tags: [research]
 ---
 
 The Cardano Vision 2026 research roadmap outlines 15 key initiatives across six core technical pillars. Developed by a global academic consortium, the program drives multi-layer scalability (via Leios and Peras), cross-chain zero-knowledge (ZK) tooling, decentralized identity, and verified governance models. Its primary strategic defense is a bottom-up post-quantum cryptography (PQC) framework designed to preemptively swap out core consensus primitives for quantum-secure alternatives.

--- a/blog/2026-06-19-weekly-development-report/index.md
+++ b/blog/2026-06-19-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-19-weekly-development-report
 title: "Weekly Development Report"
 description: "Lace Carbon entered internal testing, Hydra v2.2.0 launched, Mithril advanced recursive SNARKs, and the Constitutional Committee election officially became competitive with five candidates."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The Consensus team improved Mithril integration for snapshot exports, while Lace Carbon began internal testing. For scaling, Hydra v2.2.0 launched with upgraded benchmarks, and Mithril finalized recursive SNARK verification. Under Voltaire, the Constitutional Committee election became competitive with five candidates for four seats, with DRep voting starting June 23. The Research team advanced its Cardano Vision 2026 workstreams.

--- a/blog/2026-06-24-community-digest/index.md
+++ b/blog/2026-06-24-community-digest/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-24-community-digest
 title: "Community Digest"
 description: "The Ouroboros Leios scaling testnet (Musashi Dojo) has launched; applications are opening for the $80M Orion Fund cohort and a board seat; Pyth Network oracles are live; and Fortune recognized the Cardano Foundation."
 authors: [cf]
-tags: [community digest]
+tags: [community]
 ---
 
 

--- a/blog/2026-06-25-cf-senai-partnership/index.md
+++ b/blog/2026-06-25-cf-senai-partnership/index.md
@@ -3,7 +3,7 @@ slug: 2026-06-25-cf-senai-partnership
 title: "Cardano Foundation and SENAI São Paulo Forge Strategic Partnership"
 description: "The Cardano Foundation partnered with SENAI São Paulo to integrate blockchain technology into Brazilian industry through comprehensive training, certifications, and real-world industrial traceability pilots."
 authors: [cf]
-tags: [adoption]
+tags: [ecosystem]
 ---
 
 

--- a/blog/2026-07-04-learncardano-update/index.md
+++ b/blog/2026-07-04-learncardano-update/index.md
@@ -3,7 +3,7 @@ slug: 2026-07-04-media-cardano-ecosystem-updates
 title: "SecondFi Recovery, Midnight Pause, Open USD and Cardano's DeFi Funding Debate"
 description: "Video covering the SecondFi asset recovery process, paused Midnight Glacier Drop redemptions, the Open USD stablecoin standard, and Cardano treasury funding for DeFi growth."
 authors: [learncardano]
-tags: [media]
+tags: [ecosystem]
 ---
 
 Learn Cardano examines the SecondFi asset recovery checker and its 16 million ada recovery fund, the precautionary pause on Midnight Glacier Drop redemptions, and how the Open USD stablecoin standard connects to Cardano through Brale. The episode also explores the proposed 500 million ada net change limit and what treasury funding means for DeFi and infrastructure growth.

--- a/blog/2026-07-08-community-digest/index.md
+++ b/blog/2026-07-08-community-digest/index.md
@@ -3,7 +3,7 @@ slug: 2026-07-08-community-digest
 title: "Community Digest"
 description: "Genesis Hacker House applications opened for Cardano builders, the State of Cardano Governance 2026 report was released, RealFi launched its Phase 1 testnet, and several CIPs advanced through review."
 authors: [community]
-tags: [community digest]
+tags: [community]
 ---
 
 Applications are open for Draper University's Genesis Hacker House, a four week Silicon Valley residency for early stage teams building on Cardano, while Arouet Holdings is seeking candidates for its voluntary Community Director board role. The State of Cardano Governance 2026 report examines DRep participation, voting power concentration, and SPO engagement, with six recommendations to strengthen governance. RealFi launched its Phase 1 testnet, opening swap, stake, and unstake actions for its stablecoin based credit protocol, and several Cardano Improvement Proposals advanced through active review, including Proof of Existence metadata and DRep voting power concentration.

--- a/blog/2026-07-10-media-cardano-defi-utxo-emurgo-update/index.md
+++ b/blog/2026-07-10-media-cardano-defi-utxo-emurgo-update/index.md
@@ -3,7 +3,7 @@ slug: 2026-07-10-media-cardano-defi-utxo-emurgo-update
 title: "Cardano's 120M ada DeFi Bet, Ethereum UTXO Shift and EMURGO Exit"
 description: "Cardano news update on AlphaGrowth's 120 million ada DeFi proposal, Ethereum UTXO research, RealFi testnet, SecondFi guidance and EMURGO's Pentad exit."
 authors: [learncardano]
-tags: [media]
+tags: [ecosystem]
 ---
 
 Learn Cardano's latest episode covers AlphaGrowth's on-chain Cardano PRIME proposal, a 120 million ada DeFi growth request, governance debate around the net change limit, Ethereum research into native UTXOs, RealFi's testnet launch, SecondFi recovery guidance, and EMURGO stepping down from the Pentad while recovery work continues.

--- a/blog/2026-07-10-weekly-development-report/index.md
+++ b/blog/2026-07-10-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-07-10-weekly-development-report
 title: "Weekly Development Report"
 description: "The legacy iohk-monitoring tracing backend and RTView were removed from cardano-node, Lace shipped browser extension 2.1 with a wallet security check, and DRep voting opened in the Constitutional Committee election."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The performance and tracing team removed the legacy iohk-monitoring tracing backend (roughly 11,000 lines) and RTView from cardano-tracer, while the ledger team extended StAnnTx memoization to Alonzo and merged the first Leios-related changes. In wallets, Lace released browser extension 2.1, headlined by a wallet security check feature. Under Voltaire, DRep voting is underway in the Constitutional Committee election ahead of the July 23 deadline, and the Research team advanced its Cardano Vision 2026 workstreams with the first zero-knowledge technical workshop.

--- a/blog/2026-07-16-aiken-primitives-explained/index.md
+++ b/blog/2026-07-16-aiken-primitives-explained/index.md
@@ -3,7 +3,7 @@ slug: 2026-07-16-aiken-primitives-explained
 title: "Aiken’s BLS12-381 Primitives Wide Possibilities Explained"
 description: "Cardano's Plutus Core ships native BLS12-381 elliptic-curve primitives that let Aiken scripts aggregate signatures, verify zero-knowledge proofs, and build anonymous credentials on-chain without oracles."
 authors: [cf]
-tags: [development, developers]
+tags: [development]
 ---
 
 Cardano's Plutus Core ships first-class built-in primitives for the pairing-friendly BLS12-381 elliptic curve, exposing scalar multiplication, point addition, hash-to-curve, and pairing checks that any Plutus or Aiken script can run natively without external services or trusted oracles. The article walks through the curve and the Aiken API, then builds four concrete protocols on top of those primitives: BLS signature aggregation and multi-sig, key derivation from passwords and seeds, verifiable random functions for privacy and leader selection, and BBS+ signatures for anonymous credentials with selective disclosure. A follow-up will compose the same primitives into zk-SNARKs and polynomial commitment schemes.

--- a/blog/2026-07-16-introducing-the-cans-protocol/index.md
+++ b/blog/2026-07-16-introducing-the-cans-protocol/index.md
@@ -3,7 +3,7 @@ slug: 2026-07-16-introducing-the-cans-protocol
 title: "Introducing the CANS protocol: unlocking Bitcoin liquidity for Cardano DeFi"
 description: "Input Output's Cyclic Atomic N-party Swap protocol enables trustless cross-chain asset exchanges without bridges, wrapped tokens, or custodians, with a mathematical guarantee that every party receives funds or none do."
 authors: [iog]
-tags: [interoperability]
+tags: [development]
 ---
 
 Input Output's Cyclic Atomic N-party Swap (CANS) protocol arranges participants in a ring where each sends assets once and receives once, with the entire swap enforced as atomic: either everyone gets what they agreed to, or nobody loses anything. The design removes the need for bridges, wrapped tokens, or trusted intermediaries by making signatures conditionally valid behind a shared secret revealed only once every party has locked funds. A reference implementation in Rust, formally verified with up to 20 concurrent parties, shows the approach works in practice today, and any chain with native or verifiable Schnorr signatures can join a swap session.

--- a/blog/2026-07-16-media-constitutional-committee-election-2026/index.md
+++ b/blog/2026-07-16-media-constitutional-committee-election-2026/index.md
@@ -3,7 +3,7 @@ slug: 2026-07-16-media-constitutional-committee-election-2026
 title: "Constitutional Committee Election 2026: Real Talk with the Candidates"
 description: "A Cardano Community roundtable with Constitutional Committee candidates explores the realities of the role, including workload, transparency, constitutional interpretation, and whether the current incentive model supports long-term participation."
 authors: [community]
-tags: [media]
+tags: [governance]
 ---
 
 A Cardano Community roundtable hosted three Constitutional Committee candidates to discuss what serving on the Committee involves as the 2026 election gets underway. Moderated by the Cardano Foundation governance lead, the session moved past a traditional candidate introduction to examine the practical realities of the role, including workload, transparency, constitutional interpretation, collaboration, and Committee fatigue. Candidates also addressed whether the current incentive model is sufficient to sustain long-term participation, giving DReps and observers a fuller view of the responsibilities and challenges ahead of the vote.

--- a/blog/2026-07-17-weekly-development-report/index.md
+++ b/blog/2026-07-17-weekly-development-report/index.md
@@ -3,7 +3,7 @@ slug: 2026-07-17-weekly-development-report
 title: "Weekly Development Report"
 description: "The Leios testnet was stabilized with two prototype builds and a voting dashboard, the Plinth Static Analyzer launched, Mithril advanced its SNARK circuit, and the van Rossem hard fork passed ratification ahead of the Dijkstra era."
 authors: [iog]
-tags: [weekly development report, development]
+tags: [development]
 ---
 
 The consensus team stabilized the Leios testnet with two prototype builds and a voting dashboard for endorser block observability. The High Assurance team shipped the Plinth Static Analyzer on the Visual Studio Marketplace and a JSON-RPC backend for property-based testing. Mithril completed the SNARK recursive circuit modularity work and upgraded the midnight-zk library. Under Voltaire, the van Rossem hard fork passed ratification and will enact at the next epoch boundary, advancing Plutus ahead of the Dijkstra era that introduces Ouroboros Leios. The research team published the Cardano Vision 2026 Mid-Year Progress and Transparency Report draft for community feedback.

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -1,0 +1,41 @@
+# Canonical tag taxonomy for Cardano News.
+#
+# These are the ONLY tags posts may use. The blog plugin is configured with
+# onInlineTags: 'throw', so a post referencing any tag not listed here fails
+# the build. Keep this list short and meaningful; do not add narrow one-off
+# tags. When a post spans several topics, list the most specific tag first.
+
+development:
+  label: Development
+  permalink: /development
+  description: Weekly development reports, protocol progress, tooling, and developer resources.
+
+research:
+  label: Research
+  permalink: /research
+  description: Peer-reviewed research, Ouroboros, and scaling work behind Cardano.
+
+governance:
+  label: Governance
+  permalink: /governance
+  description: On-chain governance, Project Catalyst, Intersect, and stake pool operations.
+
+community:
+  label: Community
+  permalink: /community
+  description: Community digests, ambassadors, and grassroots initiatives.
+
+ecosystem:
+  label: Ecosystem
+  permalink: /ecosystem
+  description: Ecosystem news, partnerships, adoption, and Cardano Foundation updates.
+
+education:
+  label: Education
+  permalink: /education
+  description: Guides, tutorials, and learning resources for Cardano.
+
+events:
+  label: Events
+  permalink: /events
+  description: Summits, hackathons, meetups, and community events.

--- a/docs/get-involved/create-a-news-article.md
+++ b/docs/get-involved/create-a-news-article.md
@@ -65,7 +65,7 @@ Every news article must declare the following fields at the top of its `index.md
 | `title` | The headline shown on the article page, in listings, and in social cards. |
 | `description` | A 140-160 character meta description used by search engines and social previews (Google snippet, OG card, Twitter card). This is **not** the same as the in-post summary. |
 | `authors` | One or more author handles defined in `/blog/authors.yml`. |
-| `tags` | Topical labels (specific to broad). |
+| `tags` | One or more categories from the fixed set (see [News Article Tags](#news-article-tags)). Any tag outside that set fails the build. |
 
 ### Writing a good `description`
 
@@ -99,7 +99,7 @@ slug: hello-world
 title: Hello World!
 description: A short greeting and our first post on cardano.org, demonstrating how the news system works for new contributors.
 authors: [builderfest]
-tags: [greetings]
+tags: [community]
 ---
 
 Congratulations, you have made your first news article!
@@ -121,7 +121,7 @@ slug: hello-world
 title: Hello World!
 description: A short greeting and our first post on cardano.org, demonstrating how the news system works for new contributors.
 authors: [builderfest, taptools]
-tags: [greetings]
+tags: [community]
 ---
 
 Congratulations, you have made your first news article!
@@ -133,6 +133,12 @@ Feel free to play around and edit this post as much as you like.
 For banners and other graphic media, please use the following file formats:
 
 Images: `.png`, `.jpg` (or `.jpeg`), `.webp`, and `.svg`.
+
+:::tip
+
+The first image in the post is also used as the article's thumbnail in the homepage news section. Articles without an image fall back to an on-brand image for their category.
+
+:::
 
 :::tip
 
@@ -155,7 +161,7 @@ slug: hello-world
 title: Hello World!
 description: A short greeting and our first post on cardano.org, demonstrating how the news system works for new contributors.
 authors: [builderfest, taptools]
-tags: [greetings]
+tags: [community]
 ---
 
 Congratulations, you have made your first news article!
@@ -202,7 +208,7 @@ slug: 2024-10-25-media-cardano-summit-2024-day1
 title: "Cardano Summit 2024 - Day 1 Highlights"
 description: "Recap of day one at the Cardano Summit 2024 in Dubai: keynotes, panels, the Cardano Market, and community highlights from across the ecosystem."
 authors: [cf]
-tags: [media, summit, events]
+tags: [events]
 ---
 
 An amazing first day at the Cardano Summit 2024 in Dubai! Keynotes: Unveiling the latest in blockchain innovation and envisioning Cardano’s future. Panels: Delving into real-world applications with insights from industry leaders and experts. Cardano Market: Exploring groundbreaking projects, startups, and connecting with the vibrant Cardano community. Community: Meeting passionate people from all corners of the world, exchanging ideas and experiences.
@@ -216,11 +222,23 @@ An amazing first day at the Cardano Summit 2024 in Dubai! Keynotes: Unveiling th
 
 ## News Article Tags
 
-Tags are labels assigned to articles, allowing multiple tags per article and enabling flexible categorization and search. You should always use tags so that there are several hits per tag and they are not too specific. You can find an overview of all tags on https://cardano.org/news/tags
+cardano.org uses a **fixed set of seven categories**, defined in `/blog/tags.yml`. Only these tags may be used; any other tag fails the build.
+
+| Tag | Use for |
+|---|---|
+| `development` | Development reports, protocol and node progress, tooling, integrations, releases |
+| `research` | Peer-reviewed research, Ouroboros, and scaling work |
+| `governance` | On-chain governance, Project Catalyst, Intersect, the Constitution, voting, treasury |
+| `community` | Community digests, ambassadors, and grassroots initiatives |
+| `ecosystem` | Ecosystem news, partnerships, adoption, and Cardano Foundation updates |
+| `education` | Guides, tutorials, and explainers |
+| `events` | Summits, hackathons, meetups, and event recaps |
+
+An article may carry more than one tag. **List the most relevant category first** because it is shown as the article's badge in the homepage news section and is used as its main category. You can browse the category pages at https://cardano.org/news/tags
 
 :::tip
 
-When tagging go from specific to broad. Example: weekly development report, development. Not: development, weekly development report.
+If an article fits none of the seven categories well, pick the closest one rather than inventing a new tag. To propose a new category, add it to `/blog/tags.yml` in the same pull request.
 
 :::
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -170,6 +170,9 @@ const config = {
           showReadingTime: false,
           routeBasePath: 'news',
           blogSidebarCount: 50,
+          // Only tags defined in blog/tags.yml may be used; any other tag
+          // fails the build. Keeps the tag taxonomy from drifting over time.
+          onInlineTags: 'throw',
           editUrl: `${vars.repository}/edit/${vars.branch}`,
           onUntruncatedBlogPosts: 'ignore',
           // Replaces the default "Blog | Cardano" page title and missing
@@ -228,6 +231,34 @@ const config = {
             const prefix = match[1] || '';
             return [`${prefix}/docs/glossary`];
           }
+
+          // The blog tag taxonomy was consolidated to the 7 tags in
+          // blog/tags.yml. Redirect the retired tag pages to the tag they were
+          // folded into so old links and search results keep working.
+          const tagMerges = {
+            development: ['weekly-development-report', 'developers', 'interoperability'],
+            research: ['ouroboros', 'scaling'],
+            governance: ['catalyst', 'mbo', 'spo'],
+            community: ['community-digest', 'ambassadors'],
+            ecosystem: ['media', 'adoption', 'report', 'activity-report', 'strategy'],
+            events: ['summit', 'buidler-fest', 'hackathons'],
+          };
+          const tagMatch = existingPath.match(/^(\/(?:ja|de|es|vi))?\/news\/tags\/([a-z-]+)\/?$/);
+          if (tagMatch) {
+            const prefix = tagMatch[1] || '';
+            const retired = tagMerges[tagMatch[2]];
+            if (retired) {
+              return retired.map((slug) => `${prefix}/news/tags/${slug}`);
+            }
+          }
+
+          // Dropped tags (format modifiers) point at the news index.
+          const newsIndex = existingPath.match(/^(\/(?:ja|de|es|vi))?\/news\/?$/);
+          if (newsIndex) {
+            const prefix = newsIndex[1] || '';
+            return ['recap', 'survey'].map((slug) => `${prefix}/news/tags/${slug}`);
+          }
+
           return undefined;
         },
       },

--- a/scripts/generate-recent-news.js
+++ b/scripts/generate-recent-news.js
@@ -27,12 +27,16 @@ const dirs = fs
   .sort()
   .reverse();
 
+// Return the markdown body after the YAML frontmatter.
+function getPostBody(content) {
+  const parts = content.split('---');
+  return parts.length >= 3 ? parts.slice(2).join('---') : '';
+}
+
 // Extract first paragraph from markdown content (after frontmatter)
 function extractDescription(content) {
-  // Remove frontmatter
-  const parts = content.split('---');
-  if (parts.length < 3) return '';
-  const body = parts.slice(2).join('---').trim();
+  const body = getPostBody(content).trim();
+  if (!body) return '';
 
   // Find first non-empty paragraph (skip images, HTML blocks, empty lines)
   const lines = body.split('\n');
@@ -60,9 +64,7 @@ function extractDescription(content) {
 // thumbnail under static/. Returns a web URL usable as a card thumbnail, or
 // null when the post has no usable image (component falls back to default).
 async function resolveThumbnail(dir, content, slug) {
-  // Body after frontmatter
-  const parts = content.split('---');
-  const body = parts.length >= 3 ? parts.slice(2).join('---') : content;
+  const body = getPostBody(content);
 
   // First inline markdown image, e.g. ![alt](./banner.webp "title")
   const imgMatch = body.match(/!\[[^\]]*\]\(([^)]+)\)/);
@@ -72,8 +74,7 @@ async function resolveThumbnail(dir, content, slug) {
   const rawUrl = imgMatch[1].trim().split(/\s+/)[0];
 
   // Remote or already-public paths can be used as-is
-  if (/^https?:\/\//.test(rawUrl)) return rawUrl;
-  if (rawUrl.startsWith('/')) return rawUrl;
+  if (/^https?:\/\//.test(rawUrl) || rawUrl.startsWith('/')) return rawUrl;
 
   // In-post relative asset: resolve on disk and emit a small WebP thumbnail
   const rel = rawUrl.replace(/^\.\//, '');

--- a/scripts/generate-recent-news.js
+++ b/scripts/generate-recent-news.js
@@ -7,10 +7,13 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
+const sharp = require('sharp');
 
 const blogDir = path.join(__dirname, '../blog');
 const outputPath = path.join(__dirname, '../src/data/recentNews.json');
 const authorsPath = path.join(__dirname, '../blog/authors.yml');
+const thumbsDir = path.join(__dirname, '../static/img/news-thumbs');
+const thumbsPublicBase = '/img/news-thumbs';
 
 // Load authors for resolving author keys
 const authorsYaml = fs.readFileSync(authorsPath, 'utf8');
@@ -53,6 +56,38 @@ function extractDescription(content) {
     .replace(/`([^`]+)`/g, '$1'); // `code` -> code
 }
 
+// Find the post banner image and, for in-post files, emit a downscaled WebP
+// thumbnail under static/. Returns a web URL usable as a card thumbnail, or
+// null when the post has no usable image (component falls back to default).
+async function resolveThumbnail(dir, content, slug) {
+  // Body after frontmatter
+  const parts = content.split('---');
+  const body = parts.length >= 3 ? parts.slice(2).join('---') : content;
+
+  // First inline markdown image, e.g. ![alt](./banner.webp "title")
+  const imgMatch = body.match(/!\[[^\]]*\]\(([^)]+)\)/);
+  if (!imgMatch) return null;
+
+  // Drop an optional title after the URL, and any surrounding whitespace
+  const rawUrl = imgMatch[1].trim().split(/\s+/)[0];
+
+  // Remote or already-public paths can be used as-is
+  if (/^https?:\/\//.test(rawUrl)) return rawUrl;
+  if (rawUrl.startsWith('/')) return rawUrl;
+
+  // In-post relative asset: resolve on disk and emit a small WebP thumbnail
+  const rel = rawUrl.replace(/^\.\//, '');
+  const srcPath = path.join(blogDir, dir, rel);
+  if (!fs.existsSync(srcPath)) return null;
+
+  const destName = `${slug}.webp`;
+  await sharp(srcPath)
+    .resize({ width: 800, withoutEnlargement: true })
+    .webp({ quality: 80 })
+    .toFile(path.join(thumbsDir, destName));
+  return `${thumbsPublicBase}/${destName}`;
+}
+
 // Resolve author keys to name + imageUrl
 function resolveAuthors(authorKeys) {
   if (!authorKeys) return [];
@@ -65,38 +100,47 @@ function resolveAuthors(authorKeys) {
     }));
 }
 
-const recentNews = [];
+async function main() {
+  // Start from a clean thumbnails directory so stale banners don't linger
+  fs.rmSync(thumbsDir, { recursive: true, force: true });
+  fs.mkdirSync(thumbsDir, { recursive: true });
 
-for (const dir of dirs) {
-  if (recentNews.length >= 6) break;
+  const recentNews = [];
 
-  const indexPath = path.join(blogDir, dir, 'index.md');
-  if (!fs.existsSync(indexPath)) continue;
+  for (const dir of dirs) {
+    if (recentNews.length >= 6) break;
 
-  const content = fs.readFileSync(indexPath, 'utf8');
+    const indexPath = path.join(blogDir, dir, 'index.md');
+    if (!fs.existsSync(indexPath)) continue;
 
-  // Parse frontmatter
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!fmMatch) continue;
+    const content = fs.readFileSync(indexPath, 'utf8');
 
-  const frontmatter = yaml.load(fmMatch[1]);
+    // Parse frontmatter
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!fmMatch) continue;
 
-  // Extract date from directory name
-  const dateMatch = dir.match(/^(\d{4}-\d{2}-\d{2})/);
-  if (!dateMatch) continue;
+    const frontmatter = yaml.load(fmMatch[1]);
 
-  const slug = frontmatter.slug || dir;
-  const description = frontmatter.description || extractDescription(content);
+    // Extract date from directory name
+    const dateMatch = dir.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (!dateMatch) continue;
 
-  recentNews.push({
-    title: frontmatter.title,
-    permalink: `/news/${slug}`,
-    date: dateMatch[1],
-    description,
-    authors: resolveAuthors(frontmatter.authors),
-    tags: frontmatter.tags || [],
-  });
+    const slug = frontmatter.slug || dir;
+    const description = frontmatter.description || extractDescription(content);
+
+    recentNews.push({
+      title: frontmatter.title,
+      permalink: `/news/${slug}`,
+      date: dateMatch[1],
+      description,
+      image: await resolveThumbnail(dir, content, slug),
+      authors: resolveAuthors(frontmatter.authors),
+      tags: frontmatter.tags || [],
+    });
+  }
+
+  fs.writeFileSync(outputPath, JSON.stringify(recentNews, null, 2));
+  console.log(`✅ Generated recentNews.json with ${recentNews.length} posts`);
 }
 
-fs.writeFileSync(outputPath, JSON.stringify(recentNews, null, 2));
-console.log(`✅ Generated recentNews.json with ${recentNews.length} posts`);
+main();

--- a/src/components/LatestNewsSection/index.js
+++ b/src/components/LatestNewsSection/index.js
@@ -19,8 +19,7 @@ const CATEGORY_LABELS = {
 };
 
 // On-brand category tiles (the site's Open Graph images) used as the thumbnail
-// when a post has no banner of its own. Each tile already names its category,
-// so the badge is suppressed for these (see below).
+// when a post has no banner of its own.
 const CATEGORY_IMAGES = {
   development: "/img/og/developers.jpg",
   research: "/img/og/research.jpg",

--- a/src/components/LatestNewsSection/index.js
+++ b/src/components/LatestNewsSection/index.js
@@ -5,6 +5,34 @@ import {translate} from "@docusaurus/Translate";
 import recentNews from "@site/src/data/recentNews.json";
 import styles from "./styles.module.css";
 
+// Display labels for the canonical tags defined in blog/tags.yml. Posts store
+// their tags in priority order, so tags[0] is the primary category. Colors are
+// keyed off the tag slug in styles.module.css.
+const CATEGORY_LABELS = {
+  development: "Development",
+  research: "Research",
+  governance: "Governance",
+  community: "Community",
+  ecosystem: "Ecosystem",
+  education: "Education",
+  events: "Events",
+};
+
+// On-brand category tiles (the site's Open Graph images) used as the thumbnail
+// when a post has no banner of its own. Each tile already names its category,
+// so the badge is suppressed for these (see below).
+const CATEGORY_IMAGES = {
+  development: "/img/og/developers.jpg",
+  research: "/img/og/research.jpg",
+  governance: "/img/og/governance.jpg",
+  community: "/img/og/ambassadors.jpg",
+  ecosystem: "/img/og/cardano-news.jpg",
+  education: "/img/og/get-started.jpg",
+  events: "/img/og/events.jpg",
+};
+
+const DEFAULT_IMAGE = "/img/og/default.jpg";
+
 export default function LatestNewsSection({ count = 3 }) {
   const { withBaseUrl } = useBaseUrlUtils();
   const posts = recentNews.slice(0, count);
@@ -22,9 +50,28 @@ export default function LatestNewsSection({ count = 3 }) {
   return (
     <section className={styles.newsSection}>
       <div className={styles.cardsGrid}>
-        {posts.map((post, index) => (
+        {posts.map((post, index) => {
+          const category = post.tags?.[0];
+          const imageSrc = post.image || CATEGORY_IMAGES[category] || DEFAULT_IMAGE;
+          const categoryLabel = CATEGORY_LABELS[category];
+          return (
           <Link key={post.permalink} to={post.permalink} className={`${styles.newsCard} ${index >= 3 ? styles.desktopOnly : ''}`}>
-            <span className={styles.cardDate}>{formatDate(post.date)}</span>
+            <div className={styles.cardImageWrapper}>
+              <img
+                src={withBaseUrl(imageSrc)}
+                alt=""
+                className={styles.cardImage}
+                loading="lazy"
+              />
+            </div>
+            <div className={styles.cardMeta}>
+              <span className={styles.cardDate}>{formatDate(post.date)}</span>
+              {categoryLabel && (
+                <span className={styles.categoryBadge} data-category={category}>
+                  {categoryLabel}
+                </span>
+              )}
+            </div>
             <h3 className={styles.cardTitle}>{post.title}</h3>
             <p className={styles.cardDescription}>{post.description}</p>
             <div className={styles.cardFooter}>
@@ -46,7 +93,8 @@ export default function LatestNewsSection({ count = 3 }) {
               </span>
             </div>
           </Link>
-        ))}
+          );
+        })}
       </div>
 
       <div className={styles.ctaWrapper}>

--- a/src/components/LatestNewsSection/styles.module.css
+++ b/src/components/LatestNewsSection/styles.module.css
@@ -23,8 +23,52 @@
   border: 1px solid var(--ifm-color-emphasis-200);
   text-decoration: none;
   color: inherit;
+  overflow: hidden; /* clip the full-bleed thumbnail to the card radius */
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
+
+.cardImageWrapper {
+  position: relative;
+  margin: -1.5rem -1.5rem 1.25rem; /* bleed to the card edges */
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: var(--ifm-color-emphasis-200);
+}
+
+.cardImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.cardMeta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.categoryBadge {
+  flex-shrink: 0;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #fff;
+  background: var(--ifm-color-primary);
+}
+
+.categoryBadge[data-category="development"] { background: #2563a8; }
+.categoryBadge[data-category="research"] { background: #6b46c1; }
+.categoryBadge[data-category="governance"] { background: #2f855a; }
+.categoryBadge[data-category="community"] { background: #c05621; }
+.categoryBadge[data-category="ecosystem"] { background: #2c5282; }
+.categoryBadge[data-category="education"] { background: #b7791f; }
+.categoryBadge[data-category="events"] { background: #b83280; }
 
 .newsCard:hover {
   transform: translateY(-4px);
@@ -37,7 +81,6 @@
 .cardDate {
   font-size: 0.8rem;
   color: var(--ifm-color-emphasis-600);
-  margin-bottom: 0.5rem;
 }
 
 .cardTitle {


### PR DESCRIPTION
- Homepage news cards now show the article's image, with an on-brand fallback image per category when an article has none
- Each news card shows its main category next to the date
- News tags are now a fixed set of seven categories; any other tag is rejected
- Reclassified the articles that were filed under the wrong category, and community digests now appear under Community
- Retired category pages now redirect to their replacement so existing links keep working
- Updated the contributor guide for news articles to match the new categories
