### PR TITLE
refactor: simplify beginner curation and validate wallet features

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add-app.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add-app.md
@@ -15,7 +15,6 @@
 - [ ] I have run `yarn build` after adding my changes **without getting any errors**.
 - [ ] I have not committed any changes to `yarn.lock`.
 - [ ] I have left `maintainerPick: false` on my entry. `maintainerPick` is set by page maintainers through the [Maintainer picks](https://github.com/cardano-foundation/cardano-org/blob/staging/docs/get-involved/maintainer-picks.md) process, not by submitters.
-- [ ] I have left `beginnerFriendly: false` unless the app is verifiably newcomer-friendly (clear onboarding, low jargon, working defaults).
 - [ ] My screenshot follows the [screenshot guidelines](https://github.com/cardano-foundation/cardano-org/blob/staging/docs/get-involved/add-app.md#step-by-step-process): around 1280×720 (16:9) JPEG, under 500 KB, light theme, app UI not a marketing page. The build's screenshot size check will reject anything over 500 KB.
 - [ ] My `title` is ≤ 25 characters (ideally 15-20). The build's schema validator rejects anything longer. Drop a redundant `Cardano` prefix where the bare project name still reads cleanly.
 - [ ] My `tagline` is ≤ 60 characters and describes what the app **is**, not what it promises (e.g. "Multi-pool DEX with deepest liquidity", not "Best DEX on Cardano!"). The build's schema validator rejects anything longer.

--- a/.github/PULL_REQUEST_TEMPLATE/add-app.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add-app.md
@@ -15,6 +15,7 @@
 - [ ] I have run `yarn build` after adding my changes **without getting any errors**.
 - [ ] I have not committed any changes to `yarn.lock`.
 - [ ] I have left `maintainerPick: false` on my entry. `maintainerPick` is set by page maintainers through the [Maintainer picks](https://github.com/cardano-foundation/cardano-org/blob/staging/docs/get-involved/maintainer-picks.md) process, not by submitters.
+- [ ] If my entry is a wallet, I have filled in `walletFeatures` (platforms, custody, features, type) using the exact identifiers from the [App Requirements](https://github.com/cardano-foundation/cardano-org/blob/staging/docs/get-involved/add-app.md). The build rejects a wallet entry without it, and unknown values are rejected too.
 - [ ] My screenshot follows the [screenshot guidelines](https://github.com/cardano-foundation/cardano-org/blob/staging/docs/get-involved/add-app.md#step-by-step-process): around 1280×720 (16:9) JPEG, under 500 KB, light theme, app UI not a marketing page. The build's screenshot size check will reject anything over 500 KB.
 - [ ] My `title` is ≤ 25 characters (ideally 15-20). The build's schema validator rejects anything longer. Drop a redundant `Cardano` prefix where the bare project name still reads cleanly.
 - [ ] My `tagline` is ≤ 60 characters and describes what the app **is**, not what it promises (e.g. "Multi-pool DEX with deepest liquidity", not "Best DEX on Cardano!"). The build's schema validator rejects anything longer.
@@ -52,3 +53,4 @@
   * `mobile` — native mobile app, not a responsive site
   * `nft` — supports or uses NFTs (not for image-based collections)
   * `opensource` — public source repository linked above
+  * `drepdelegation`: voting power can be delegated to a DRep inside the app

--- a/docs/get-involved/add-app.md
+++ b/docs/get-involved/add-app.md
@@ -81,7 +81,6 @@ These criteria are also applied retroactively. Apps that go offline, get abandon
      category: "dex",                  // exactly one (see categories below)
      properties: ["opensource"],       // zero or more (see properties below)
      maintainerPick: false,            // leave false; maintainers set this
-     beginnerFriendly: false,          // leave false unless verifiably beginner-friendly
      x: "yourproject",                 // OPTIONAL - X (Twitter) handle without @, shown on detail page
    }
    ```
@@ -99,11 +98,9 @@ These criteria are also applied retroactively. Apps that go offline, get abandon
    - `nft`: supports or uses NFTs (do not use for image-based NFT collections)
    - `opensource`: public source repository; you must also fill in `source`
 
-7. **`maintainerPick` and `beginnerFriendly`**
+7. **`maintainerPick`**
 
-   Both default to `false` for new submissions.
-   - `maintainerPick: true` is set only by page maintainers via the [Maintainer picks](/docs/get-involved/maintainer-picks) process.
-   - `beginnerFriendly: true` should only be set if onboarding is genuinely smooth for newcomers (no jargon walls, sensible defaults, working out of the box). Reviewers may push back if this looks promotional.
+   Defaults to `false` for new submissions. `maintainerPick: true` is set only by page maintainers via the [Maintainer picks](/docs/get-involved/maintainer-picks) process.
 
 8. **Optional Fields Explained**
 

--- a/docs/get-involved/add-app.md
+++ b/docs/get-involved/add-app.md
@@ -97,12 +97,55 @@ These criteria are also applied retroactively. Apps that go offline, get abandon
    - `mobile`: first-class native mobile app (not a responsive site)
    - `nft`: supports or uses NFTs (do not use for image-based NFT collections)
    - `opensource`: public source repository; you must also fill in `source`
+   - `drepdelegation`: voting power can be delegated to a DRep directly inside the app. Entries carrying this flag are listed on [/governance/delegate](/governance/delegate)
 
 7. **`maintainerPick`**
 
    Defaults to `false` for new submissions. `maintainerPick: true` is set only by page maintainers via the [Maintainer picks](/docs/get-involved/maintainer-picks) process.
 
-8. **Optional Fields Explained**
+8. **Wallets only: `walletFeatures`** ⚠️
+
+   Entries with `category: "wallet"` must carry a `walletFeatures` object. It powers the [wallet finder](/wallets) filters, and the build rejects a wallet entry that leaves it out, because such an entry would be invisible on `/wallets`.
+
+   ```javascript
+   walletFeatures: {
+     platforms: ["ios", "android"],   // one or more
+     custody: "non-custodial",        // exactly one
+     features: ["staking", "nft"],    // zero or more
+     type: "light",                   // exactly one
+   },
+   ```
+
+   **`platforms`** (one or more):
+   - `ios`, `android`: native mobile apps
+   - `browser`: browser extension
+   - `desktop`: installable Windows, macOS, or Linux application
+   - `web`: usable in a browser without installing anything
+
+   **`custody`** (exactly one): `non-custodial` (the user holds the keys) or `custodial` (a third party holds them).
+
+   **`type`** (exactly one): `light` (talks to the network through a server) or `full-node` (downloads and verifies the chain itself).
+
+   **`features`** (zero or more), claim only what ships today:
+   - `staking`: delegate ada to a stake pool from inside the wallet
+   - `governance`: on-chain voting or DRep delegation
+   - `nft`: view, send, and manage NFTs
+   - `multi-asset`: manage native tokens beyond ada
+   - `dapp-connector`: connect to DApps (CIP-30)
+   - `hardware-wallet`: pair a Ledger or Trezor
+   - `multi-account`: several accounts in one wallet
+   - `dex`: built-in token swaps
+   - `qr-claim`: claim tokens via QR codes or claim links ([CIP-0099](https://cips.cardano.org/cip/CIP-0099))
+   - `easy-setup`: a new user can start using the wallet before writing down a seed phrase, with the backup deferred to later
+
+   Every value is validated against the lists above, so copy the identifiers exactly as written. A typo such as `easy_setup` fails the build and names the offending value:
+
+   ```
+   Showcase site with title=Your Wallet contains errors:
+   Unknown walletFeatures.features=[easy_setup]
+   ```
+
+9. **Optional Fields Explained**
 
    **icon field:**
    - Path to your logo/icon for display in component grids
@@ -131,12 +174,12 @@ These criteria are also applied retroactively. Apps that go offline, get abandon
    - All three fields required if set; URL must be `http(s)://`
    - Submitters: leave omitted. Maintainers add this when a Spotlight is published.
 
-9. **Test your submission**
-   - Run `yarn build` (must complete without errors). The schema validator will reject unknown categories or properties.
+10. **Test your submission**
+   - Run `yarn build` (must complete without errors). The schema validator will reject unknown categories, properties, or wallet features.
    - Check that your project displays correctly
    - Verify your icon appears if you added one
    - Ensure category is the most specific match and properties are minimal
 
-10. **Submit your pull request**
+11. **Submit your pull request**
    - Use the "Add Your App" GitHub PR template
    - Fill out the checklist in the template 

--- a/docs/get-involved/components/app-list.md
+++ b/docs/get-involved/components/app-list.md
@@ -32,7 +32,6 @@ The [`<AppList>`](/docs/get-involved/components/app-list) component displays a c
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `categories` | `string[]` | `[]` | Array of category ids to filter apps (e.g., `['dex']`, `['wallet']`). Empty array shows all apps. |
-| `beginnerFriendly` | `boolean` | `false` | When true, only apps with `beginnerFriendly: true` are shown. |
 | `limit` | `number` | `5` | Maximum number of apps to display. Set to `null` to show all. |
 | `categoryTitle` | `string` | `"Apps"` | Title displayed in the component header. |
 | `showTxCount` | `boolean` | `false` | Whether to display transaction counts next to each app. |

--- a/docs/get-involved/maintainer-picks.md
+++ b/docs/get-involved/maintainer-picks.md
@@ -10,6 +10,15 @@ The **Maintainer picks** section on [/apps](/apps) is a curated shortlist of app
 
 Picks are visible at the top of `/apps` and are the first thing a newcomer sees. The bar for inclusion is therefore higher than for the broader showcase.
 
+## Where picks show up
+
+Picks drive two places on the site, not one:
+
+- The **Maintainer picks** section at the top of [/apps](/apps).
+- The beginner mode of the [wallet finder](/wallets). When a visitor chooses "I'm new to Cardano" and names their device, the suggestions are exactly the wallet picks available on that device. There is no separate beginner flag on wallet entries.
+
+The coupling is deliberate, so that newcomer guidance stays in one curated list instead of drifting away from the picks over time. It also means every wallet pick decision changes what a newcomer sees first. Weigh criterion 4 below with that in mind whenever the candidate is a wallet.
+
 ## Selection criteria
 
 A pick must meet all four:
@@ -25,7 +34,7 @@ A pick must meet all four:
 2. State which category the app fits into, and which criterion above carries it (especially criterion 4: write the one-liner).
 3. If the category cap (one to two picks) is already full, name which existing pick should be replaced and why.
 4. Wait for one other maintainer to second the proposal.
-5. If no maintainer raises a blocking objection within **7 days**, the pick is merged into `apps.js` (`favorite` tag set on the entry).
+5. If no maintainer raises a blocking objection within **7 days**, the pick is merged into `apps.js` (`maintainerPick: true` set on the entry).
 
 ## Removing a pick
 

--- a/scripts/lib/parse-apps.cjs
+++ b/scripts/lib/parse-apps.cjs
@@ -16,7 +16,7 @@ function parseShowcases(source) {
   if (closeIdx < 0) throw new Error('Cannot find end of Showcases array');
   const block = source.slice(blockStart, closeIdx);
 
-  const entryRegex = /\{\s*\n\s*title:\s*"((?:[^"\\]|\\.)+)",[\s\S]*?(?:description:\s*(?:\n\s*)?"((?:[^"\\]|\\.)*)"[\s\S]*?)?(?:tagline:\s*"((?:[^"\\]|\\.)*)",[\s\S]*?)?(?:icon:\s*"([^"]+)",[\s\S]*?)?(?:statsLabel:\s*"([^"]+)",[\s\S]*?)?(?:metadataLabel:\s*(\d+),[\s\S]*?)?website:\s*"([^"]+)"[\s\S]*?source:\s*(null|"[^"]+"),[\s\S]*?category:\s*"([^"]+)",[\s\S]*?properties:\s*\[([^\]]*)\],[\s\S]*?maintainerPick:\s*(true|false),[\s\S]*?beginnerFriendly:\s*(true|false),[\s\S]*?(?:x:\s*"([^"]+)",[\s\S]*?)?(?:spotlight:\s*\{\s*url:\s*"([^"]+)",\s*title:\s*"((?:[^"\\]|\\.)+)",\s*date:\s*"([^"]+)",?\s*\},?[\s\S]*?)?\n\s*\},?/g;
+  const entryRegex = /\{\s*\n\s*title:\s*"((?:[^"\\]|\\.)+)",[\s\S]*?(?:description:\s*(?:\n\s*)?"((?:[^"\\]|\\.)*)"[\s\S]*?)?(?:tagline:\s*"((?:[^"\\]|\\.)*)",[\s\S]*?)?(?:icon:\s*"([^"]+)",[\s\S]*?)?(?:statsLabel:\s*"([^"]+)",[\s\S]*?)?(?:metadataLabel:\s*(\d+),[\s\S]*?)?website:\s*"([^"]+)"[\s\S]*?source:\s*(null|"[^"]+"),[\s\S]*?category:\s*"([^"]+)",[\s\S]*?properties:\s*\[([^\]]*)\],[\s\S]*?maintainerPick:\s*(true|false),[\s\S]*?(?:x:\s*"([^"]+)",[\s\S]*?)?(?:spotlight:\s*\{\s*url:\s*"([^"]+)",\s*title:\s*"((?:[^"\\]|\\.)+)",\s*date:\s*"([^"]+)",?\s*\},?[\s\S]*?)?\n\s*\},?/g;
 
   // Preview is a webpack require() expression — not captured by the main regex
   // because group ordering is too brittle to extend. Searched per-entry so missing
@@ -56,13 +56,12 @@ function parseShowcases(source) {
         .map((t) => t.trim().replace(/^"|"$/g, ''))
         .filter(Boolean),
       maintainerPick: m[11] === 'true',
-      beginnerFriendly: m[12] === 'true',
-      x: m[13] || null,
-      spotlight: m[14]
+      x: m[12] || null,
+      spotlight: m[13]
         ? {
-            url: m[14],
-            title: parseStringValue(`"${m[15]}"`),
-            date: m[16],
+            url: m[13],
+            title: parseStringValue(`"${m[14]}"`),
+            date: m[15],
           }
         : null,
       previewFile: previewMatch ? previewMatch[1] : null,

--- a/src/components/AppList/index.js
+++ b/src/components/AppList/index.js
@@ -58,8 +58,8 @@ function AppListItem({ app, stats, showTxCount, showTags, showDescription = true
   );
 }
 
-export default function AppList({ categories = [], beginnerFriendly = false, slugs = null, limit = 5, categoryTitle = "Apps", showTxCount = false, hideHeader = false, showTags = false, showDescription = true }) {
-  // Explicit slug list (used by curated Collections) bypasses category/beginner filtering
+export default function AppList({ categories = [], slugs = null, limit = 5, categoryTitle = "Apps", showTxCount = false, hideHeader = false, showTags = false, showDescription = true }) {
+  // Explicit slug list (used by curated Collections) bypasses category filtering
   // and preserves the curator's chosen order.
   const isExplicit = Array.isArray(slugs) && slugs.length > 0;
 
@@ -75,7 +75,6 @@ export default function AppList({ categories = [], beginnerFriendly = false, slu
         .filter(Boolean)
     : Showcases.filter((app) => {
         if (categories.length > 0 && !categories.includes(app.category)) return false;
-        if (beginnerFriendly && !app.beginnerFriendly) return false;
         return true;
       });
 

--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -10,6 +10,12 @@
 
 import React from "react";
 import { sortBy, difference } from "../utils/jsUtils";
+import {
+  WalletPlatformList,
+  WalletFeatureList,
+  WalletCustodyList,
+  WalletNodeTypeList,
+} from "./walletFeatures";
 
 // Primary categories — each Showcase has exactly one. Answers: "what is this app?".
 // `trackable: true` means on-chain tx count is a meaningful usage signal for that category;
@@ -1994,6 +2000,70 @@ function ensureShowcaseValid(showcase) {
     }
   }
 
+  // walletFeatures drives the filters on /wallets. Unknown values used to build
+  // fine and just dropped the wallet out of the matching filter without a word,
+  // so every value is checked against the lists in walletFeatures.js.
+  function checkWalletFeatures() {
+    const wf = showcase.walletFeatures;
+    if (wf === undefined) {
+      if (showcase.category === "wallet") {
+        throw new Error(
+          "Wallet entries must define walletFeatures {platforms, custody, features, type}.\nWithout it the wallet never appears in the wallet finder on /wallets."
+        );
+      }
+      return;
+    }
+    if (!wf || typeof wf !== "object" || Array.isArray(wf)) {
+      throw new Error(
+        "walletFeatures must be an object {platforms, custody, features, type}"
+      );
+    }
+    const unknownKeys = difference(Object.keys(wf), [
+      "platforms",
+      "custody",
+      "features",
+      "type",
+    ]);
+    if (unknownKeys.length > 0) {
+      throw new Error(
+        `walletFeatures contains unknown attribute names=[${unknownKeys.join(",")}]`
+      );
+    }
+
+    // platforms must name at least one, features may legitimately be empty
+    for (const [key, allowed, required] of [
+      ["platforms", WalletPlatformList, true],
+      ["features", WalletFeatureList, false],
+    ]) {
+      const value = wf[key];
+      if (!Array.isArray(value)) {
+        throw new Error(
+          `walletFeatures.${key} must be an array, got ${typeof value}`
+        );
+      }
+      if (required && value.length === 0) {
+        throw new Error(`walletFeatures.${key} must list at least one value`);
+      }
+      const unknown = difference(value, allowed);
+      if (unknown.length > 0) {
+        throw new Error(
+          `Unknown walletFeatures.${key}=[${unknown.join(",")}]\nAvailable ${key}: ${allowed.join(", ")}`
+        );
+      }
+    }
+
+    for (const [key, allowed] of [
+      ["custody", WalletCustodyList],
+      ["type", WalletNodeTypeList],
+    ]) {
+      if (!allowed.includes(wf[key])) {
+        throw new Error(
+          `Unknown walletFeatures.${key}=${JSON.stringify(wf[key])}\nAvailable ${key}: ${allowed.join(", ")}`
+        );
+      }
+    }
+  }
+
   function checkSpotlight() {
     if (showcase.spotlight === undefined) return;
     const s = showcase.spotlight;
@@ -2024,6 +2094,7 @@ function ensureShowcaseValid(showcase) {
     checkMetadataLabel();
     checkX();
     checkSpotlight();
+    checkWalletFeatures();
   } catch (e) {
     throw new Error(
       `Showcase site with title=${showcase.title} contains errors:\n${e.message}`,

--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -211,7 +211,6 @@ export const PropertyList = Object.keys(Properties);
 //   category: "dex",                  // exactly one — see Categories above
 //   properties: ["opensource"],       // zero or more — see Properties above
 //   maintainerPick: false,
-//   beginnerFriendly: false,
 // }
 export const Showcases = [
   {
@@ -225,7 +224,6 @@ export const Showcases = [
     category: "other",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Cardano Wall",
@@ -238,7 +236,6 @@ export const Showcases = [
     category: "notary",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "NMKR",
@@ -251,7 +248,6 @@ export const Showcases = [
     category: "minting",
     properties: ["nft"],
     maintainerPick: true,
-    beginnerFriendly: false,
     x: "nmkr_io",
     spotlight: {
       url: "https://developers.cardano.org/blog/2021-07-26-july/",
@@ -270,7 +266,6 @@ export const Showcases = [
     category: "explorer",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: false,
   },
   {
     title: "Cardano Explorer Index",
@@ -282,7 +277,6 @@ export const Showcases = [
     category: "explorer",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "CExplorer",
@@ -295,7 +289,6 @@ export const Showcases = [
     category: "explorer",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Cardano Scan",
@@ -308,7 +301,6 @@ export const Showcases = [
     category: "explorer",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Pool PM",
@@ -321,7 +313,6 @@ export const Showcases = [
     category: "explorer",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "PoolTool",
@@ -334,7 +325,6 @@ export const Showcases = [
     category: "pooltool",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: false,
   },
   {
     title: "AdaLite",
@@ -347,7 +337,6 @@ export const Showcases = [
     category: "wallet",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["web"],
       custody: "non-custodial",
@@ -366,7 +355,6 @@ export const Showcases = [
     category: "wallet",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["ios", "android", "desktop"],
       custody: "non-custodial",
@@ -385,7 +373,6 @@ export const Showcases = [
     category: "wallet",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["desktop"],
       custody: "non-custodial",
@@ -404,7 +391,6 @@ export const Showcases = [
     category: "analytics",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: false,
   },
   {
     title: "Pool Stats",
@@ -416,7 +402,6 @@ export const Showcases = [
     category: "pooltool",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "NOWPayments",
@@ -429,7 +414,6 @@ export const Showcases = [
     category: "other",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "NOWPayments_io",
   },
   {
@@ -443,7 +427,6 @@ export const Showcases = [
     category: "education",
     properties: ["opensource"],
     maintainerPick: true,
-    beginnerFriendly: false,
     x: "gimbalabs",
     spotlight: {
       url: "https://developers.cardano.org/blog/2023-01-02-january/",
@@ -467,7 +450,6 @@ export const Showcases = [
     category: "wallet",
     properties: ["nft", "mobile"],
     maintainerPick: true,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["ios", "android", "browser"],
       custody: "non-custodial",
@@ -485,7 +467,6 @@ export const Showcases = [
     category: "minting",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "cardano-tools.io",
@@ -498,7 +479,6 @@ export const Showcases = [
     category: "minting",
     properties: ["nft", "opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Typhon",
@@ -511,7 +491,6 @@ export const Showcases = [
     category: "wallet",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["browser"],
       custody: "non-custodial",
@@ -535,7 +514,6 @@ export const Showcases = [
     category: "pooltool",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: false,
   },
   {
     title: "MuesliSwap",
@@ -549,7 +527,6 @@ export const Showcases = [
     category: "dex",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "SundaeSwap",
@@ -567,7 +544,6 @@ export const Showcases = [
     category: "dex",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "DripDropz",
@@ -581,7 +557,6 @@ export const Showcases = [
     category: "distribution",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: false,
   },
   {
     title: "Minswap",
@@ -600,7 +575,6 @@ export const Showcases = [
     category: "dex",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: true,
     x: "MinswapDEX",
     spotlight: {
       url: "https://developers.cardano.org/blog/2022-04-27-april/",
@@ -619,7 +593,6 @@ export const Showcases = [
     category: "wallet",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["browser", "web"],
       custody: "non-custodial",
@@ -638,7 +611,6 @@ export const Showcases = [
     category: "wallet",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["browser"],
       custody: "non-custodial",
@@ -657,7 +629,6 @@ export const Showcases = [
     category: "ecosystem",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "gerowallet",
   },
   {
@@ -671,7 +642,6 @@ export const Showcases = [
     category: "ecosystem",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: false,
     x: "CardanoCube",
   },
   {
@@ -690,7 +660,6 @@ export const Showcases = [
     category: "dex",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "wingriderscom",
   },
   {
@@ -704,7 +673,6 @@ export const Showcases = [
     category: "ecosystem",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "eUTxO",
@@ -717,7 +685,6 @@ export const Showcases = [
     category: "explorer",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Vibrant",
@@ -730,7 +697,6 @@ export const Showcases = [
     category: "other",
     properties: ["nft", "opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "VibrantNet_io",
   },
   {
@@ -748,7 +714,6 @@ export const Showcases = [
     category: "marketplace",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "NuFi Wallet",
@@ -761,7 +726,6 @@ export const Showcases = [
     category: "wallet",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["browser"],
       custody: "non-custodial",
@@ -780,7 +744,6 @@ export const Showcases = [
     category: "minting",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "nufiwallet",
   },
   {
@@ -794,7 +757,6 @@ export const Showcases = [
     category: "analytics",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: false,
   },
   {
     title: "Dune",
@@ -806,7 +768,6 @@ export const Showcases = [
     category: "analytics",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Chainport",
@@ -819,7 +780,6 @@ export const Showcases = [
     category: "bridge",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "chain_port",
   },
   {
@@ -833,7 +793,6 @@ export const Showcases = [
     category: "minting",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "cardano_studio",
   },
   {
@@ -847,7 +806,6 @@ export const Showcases = [
     category: "bridge",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "BALANCE Analytics",
@@ -860,7 +818,6 @@ export const Showcases = [
     category: "analytics",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "adahandle",
@@ -873,7 +830,6 @@ export const Showcases = [
     category: "identity",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Lace",
@@ -886,7 +842,6 @@ export const Showcases = [
     category: "wallet",
     properties: ["nft", "opensource"],
     maintainerPick: true,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["browser"],
       custody: "non-custodial",
@@ -905,7 +860,6 @@ export const Showcases = [
     category: "notary",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "lace_io",
   },
   {
@@ -925,7 +879,6 @@ export const Showcases = [
     category: "wallet",
     properties: ["nft", "mobile"],
     maintainerPick: true,
-    beginnerFriendly: false,
     spotlight: {
       url: "https://developers.cardano.org/blog/2024-01-22-january/",
       title: "Cardano Developer Spotlight: January 2024",
@@ -954,7 +907,6 @@ export const Showcases = [
     category: "dex",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "dexhunterio",
     spotlight: {
       url: "https://developers.cardano.org/blog/2024-12-09-december/",
@@ -979,7 +931,6 @@ export const Showcases = [
     category: "lending",
     properties: ["opensource"],
     maintainerPick: true,
-    beginnerFriendly: true,
     x: "liqwidfinance",
   },
   {
@@ -993,7 +944,6 @@ export const Showcases = [
     category: "education",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: false,
   },
   {
     title: "Cardano Governance Tool",
@@ -1006,7 +956,6 @@ export const Showcases = [
     category: "governance",
     properties: ["drepdelegation"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Treasury Donation",
@@ -1018,7 +967,6 @@ export const Showcases = [
     category: "governance",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Chang Watch",
@@ -1031,7 +979,6 @@ export const Showcases = [
     category: "governance",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Medusa Wallet",
@@ -1044,7 +991,6 @@ export const Showcases = [
     category: "wallet",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["web"],
       custody: "non-custodial",
@@ -1069,7 +1015,6 @@ export const Showcases = [
     category: "lending",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Multisig Wallet",
@@ -1082,7 +1027,6 @@ export const Showcases = [
     category: "wallet",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["web"],
       custody: "non-custodial",
@@ -1101,7 +1045,6 @@ export const Showcases = [
     category: "governance",
     properties: ["drepdelegation"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Nio",
@@ -1114,7 +1057,6 @@ export const Showcases = [
     category: "other",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "NioApp",
   },
   {
@@ -1128,7 +1070,6 @@ export const Showcases = [
     category: "wallet",
     properties: ["nft", "mobile"],
     maintainerPick: false,
-    beginnerFriendly: false,
     walletFeatures: {
       platforms: ["ios", "android", "browser"],
       custody: "non-custodial",
@@ -1147,7 +1088,6 @@ export const Showcases = [
     category: "distribution",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "BeginWallet",
   },
   {
@@ -1161,7 +1101,6 @@ export const Showcases = [
     category: "marketplace",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "stuff_io",
   },
   {
@@ -1175,7 +1114,6 @@ export const Showcases = [
     category: "identity",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
     spotlight: {
       url: "https://developers.cardano.org/blog/2025-11-07-media-cardano-developer-office-hours/",
       title: "Cardano Developer Office Hours",
@@ -1193,7 +1131,6 @@ export const Showcases = [
     category: "governance",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Adastack.io",
@@ -1206,7 +1143,6 @@ export const Showcases = [
     category: "ecosystem",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "adastackio",
   },
   {
@@ -1220,7 +1156,6 @@ export const Showcases = [
     category: "other",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Governance Voting Tool",
@@ -1233,7 +1168,6 @@ export const Showcases = [
     category: "governance",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Andamio",
@@ -1246,7 +1180,6 @@ export const Showcases = [
     category: "identity",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "andamio_teams",
   },
   {
@@ -1265,7 +1198,6 @@ export const Showcases = [
     category: "dex",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "FluidTokens",
@@ -1283,7 +1215,6 @@ export const Showcases = [
     category: "lending",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "FluidTokens",
     spotlight: {
       url: "https://developers.cardano.org/blog/2025-02-03-february/",
@@ -1303,7 +1234,6 @@ export const Showcases = [
     category: "dex",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "GeniusyieldO",
   },
   {
@@ -1317,7 +1247,6 @@ export const Showcases = [
     category: "marketplace",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "IagonOfficial",
     spotlight: {
       url: "https://developers.cardano.org/blog/2025-09-29-september/",
@@ -1337,7 +1266,6 @@ export const Showcases = [
     category: "dex",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Splash",
@@ -1351,7 +1279,6 @@ export const Showcases = [
     category: "dex",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Palmyra",
@@ -1364,7 +1291,6 @@ export const Showcases = [
     category: "marketplace",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "palmeconomy",
   },
   {
@@ -1378,7 +1304,6 @@ export const Showcases = [
     category: "lending",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "OptimFi",
   },
   {
@@ -1392,7 +1317,6 @@ export const Showcases = [
     category: "other",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Empowa",
@@ -1405,7 +1329,6 @@ export const Showcases = [
     category: "marketplace",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Strike Finance",
@@ -1420,7 +1343,6 @@ export const Showcases = [
     category: "dex",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: true,
     x: "strikeperps",
   },
   {
@@ -1434,7 +1356,6 @@ export const Showcases = [
     category: "marketplace",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "snekdotfun",
   },
   {
@@ -1448,7 +1369,6 @@ export const Showcases = [
     category: "marketplace",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "Xerberus",
   },
   {
@@ -1463,7 +1383,6 @@ export const Showcases = [
     category: "marketplace",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "MasumiNetwork",
     spotlight: {
       url: "https://developers.cardano.org/blog/2025-06-24-june/",
@@ -1482,7 +1401,6 @@ export const Showcases = [
     category: "marketplace",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Butane",
@@ -1495,7 +1413,6 @@ export const Showcases = [
     category: "lending",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Bodega Market",
@@ -1513,7 +1430,6 @@ export const Showcases = [
     category: "marketplace",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: true,
   },
   {
     title: "Infinity Rising",
@@ -1526,7 +1442,6 @@ export const Showcases = [
     category: "game",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "InfinityRisingX",
   },
   {
@@ -1540,7 +1455,6 @@ export const Showcases = [
     category: "notary",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Ascent Rivals",
@@ -1553,7 +1467,6 @@ export const Showcases = [
     category: "game",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "AscentRivals",
   },
   {
@@ -1567,7 +1480,6 @@ export const Showcases = [
     category: "game",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Ale & Axes",
@@ -1580,7 +1492,6 @@ export const Showcases = [
     category: "game",
     properties: [],
     maintainerPick: true,
-    beginnerFriendly: false,
   },
   {
     title: "Clarity Protocol",
@@ -1593,7 +1504,6 @@ export const Showcases = [
     category: "governance",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Indigo",
@@ -1612,7 +1522,6 @@ export const Showcases = [
     category: "lending",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "indigo_protocol",
   },
   {
@@ -1626,7 +1535,6 @@ export const Showcases = [
     category: "other",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "CGOV",
@@ -1639,7 +1547,6 @@ export const Showcases = [
     category: "governance",
     properties: ["opensource"],
     maintainerPick: true,
-    beginnerFriendly: false,
   },
   {
     title: "Sundae Treasury Dashboard",
@@ -1652,7 +1559,6 @@ export const Showcases = [
     category: "governance",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Supply Summary",
@@ -1665,7 +1571,6 @@ export const Showcases = [
     category: "governance",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "WanBridge",
@@ -1680,7 +1585,6 @@ export const Showcases = [
     category: "bridge",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "UVerify",
@@ -1698,7 +1602,6 @@ export const Showcases = [
     category: "notary",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "uvfyhq",
     spotlight: {
       url: "https://developers.cardano.org/blog/2025-06-13-media-cardano-developer-office-hours/",
@@ -1723,7 +1626,6 @@ export const Showcases = [
     category: "notary",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "CommitProof",
   },
   {
@@ -1738,7 +1640,6 @@ export const Showcases = [
     category: "game",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "TapDano",
@@ -1751,7 +1652,6 @@ export const Showcases = [
     category: "identity",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Claimpaign",
@@ -1771,7 +1671,6 @@ export const Showcases = [
     category: "distribution",
     properties: ["nft"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "claimpaign",
   },
   {
@@ -1790,7 +1689,6 @@ export const Showcases = [
     category: "marketplace",
     properties: ["nft"],
     maintainerPick: true,
-    beginnerFriendly: true,
     x: "wayupio",
   },
   {
@@ -1808,7 +1706,6 @@ export const Showcases = [
     category: "lending",
     properties: ["opensource"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "surfcardano",
   },
   {
@@ -1827,7 +1724,6 @@ export const Showcases = [
     category: "analytics",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "hizz_io",
   },
   {
@@ -1846,7 +1742,6 @@ export const Showcases = [
     category: "education",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "Bending AI",
@@ -1860,7 +1755,6 @@ export const Showcases = [
     category: "analytics",
     properties: [],
     maintainerPick: false,
-    beginnerFriendly: false,
   },
   {
     title: "DRepTalk",
@@ -1879,7 +1773,6 @@ export const Showcases = [
     category: "governance",
     properties: ["opensource", "drepdelegation"],
     maintainerPick: false,
-    beginnerFriendly: false,
     x: "dreptalkcom",
   },
 {
@@ -1898,7 +1791,6 @@ export const Showcases = [
   category: "notary",
   properties: ["opensource"],
   maintainerPick: false,
-  beginnerFriendly: false,
   x: "EchoForgeEF",
 },
 ];
@@ -1957,7 +1849,6 @@ function ensureShowcaseValid(showcase) {
       "category",
       "properties",
       "maintainerPick",
-      "beginnerFriendly",
       "icon",
       "statsLabel",
       "metadataLabel",
@@ -2047,7 +1938,7 @@ function ensureShowcaseValid(showcase) {
   }
 
   function checkBooleanFlags() {
-    for (const key of ["maintainerPick", "beginnerFriendly"]) {
+    for (const key of ["maintainerPick"]) {
       if (typeof showcase[key] !== "boolean") {
         throw new Error(`${key} must be a boolean, got ${typeof showcase[key]}`);
       }

--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -490,7 +490,7 @@ export const Showcases = [
     source: null,
     category: "wallet",
     properties: ["nft"],
-    maintainerPick: false,
+    maintainerPick: true,
     walletFeatures: {
       platforms: ["browser"],
       custody: "non-custodial",

--- a/src/pages/get-started.js
+++ b/src/pages/get-started.js
@@ -191,8 +191,7 @@ const steps = (onWalletConnect, images) => [
         centerVertically={false}
       >
         <AppList
-              beginnerFriendly
-              limit={5}
+              slugs={["minswap", "liqwid", "strike-finance", "bodega-market", "wayup"]}
               showTags={true}
               categoryTitle="Popular Apps"
               showTxCount={false}

--- a/src/utils/walletFinderUtils.js
+++ b/src/utils/walletFinderUtils.js
@@ -40,26 +40,22 @@ export function filterWallets(wallets, { platforms = [], features = [], custody 
 }
 
 // Filter wallets for beginner mode
-// Mobile: wallets with easy-setup feature + mobile platforms
-// Desktop: favorite wallets + browser/desktop platforms
+// Beginner suggestions are the maintainer picks that run on the selected device.
+// Curation happens once, via the Maintainer picks process, instead of being
+// re-derived per platform from individual feature flags.
 export function getBeginnerWallets(wallets, platform) {
-  if (platform === "mobile") {
-    return wallets.filter((w) => {
-      const wf = w.walletFeatures;
-      return (
-        wf.features.includes("easy-setup") &&
-        wf.platforms.some((p) => p === "ios" || p === "android")
-      );
-    });
+  const platformsFor = {
+    mobile: ["ios", "android"],
+    desktop: ["browser", "desktop"],
+  }[platform];
+
+  if (!platformsFor) {
+    return wallets;
   }
-  if (platform === "desktop") {
-    return wallets.filter((w) => {
-      const wf = w.walletFeatures;
-      return (
-        w.maintainerPick &&
-        wf.platforms.some((p) => p === "browser" || p === "desktop")
-      );
-    });
-  }
-  return wallets;
+
+  return wallets.filter(
+    (w) =>
+      w.maintainerPick &&
+      w.walletFeatures.platforms.some((p) => platformsFor.includes(p))
+  );
 }


### PR DESCRIPTION
- Beginner mode in the wallet finder now suggests the maintainer picks available on the chosen device, replacing two unrelated rules for mobile and desktop
- Typhon is now a maintainer pick and appears among the desktop suggestions
- The unused `beginnerFriendly` flag is removed from all app entries, and the Get Started page lists its five apps explicitly, in a fixed order
- Wallet entries are validated at build time, so an unknown platform or feature value now fails the build instead of quietly hiding the wallet from the finder
- Wallet fields and the `drepdelegation` property are documented for submitters for the first time
