### PR TITLE
Add Vultisig wallet

### DIFF
--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -1901,6 +1901,26 @@ export const Showcases = [
   beginnerFriendly: false,
   x: "EchoForgeEF",
 },
+  {
+    title: "Vultisig",
+    description:
+      "The crypto wallet with no seed phrase. Your crypto stays safe across your own devices, and only you can move it. 30+ chains including Cardano.",
+    tagline: "Multi-chain wallet with no seed phrase",
+    icon: "/img/app-icons/vultisig.svg",
+    website: "https://vultisig.com",
+    source: "https://github.com/vultisig",
+    category: "wallet",
+    properties: ["opensource", "mobile"],
+    maintainerPick: false,
+    beginnerFriendly: false,
+    x: "vultisig",
+    walletFeatures: {
+      platforms: ["ios", "android", "desktop", "browser"],
+      custody: "non-custodial",
+      features: [],
+      type: "light",
+    },
+  },
 ];
 
 export const TagList = Object.keys(Tags);

--- a/static/img/app-icons/vultisig.svg
+++ b/static/img/app-icons/vultisig.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 1024 1024" fill="none">
+<rect width="1024" height="1024" rx="512" fill="#061B3A" />
+<path d="M502.487 560.085L263.176 698.603L228.016 663.443L437.804 522.477L502.487 560.085Z" fill="url(#paint0_linear_6897_19996)" />
+<path d="M507.896 569.454L268.281 707.444L281.15 755.474L508.124 644.274L507.896 569.454Z" fill="url(#paint1_linear_6897_19996)" />
+<path d="M517.409 569.454L757.024 707.444L744.154 755.473L517.18 644.274L517.409 569.454Z" fill="url(#paint2_linear_6897_19996)" />
+<path d="M522.818 560.085L762.128 698.602L797.288 663.443L587.5 522.477L522.818 560.085Z" fill="url(#paint3_linear_6897_19996)" />
+<path d="M517.409 549.849L517.104 273.341L565.134 260.471L582.32 512.636L517.409 549.849Z" fill="url(#paint4_linear_6897_19996)" />
+<path d="M506.591 549.849L506.895 273.341L458.866 260.471L441.68 512.636L506.591 549.849Z" fill="url(#paint5_linear_6897_19996)" />
+<path d="M502.487 560.085L263.176 698.603L228.016 663.443L437.804 522.477L502.487 560.085Z" stroke="url(#paint6_linear_6897_19996)" />
+<path d="M507.896 569.454L268.281 707.444L281.15 755.474L508.124 644.274L507.896 569.454Z" stroke="url(#paint7_linear_6897_19996)" />
+<path d="M517.409 569.454L757.024 707.444L744.154 755.473L517.18 644.274L517.409 569.454Z" stroke="url(#paint8_linear_6897_19996)" />
+<path d="M522.818 560.085L762.128 698.602L797.288 663.443L587.5 522.477L522.818 560.085Z" stroke="url(#paint9_linear_6897_19996)" />
+<path d="M517.409 549.849L517.104 273.341L565.134 260.471L582.32 512.636L517.409 549.849Z" stroke="url(#paint10_linear_6897_19996)" />
+<path d="M506.591 549.849L506.895 273.341L458.866 260.471L441.68 512.636L506.591 549.849Z" stroke="url(#paint11_linear_6897_19996)" />
+<defs>
+<linearGradient id="paint0_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint1_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint2_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint3_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint4_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint5_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint6_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint7_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint8_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint9_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint10_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint11_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
This PR adds **Vultisig** to the wallet directory in `src/data/apps.js`.

**About:** Vultisig is a free, open-source, non-custodial multi-chain wallet with no seed phrase — the wallet is protected across the user's own devices. Cardano (ADA send/receive) is supported alongside 30+ chains, on iOS, Android, desktop (Windows/macOS/Linux), and a Chrome extension.

- Website: https://vultisig.com
- Source: https://github.com/vultisig (fully open source)
- Live since March 2024

**Notes for review:**
- Icon added at `static/img/app-icons/vultisig.svg` (XML normalized to match existing icons).
- `walletFeatures.features` is intentionally empty: we only claim what Vultisig supports on Cardano today (light wallet, non-custodial, mobile+desktop+browser). No staking/governance/CIP-30/native-asset claims.
- No preview screenshot yet; happy to add one on request.

## receipts

no runtime changes

Data-only change, validated with the repo's own tooling:
- `ensureShowcaseValid` (from `src/data/apps.js`) executed over all entries including the new one → 108 entries pass; new entry measures title 8 / tagline 38 / description 142 chars (limits 25/60/120–180).
- `node scripts/generate-apps-metadata.js` → 108 apps, exit 0.
- `node scripts/check-app-screenshots.js` → exit 0.