### PR TITLE
fix: show up to 4 lines of news description and remove flex:1

### DIFF
--- a/src/components/LatestNewsSection/styles.module.css
+++ b/src/components/LatestNewsSection/styles.module.css
@@ -96,9 +96,8 @@
   line-height: 1.6;
   color: var(--ifm-color-emphasis-700);
   margin: 0 0 1rem 0;
-  flex: 1;
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }


### PR DESCRIPTION
The description text in homepage news cards was showing more than 4 lines despite `-webkit-line-clamp: 3` being set, because `flex: 1` forced the description element to grow vertically and override the clamp limit.

### What changed

`src/components/LatestNewsSection/styles.module.css` — removed `flex: 1`from `.cardDescription`.
