### PR TITLE
chore: remove MEXC from Europe region in exchanges.json

### DIFF
--- a/src/data/exchanges.json
+++ b/src/data/exchanges.json
@@ -18,12 +18,6 @@
         "link": "https://nbx.com",
         "ada": true,
         "cnt": true
-      },
-      {
-        "name": "MEXC",
-        "link": "https://www.mexc.com",
-        "ada": true,
-        "cnt": true
       }
     ]
   },


### PR DESCRIPTION
MEXC left the EEA (MiCA), but is still listed in the shared Europe region, showing up for all 30 European countries.
Removed the MEXC entry from regions.Europe. Non-European country entries (Philippines, Thailand, UAE, etc.) untouched.

