### PR TITLE
fix: escape JSON-LD structured data on governance and insights pages

### DIFF
--- a/src/pages/governance.js
+++ b/src/pages/governance.js
@@ -27,6 +27,7 @@ import {translate} from '@docusaurus/Translate';
 import styles from "./governance.module.css";
 import governanceRoleSurvey from "@site/src/data/governanceRoleSurvey.json";
 import governanceFAQ from "@site/src/data/governanceFAQ.json";
+import { jsonLdString } from "@site/src/utils/jsonLd";
 
 function GovernanceHero() {
   return (
@@ -254,7 +255,7 @@ export default function Governance() {
       <OpenGraphInfo pageName="governance" />
       <Head>
         <script type="application/ld+json">
-          {JSON.stringify({
+          {jsonLdString({
             "@context": "https://schema.org",
             "@type": "FAQPage",
             "mainEntity": governanceFAQ.map((faq) => ({

--- a/src/pages/insights/governance-actions/index.js
+++ b/src/pages/insights/governance-actions/index.js
@@ -18,6 +18,7 @@ import Divider from "@site/src/components/Layout/Divider";
 import GovernanceCharts from "@site/src/components/GovernanceCharts";
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
 import authors from '@site/src/data/authors.json';
+import { jsonLdString } from '@site/src/utils/jsonLd';
 
 // ────────────────────────────────────────────────────────────────────────────
 //  Page Meta
@@ -100,15 +101,13 @@ function PageContent() {
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:url" content={`https://www.cardano.org/insights/${meta.pageName}`} />
         <link rel="canonical" href={`https://www.cardano.org/insights/${meta.pageName}`} />
-        <script type="application/ld+json">{`
-        {
+        <script type="application/ld+json">{jsonLdString({
           "@context": "https://schema.org",
           "@type": "Article",
-          "headline": "${pageTitle}",
-          "description": "${pageDescription}",
-          "url": "${canonicalUrl}"
-        }
-        `}</script>
+          headline: pageTitle,
+          description: pageDescription,
+          url: canonicalUrl,
+        })}</script>
       </Head>
 
       <TitleWithText

--- a/src/pages/insights/template/index.js
+++ b/src/pages/insights/template/index.js
@@ -11,6 +11,7 @@ import axios from 'axios';
 import * as echarts from 'echarts';
 import authors from '@site/src/data/authors.json';
 import { useLocation } from '@docusaurus/router';
+import { jsonLdString } from '@site/src/utils/jsonLd';
 
 // 🔹 Export meta so the indexer (mod.meta) can read it, even though indexed=false
 export const meta = {
@@ -91,7 +92,7 @@ function PageContent() {
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:url" content={canonicalUrl} />
         <link rel="canonical" href={canonicalUrl} />
-        <script type="application/ld+json">{JSON.stringify({
+        <script type="application/ld+json">{jsonLdString({
           "@context": "https://schema.org",
           "@type": "Article",
           "headline": pageTitle,


### PR DESCRIPTION
- Structured data (JSON-LD) on the Governance, Governance Actions, and
  insights template pages now escapes its values, the same way the rest
  of the site already renders JSON-LD.
- Prevents a page title or description, including translated strings,
  that contains special characters from breaking the page's structured
  data or injecting markup into the page head.
- No visible change; valid structured data and rich-result eligibility
  are unaffected.