### PR TITLE
feat: add the learn hub with a five-stage learning path

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -443,6 +443,10 @@ const config = {
             title: 'More',
             items: [
               {
+                label: 'Learn Cardano',
+                to: '/learn',
+              },
+              {
                 label: 'Cardano News',
                 to: '/news',
               },

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -2562,16 +2562,16 @@
     "message": "Note that some hard forks, particularly Byron and Shelley, transitioned through a series of updates and may not have a single specific transaction id associated with them. For the others, the provided transaction ids correspond to significant parameter updates leading to the hard forks."
   },
   "learn.hero.title": {
-    "message": "Learn"
+    "message": "Learn Cardano"
   },
   "learn.hero.description": {
-    "message": "Empowering the digital architects of the future."
+    "message": "From your first wallet to on-chain governance, one stage at a time."
   },
   "learn.layout.title": {
-    "message": "Learn About Cardano, Guides, Tutorials and Resources"
+    "message": "Learn Cardano, a Guided Path from Beginner to Advanced"
   },
   "learn.layout.description": {
-    "message": "Learn how Cardano works, from proof-of-stake consensus and smart contracts to staking, governance, and building decentralized applications."
+    "message": "A five-stage learning path through cardano.org: understand the basics, use Cardano safely, learn how the technology works, take part in governance and go deeper with research and courses."
   },
   "newsletter.hero.title": {
     "message": "Stay Informed"
@@ -6649,5 +6649,224 @@
   },
   "home.proofPoints.cta": {
     "message": "What is Cardano?"
+  },
+  "learn.stage.dividerLabel": {
+    "message": "Stage {number}"
+  },
+  "learn.intro.callout": {
+    "message": "Five stages, each with a handful of pages and a quiz. Read them in order if you are new, or jump in where you already are."
+  },
+  "learn.cta.title": {
+    "message": "Want a certificate at the end? The Cardano Academy offers free courses on everything above."
+  },
+  "learn.cta.button": {
+    "message": "Explore the Academy"
+  },
+  "learn.stage.start.title": {
+    "message": "Start here"
+  },
+  "learn.stage.start.intro": {
+    "message": "What Cardano is, what ada is, and the one tool you need to use either of them."
+  },
+  "learn.stage.start.quiz": {
+    "message": "Check what you learned with the [basics quiz](/quiz)."
+  },
+  "learn.item.whatIsCardano.title": {
+    "message": "What is Cardano?"
+  },
+  "learn.item.whatIsCardano.text": {
+    "message": "The platform in plain terms: how it works, what makes it different, who runs it."
+  },
+  "learn.item.whatIsAda.title": {
+    "message": "What is ada?"
+  },
+  "learn.item.whatIsAda.text": {
+    "message": "The currency of the network, what it is used for and how to get it."
+  },
+  "learn.item.whatIsAWallet.title": {
+    "message": "What is a wallet?"
+  },
+  "learn.item.whatIsAWallet.text": {
+    "message": "Your keys, your ada. Wallet types, recovery phrases and how to stay safe."
+  },
+  "learn.item.getStarted.title": {
+    "message": "Get started"
+  },
+  "learn.item.getStarted.text": {
+    "message": "A guided walk-through from download to your first transaction."
+  },
+  "learn.stage.use.title": {
+    "message": "Use Cardano"
+  },
+  "learn.stage.use.intro": {
+    "message": "Pick a wallet, get your first ada, keep it safe and put it to work."
+  },
+  "learn.stage.use.quiz": {
+    "message": "Check what you learned with the [wallets and security quizzes](/quiz)."
+  },
+  "learn.item.wallets.title": {
+    "message": "Find a wallet"
+  },
+  "learn.item.wallets.text": {
+    "message": "Compare wallets by platform, features and hardware support."
+  },
+  "learn.item.whereToGetAda.title": {
+    "message": "Where to get ada"
+  },
+  "learn.item.whereToGetAda.text": {
+    "message": "Trusted exchanges and other ways to get ada."
+  },
+  "learn.item.commonScams.title": {
+    "message": "Protect your ada"
+  },
+  "learn.item.commonScams.text": {
+    "message": "The scams that catch newcomers, and how to spot them."
+  },
+  "learn.item.delegation.title": {
+    "message": "Delegate your ada"
+  },
+  "learn.item.delegation.text": {
+    "message": "Earn rewards by delegating to a stake pool, without giving up custody."
+  },
+  "learn.item.apps.title": {
+    "message": "Explore apps"
+  },
+  "learn.item.apps.text": {
+    "message": "Curated wallets, exchanges, DeFi, identity and more."
+  },
+  "learn.stage.technology.title": {
+    "message": "Understand the technology"
+  },
+  "learn.stage.technology.intro": {
+    "message": "How the network reaches agreement, how it scales and how it changes over time."
+  },
+  "learn.stage.technology.quiz": {
+    "message": "Check what you learned with the [technical quiz](/quiz)."
+  },
+  "learn.item.ouroboros.title": {
+    "message": "Ouroboros"
+  },
+  "learn.item.ouroboros.text": {
+    "message": "The proof-of-stake protocol behind every block."
+  },
+  "learn.item.stablecoins.title": {
+    "message": "Stablecoins"
+  },
+  "learn.item.stablecoins.text": {
+    "message": "Stable value on Cardano: how the main stablecoins work and where to use them."
+  },
+  "learn.item.layer2.title": {
+    "message": "Layer 2"
+  },
+  "learn.item.layer2.text": {
+    "message": "Hydra, Midnight and the other networks that extend Cardano."
+  },
+  "learn.item.hardforks.title": {
+    "message": "Hard forks"
+  },
+  "learn.item.hardforks.text": {
+    "message": "Every protocol upgrade since launch, and how upgrades happen."
+  },
+  "learn.item.glossary.title": {
+    "message": "Glossary"
+  },
+  "learn.item.glossary.text": {
+    "message": "Every term, explained, with mental models and sources."
+  },
+  "learn.stage.takePart.title": {
+    "message": "Take part"
+  },
+  "learn.stage.takePart.intro": {
+    "message": "Every ada carries a vote and a stake. Here is how to use both."
+  },
+  "learn.stage.takePart.quiz": {
+    "message": "Check what you learned with the [governance and staking quizzes](/quiz)."
+  },
+  "learn.item.governance.title": {
+    "message": "Governance"
+  },
+  "learn.item.governance.text": {
+    "message": "How on-chain governance works and where to start."
+  },
+  "learn.item.delegateVotes.title": {
+    "message": "Delegate your voting power"
+  },
+  "learn.item.delegateVotes.text": {
+    "message": "Find a representative who votes the way you would."
+  },
+  "learn.item.treasury.title": {
+    "message": "The treasury"
+  },
+  "learn.item.treasury.text": {
+    "message": "How the community fund is filled and spent."
+  },
+  "learn.item.constitution.title": {
+    "message": "The constitution"
+  },
+  "learn.item.constitution.text": {
+    "message": "The rules the community ratified, in full."
+  },
+  "learn.item.spo.title": {
+    "message": "Run a stake pool"
+  },
+  "learn.item.spo.text": {
+    "message": "What it takes to operate a pool and produce blocks."
+  },
+  "learn.item.calculator.title": {
+    "message": "Staking calculator"
+  },
+  "learn.item.calculator.text": {
+    "message": "Estimate rewards for delegating or running a pool."
+  },
+  "learn.stage.goDeeper.title": {
+    "message": "Go deeper"
+  },
+  "learn.stage.goDeeper.intro": {
+    "message": "Research, data and courses for people who want the full picture."
+  },
+  "learn.item.research.title": {
+    "message": "Research"
+  },
+  "learn.item.research.text": {
+    "message": "The peer-reviewed papers Cardano is built on."
+  },
+  "learn.item.insights.title": {
+    "message": "Insights"
+  },
+  "learn.item.insights.text": {
+    "message": "Live and regularly refreshed on-chain data."
+  },
+  "learn.item.genesis.title": {
+    "message": "Genesis"
+  },
+  "learn.item.genesis.text": {
+    "message": "How Cardano started and who launched it."
+  },
+  "learn.item.entities.title": {
+    "message": "Entities"
+  },
+  "learn.item.entities.text": {
+    "message": "The organizations that contribute to Cardano today."
+  },
+  "learn.item.academy.title": {
+    "message": "Cardano Academy"
+  },
+  "learn.item.academy.text": {
+    "message": "Free, self-paced courses with certificates."
+  },
+  "learn.item.developers.title": {
+    "message": "Developer portal"
+  },
+  "learn.item.developers.text": {
+    "message": "Build on Cardano, from first transaction to smart contracts."
+  },
+  "learn.level.advanced": {
+    "message": "Advanced"
+  },
+  "learn.level.intermediate": {
+    "message": "Intermediate"
+  },
+  "learn.level.beginner": {
+    "message": "Beginner"
   }
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -6510,7 +6510,7 @@
     "message": "How do I start using Cardano?"
   },
   "whatIsCardano.start.outro": {
-    "message": "Prefer a guided walk-through? The getting started page takes you from download to first transaction."
+    "message": "Prefer a guided walk-through? The getting started page takes you from download to first transaction, and the [learning path](/learn) continues from there."
   },
   "whatIsCardano.start.button": {
     "message": "Start step by step"

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -2561,16 +2561,16 @@
   "hardforks.transactionIds.description": {
     "message": "Note that some hard forks, particularly Byron and Shelley, transitioned through a series of updates and may not have a single specific transaction id associated with them. For the others, the provided transaction ids correspond to significant parameter updates leading to the hard forks."
   },
-  "learn.hero.title": {
+  "learn.hero.heading": {
     "message": "Learn Cardano"
   },
-  "learn.hero.description": {
+  "learn.hero.tagline": {
     "message": "From your first wallet to on-chain governance, one stage at a time."
   },
-  "learn.layout.title": {
+  "learn.meta.title": {
     "message": "Learn Cardano, a Guided Path from Beginner to Advanced"
   },
-  "learn.layout.description": {
+  "learn.meta.description": {
     "message": "A five-stage learning path through cardano.org: understand the basics, use Cardano safely, learn how the technology works, take part in governance and go deeper with research and courses."
   },
   "newsletter.hero.title": {
@@ -6654,7 +6654,7 @@
     "message": "Stage {number}"
   },
   "learn.intro.callout": {
-    "message": "Five stages, each with a handful of pages and a quiz. Read them in order if you are new, or jump in where you already are."
+    "message": "Five stages, each with a handful of pages, and a quiz to check the first four."
   },
   "learn.cta.title": {
     "message": "Want a certificate at the end? The Cardano Academy offers free courses on everything above."
@@ -6714,7 +6714,7 @@
     "message": "Where to get ada"
   },
   "learn.item.whereToGetAda.text": {
-    "message": "Trusted exchanges and other ways to get ada."
+    "message": "Centralized and decentralized exchanges, and other ways to get ada."
   },
   "learn.item.commonScams.title": {
     "message": "Protect your ada"
@@ -6771,7 +6771,7 @@
     "message": "Glossary"
   },
   "learn.item.glossary.text": {
-    "message": "Every term, explained, with mental models and sources."
+    "message": "Every Cardano term, explained in plain language, with mental models where they help."
   },
   "learn.stage.takePart.title": {
     "message": "Take part"
@@ -6834,19 +6834,19 @@
     "message": "Insights"
   },
   "learn.item.insights.text": {
-    "message": "Live and regularly refreshed on-chain data."
+    "message": "On-chain or regularly refreshed data."
   },
   "learn.item.genesis.title": {
     "message": "Genesis"
   },
   "learn.item.genesis.text": {
-    "message": "How Cardano started and who launched it."
+    "message": "The genesis distribution: how ada was first allocated."
   },
   "learn.item.entities.title": {
     "message": "Entities"
   },
   "learn.item.entities.text": {
-    "message": "The organizations that contribute to Cardano today."
+    "message": "Organizations building on Cardano today."
   },
   "learn.item.academy.title": {
     "message": "Cardano Academy"
@@ -6868,5 +6868,8 @@
   },
   "learn.level.beginner": {
     "message": "Beginner"
+  },
+  "learn.level.ariaLabel": {
+    "message": "Level: {label}"
   }
 }

--- a/src/components/Layout/BackgroundWrapper/styles.module.css
+++ b/src/components/Layout/BackgroundWrapper/styles.module.css
@@ -92,6 +92,10 @@
 /** backgroundZoomMini */
 
 .backgroundGradientDark {
+  /* flow-root keeps the children's margins (SpacerBox, CtaOneColumn) inside
+     the gradient instead of collapsing through and leaving a page-colored
+     strip above the footer. */
+  display: flow-root;
   background-image: linear-gradient(315deg, #0133ae, #335cbe);
 }
 

--- a/src/data/glossaryCategories.js
+++ b/src/data/glossaryCategories.js
@@ -103,7 +103,7 @@ export const LEARNING_PATHS = [
     id: 'new-to-cardano',
     title: 'New to Cardano?',
     description: 'Start here if you are new to the ecosystem.',
-    href: '/get-started',
+    href: '/learn',
     icon: 'shapes-solid',
     color: '#0033ad',
     audience: 'Beginner',

--- a/src/data/learningPath.js
+++ b/src/data/learningPath.js
@@ -1,5 +1,5 @@
-// src/data/learningPath.js
 import { translate } from "@docusaurus/Translate";
+import { academyUrl } from "@site/src/data/quiz/academy";
 import {
   FaInfoCircle, FaCoins, FaWallet, FaPlay,
   FaSearch, FaShoppingCart, FaShieldAlt, FaLayerGroup, FaThLarge,
@@ -8,8 +8,7 @@ import {
   FaFlask, FaChartLine, FaHistory, FaBuilding, FaGraduationCap, FaCode,
 } from "react-icons/fa";
 
-const ACADEMY_URL =
-  "https://cardanofoundation.org/en/academy?utm_source=cardano_org&utm_medium=learn&utm_campaign=learn_hub";
+export const ACADEMY_URL = academyUrl("landing", { medium: "learn", campaign: "learn_hub" });
 
 // The five stages of /learn. Only routes that exist may appear here, the
 // site build fails on broken links. New explainer pages join a stage by
@@ -94,15 +93,12 @@ export function getLearningPath() {
   ];
 }
 
-export function getLevelLabel(level) {
-  switch (level) {
-    case "advanced":
-      return translate({ id: "learn.level.advanced", message: "Advanced" });
-    case "intermediate":
-      return translate({ id: "learn.level.intermediate", message: "Intermediate" });
-    default:
-      return translate({ id: "learn.level.beginner", message: "Beginner" });
-  }
-}
+const LEVEL_LABELS = {
+  beginner: () => translate({ id: "learn.level.beginner", message: "Beginner" }),
+  intermediate: () => translate({ id: "learn.level.intermediate", message: "Intermediate" }),
+  advanced: () => translate({ id: "learn.level.advanced", message: "Advanced" }),
+};
 
-export { ACADEMY_URL };
+export function getLevelLabel(level) {
+  return (LEVEL_LABELS[level] || LEVEL_LABELS.beginner)();
+}

--- a/src/data/learningPath.js
+++ b/src/data/learningPath.js
@@ -1,0 +1,108 @@
+// src/data/learningPath.js
+import { translate } from "@docusaurus/Translate";
+import {
+  FaInfoCircle, FaCoins, FaWallet, FaPlay,
+  FaSearch, FaShoppingCart, FaShieldAlt, FaLayerGroup, FaThLarge,
+  FaCog, FaBalanceScale, FaCodeBranch, FaBook,
+  FaVoteYea, FaUsers, FaPiggyBank, FaScroll, FaServer, FaCalculator,
+  FaFlask, FaChartLine, FaHistory, FaBuilding, FaGraduationCap, FaCode,
+} from "react-icons/fa";
+
+const ACADEMY_URL =
+  "https://cardanofoundation.org/en/academy?utm_source=cardano_org&utm_medium=learn&utm_campaign=learn_hub";
+
+// The five stages of /learn. Only routes that exist may appear here, the
+// site build fails on broken links. New explainer pages join a stage by
+// adding an item, the page itself does not change.
+export function getLearningPath() {
+  return [
+    {
+      key: "start",
+      anchor: "start",
+      level: "beginner",
+      title: translate({ id: "learn.stage.start.title", message: "Start here" }),
+      intro: translate({ id: "learn.stage.start.intro", message: "What Cardano is, what ada is, and the one tool you need to use either of them." }),
+      quiz: translate({ id: "learn.stage.start.quiz", message: "Check what you learned with the [basics quiz](/quiz)." }),
+      items: [
+        { key: "what-is-cardano", href: "/what-is-cardano", icon: <FaInfoCircle />, title: translate({ id: "learn.item.whatIsCardano.title", message: "What is Cardano?" }), text: translate({ id: "learn.item.whatIsCardano.text", message: "The platform in plain terms: how it works, what makes it different, who runs it." }) },
+        { key: "what-is-ada", href: "/what-is-ada", icon: <FaCoins />, title: translate({ id: "learn.item.whatIsAda.title", message: "What is ada?" }), text: translate({ id: "learn.item.whatIsAda.text", message: "The currency of the network, what it is used for and how to get it." }) },
+        { key: "what-is-a-wallet", href: "/what-is-a-wallet", icon: <FaWallet />, title: translate({ id: "learn.item.whatIsAWallet.title", message: "What is a wallet?" }), text: translate({ id: "learn.item.whatIsAWallet.text", message: "Your keys, your ada. Wallet types, recovery phrases and how to stay safe." }) },
+        { key: "get-started", href: "/get-started", icon: <FaPlay />, title: translate({ id: "learn.item.getStarted.title", message: "Get started" }), text: translate({ id: "learn.item.getStarted.text", message: "A guided walk-through from download to your first transaction." }) },
+      ],
+    },
+    {
+      key: "use",
+      anchor: "use",
+      level: "beginner",
+      title: translate({ id: "learn.stage.use.title", message: "Use Cardano" }),
+      intro: translate({ id: "learn.stage.use.intro", message: "Pick a wallet, get your first ada, keep it safe and put it to work." }),
+      quiz: translate({ id: "learn.stage.use.quiz", message: "Check what you learned with the [wallets and security quizzes](/quiz)." }),
+      items: [
+        { key: "wallets", href: "/wallets", icon: <FaSearch />, title: translate({ id: "learn.item.wallets.title", message: "Find a wallet" }), text: translate({ id: "learn.item.wallets.text", message: "Compare wallets by platform, features and hardware support." }) },
+        { key: "where-to-get-ada", href: "/where-to-get-ada", icon: <FaShoppingCart />, title: translate({ id: "learn.item.whereToGetAda.title", message: "Where to get ada" }), text: translate({ id: "learn.item.whereToGetAda.text", message: "Trusted exchanges and other ways to get ada." }) },
+        { key: "common-scams", href: "/common-scams", icon: <FaShieldAlt />, title: translate({ id: "learn.item.commonScams.title", message: "Protect your ada" }), text: translate({ id: "learn.item.commonScams.text", message: "The scams that catch newcomers, and how to spot them." }) },
+        { key: "delegation", href: "/stake-pool-delegation", icon: <FaLayerGroup />, title: translate({ id: "learn.item.delegation.title", message: "Delegate your ada" }), text: translate({ id: "learn.item.delegation.text", message: "Earn rewards by delegating to a stake pool, without giving up custody." }) },
+        { key: "apps", href: "/apps", icon: <FaThLarge />, title: translate({ id: "learn.item.apps.title", message: "Explore apps" }), text: translate({ id: "learn.item.apps.text", message: "Curated wallets, exchanges, DeFi, identity and more." }) },
+      ],
+    },
+    {
+      key: "technology",
+      anchor: "technology",
+      level: "intermediate",
+      title: translate({ id: "learn.stage.technology.title", message: "Understand the technology" }),
+      intro: translate({ id: "learn.stage.technology.intro", message: "How the network reaches agreement, how it scales and how it changes over time." }),
+      quiz: translate({ id: "learn.stage.technology.quiz", message: "Check what you learned with the [technical quiz](/quiz)." }),
+      items: [
+        { key: "ouroboros", href: "/ouroboros", icon: <FaCog />, title: translate({ id: "learn.item.ouroboros.title", message: "Ouroboros" }), text: translate({ id: "learn.item.ouroboros.text", message: "The proof-of-stake protocol behind every block." }) },
+        { key: "stablecoins", href: "/stablecoins", icon: <FaBalanceScale />, title: translate({ id: "learn.item.stablecoins.title", message: "Stablecoins" }), text: translate({ id: "learn.item.stablecoins.text", message: "Stable value on Cardano: how the main stablecoins work and where to use them." }) },
+        { key: "layer-2", href: "/layer-2", icon: <FaLayerGroup />, title: translate({ id: "learn.item.layer2.title", message: "Layer 2" }), text: translate({ id: "learn.item.layer2.text", message: "Hydra, Midnight and the other networks that extend Cardano." }) },
+        { key: "hardforks", href: "/hardforks", icon: <FaCodeBranch />, title: translate({ id: "learn.item.hardforks.title", message: "Hard forks" }), text: translate({ id: "learn.item.hardforks.text", message: "Every protocol upgrade since launch, and how upgrades happen." }) },
+        { key: "glossary", href: "/glossary", icon: <FaBook />, title: translate({ id: "learn.item.glossary.title", message: "Glossary" }), text: translate({ id: "learn.item.glossary.text", message: "Every term, explained, with mental models and sources." }) },
+      ],
+    },
+    {
+      key: "take-part",
+      anchor: "take-part",
+      level: "intermediate",
+      title: translate({ id: "learn.stage.takePart.title", message: "Take part" }),
+      intro: translate({ id: "learn.stage.takePart.intro", message: "Every ada carries a vote and a stake. Here is how to use both." }),
+      quiz: translate({ id: "learn.stage.takePart.quiz", message: "Check what you learned with the [governance and staking quizzes](/quiz)." }),
+      items: [
+        { key: "governance", href: "/governance", icon: <FaVoteYea />, title: translate({ id: "learn.item.governance.title", message: "Governance" }), text: translate({ id: "learn.item.governance.text", message: "How on-chain governance works and where to start." }) },
+        { key: "delegate-votes", href: "/governance/delegate", icon: <FaUsers />, title: translate({ id: "learn.item.delegateVotes.title", message: "Delegate your voting power" }), text: translate({ id: "learn.item.delegateVotes.text", message: "Find a representative who votes the way you would." }) },
+        { key: "treasury", href: "/governance/treasury", icon: <FaPiggyBank />, title: translate({ id: "learn.item.treasury.title", message: "The treasury" }), text: translate({ id: "learn.item.treasury.text", message: "How the community fund is filled and spent." }) },
+        { key: "constitution", href: "/constitution", icon: <FaScroll />, title: translate({ id: "learn.item.constitution.title", message: "The constitution" }), text: translate({ id: "learn.item.constitution.text", message: "The rules the community ratified, in full." }) },
+        { key: "spo", href: "/stake-pool-operation", icon: <FaServer />, title: translate({ id: "learn.item.spo.title", message: "Run a stake pool" }), text: translate({ id: "learn.item.spo.text", message: "What it takes to operate a pool and produce blocks." }) },
+        { key: "calculator", href: "/calculator", icon: <FaCalculator />, title: translate({ id: "learn.item.calculator.title", message: "Staking calculator" }), text: translate({ id: "learn.item.calculator.text", message: "Estimate rewards for delegating or running a pool." }) },
+      ],
+    },
+    {
+      key: "go-deeper",
+      anchor: "go-deeper",
+      level: "advanced",
+      title: translate({ id: "learn.stage.goDeeper.title", message: "Go deeper" }),
+      intro: translate({ id: "learn.stage.goDeeper.intro", message: "Research, data and courses for people who want the full picture." }),
+      items: [
+        { key: "research", href: "/research", icon: <FaFlask />, title: translate({ id: "learn.item.research.title", message: "Research" }), text: translate({ id: "learn.item.research.text", message: "The peer-reviewed papers Cardano is built on." }) },
+        { key: "insights", href: "/insights", icon: <FaChartLine />, title: translate({ id: "learn.item.insights.title", message: "Insights" }), text: translate({ id: "learn.item.insights.text", message: "Live and regularly refreshed on-chain data." }) },
+        { key: "genesis", href: "/genesis", icon: <FaHistory />, title: translate({ id: "learn.item.genesis.title", message: "Genesis" }), text: translate({ id: "learn.item.genesis.text", message: "How Cardano started and who launched it." }) },
+        { key: "entities", href: "/entities", icon: <FaBuilding />, title: translate({ id: "learn.item.entities.title", message: "Entities" }), text: translate({ id: "learn.item.entities.text", message: "The organizations that contribute to Cardano today." }) },
+        { key: "academy", href: ACADEMY_URL, icon: <FaGraduationCap />, title: translate({ id: "learn.item.academy.title", message: "Cardano Academy" }), text: translate({ id: "learn.item.academy.text", message: "Free, self-paced courses with certificates." }) },
+        { key: "developers", href: "https://developers.cardano.org", icon: <FaCode />, title: translate({ id: "learn.item.developers.title", message: "Developer portal" }), text: translate({ id: "learn.item.developers.text", message: "Build on Cardano, from first transaction to smart contracts." }) },
+      ],
+    },
+  ];
+}
+
+export function getLevelLabel(level) {
+  switch (level) {
+    case "advanced":
+      return translate({ id: "learn.level.advanced", message: "Advanced" });
+    case "intermediate":
+      return translate({ id: "learn.level.intermediate", message: "Intermediate" });
+    default:
+      return translate({ id: "learn.level.beginner", message: "Beginner" });
+  }
+}
+
+export { ACADEMY_URL };

--- a/src/data/learningPath.js
+++ b/src/data/learningPath.js
@@ -2,13 +2,17 @@ import { translate } from "@docusaurus/Translate";
 import { academyUrl } from "@site/src/data/quiz/academy";
 import {
   FaInfoCircle, FaCoins, FaWallet, FaPlay,
-  FaSearch, FaShoppingCart, FaShieldAlt, FaLayerGroup, FaThLarge,
+  FaSearch, FaShoppingCart, FaShieldAlt, FaHandshake, FaLayerGroup, FaThLarge,
   FaCog, FaBalanceScale, FaCodeBranch, FaBook,
   FaVoteYea, FaUsers, FaPiggyBank, FaScroll, FaServer, FaCalculator,
   FaFlask, FaChartLine, FaHistory, FaBuilding, FaGraduationCap, FaCode,
 } from "react-icons/fa";
 
-export const ACADEMY_URL = academyUrl("landing", { medium: "learn", campaign: "learn_hub" });
+// The Cardano Academy item in the go-deeper stage and the bottom-of-page CTA
+// link to the same landing page but need distinct utm_content values so
+// analytics can tell the two entry points apart.
+export const ACADEMY_CARD_URL = academyUrl("landing", { medium: "learn", campaign: "learn_hub", content: "go-deeper-card" });
+export const ACADEMY_CTA_URL = academyUrl("landing", { medium: "learn", campaign: "learn_hub", content: "page-cta" });
 
 // The five stages of /learn. Only routes that exist may appear here, the
 // site build fails on broken links. New explainer pages join a stage by
@@ -38,9 +42,9 @@ export function getLearningPath() {
       quiz: translate({ id: "learn.stage.use.quiz", message: "Check what you learned with the [wallets and security quizzes](/quiz)." }),
       items: [
         { key: "wallets", href: "/wallets", icon: <FaSearch />, title: translate({ id: "learn.item.wallets.title", message: "Find a wallet" }), text: translate({ id: "learn.item.wallets.text", message: "Compare wallets by platform, features and hardware support." }) },
-        { key: "where-to-get-ada", href: "/where-to-get-ada", icon: <FaShoppingCart />, title: translate({ id: "learn.item.whereToGetAda.title", message: "Where to get ada" }), text: translate({ id: "learn.item.whereToGetAda.text", message: "Trusted exchanges and other ways to get ada." }) },
+        { key: "where-to-get-ada", href: "/where-to-get-ada", icon: <FaShoppingCart />, title: translate({ id: "learn.item.whereToGetAda.title", message: "Where to get ada" }), text: translate({ id: "learn.item.whereToGetAda.text", message: "Centralized and decentralized exchanges, and other ways to get ada." }) },
         { key: "common-scams", href: "/common-scams", icon: <FaShieldAlt />, title: translate({ id: "learn.item.commonScams.title", message: "Protect your ada" }), text: translate({ id: "learn.item.commonScams.text", message: "The scams that catch newcomers, and how to spot them." }) },
-        { key: "delegation", href: "/stake-pool-delegation", icon: <FaLayerGroup />, title: translate({ id: "learn.item.delegation.title", message: "Delegate your ada" }), text: translate({ id: "learn.item.delegation.text", message: "Earn rewards by delegating to a stake pool, without giving up custody." }) },
+        { key: "delegation", href: "/stake-pool-delegation", icon: <FaHandshake />, title: translate({ id: "learn.item.delegation.title", message: "Delegate your ada" }), text: translate({ id: "learn.item.delegation.text", message: "Earn rewards by delegating to a stake pool, without giving up custody." }) },
         { key: "apps", href: "/apps", icon: <FaThLarge />, title: translate({ id: "learn.item.apps.title", message: "Explore apps" }), text: translate({ id: "learn.item.apps.text", message: "Curated wallets, exchanges, DeFi, identity and more." }) },
       ],
     },
@@ -56,7 +60,7 @@ export function getLearningPath() {
         { key: "stablecoins", href: "/stablecoins", icon: <FaBalanceScale />, title: translate({ id: "learn.item.stablecoins.title", message: "Stablecoins" }), text: translate({ id: "learn.item.stablecoins.text", message: "Stable value on Cardano: how the main stablecoins work and where to use them." }) },
         { key: "layer-2", href: "/layer-2", icon: <FaLayerGroup />, title: translate({ id: "learn.item.layer2.title", message: "Layer 2" }), text: translate({ id: "learn.item.layer2.text", message: "Hydra, Midnight and the other networks that extend Cardano." }) },
         { key: "hardforks", href: "/hardforks", icon: <FaCodeBranch />, title: translate({ id: "learn.item.hardforks.title", message: "Hard forks" }), text: translate({ id: "learn.item.hardforks.text", message: "Every protocol upgrade since launch, and how upgrades happen." }) },
-        { key: "glossary", href: "/glossary", icon: <FaBook />, title: translate({ id: "learn.item.glossary.title", message: "Glossary" }), text: translate({ id: "learn.item.glossary.text", message: "Every term, explained, with mental models and sources." }) },
+        { key: "glossary", href: "/glossary", icon: <FaBook />, title: translate({ id: "learn.item.glossary.title", message: "Glossary" }), text: translate({ id: "learn.item.glossary.text", message: "Every Cardano term, explained in plain language, with mental models where they help." }) },
       ],
     },
     {
@@ -83,10 +87,10 @@ export function getLearningPath() {
       intro: translate({ id: "learn.stage.goDeeper.intro", message: "Research, data and courses for people who want the full picture." }),
       items: [
         { key: "research", href: "/research", icon: <FaFlask />, title: translate({ id: "learn.item.research.title", message: "Research" }), text: translate({ id: "learn.item.research.text", message: "The peer-reviewed papers Cardano is built on." }) },
-        { key: "insights", href: "/insights", icon: <FaChartLine />, title: translate({ id: "learn.item.insights.title", message: "Insights" }), text: translate({ id: "learn.item.insights.text", message: "Live and regularly refreshed on-chain data." }) },
-        { key: "genesis", href: "/genesis", icon: <FaHistory />, title: translate({ id: "learn.item.genesis.title", message: "Genesis" }), text: translate({ id: "learn.item.genesis.text", message: "How Cardano started and who launched it." }) },
-        { key: "entities", href: "/entities", icon: <FaBuilding />, title: translate({ id: "learn.item.entities.title", message: "Entities" }), text: translate({ id: "learn.item.entities.text", message: "The organizations that contribute to Cardano today." }) },
-        { key: "academy", href: ACADEMY_URL, icon: <FaGraduationCap />, title: translate({ id: "learn.item.academy.title", message: "Cardano Academy" }), text: translate({ id: "learn.item.academy.text", message: "Free, self-paced courses with certificates." }) },
+        { key: "insights", href: "/insights", icon: <FaChartLine />, title: translate({ id: "learn.item.insights.title", message: "Insights" }), text: translate({ id: "learn.item.insights.text", message: "On-chain or regularly refreshed data." }) },
+        { key: "genesis", href: "/genesis", icon: <FaHistory />, title: translate({ id: "learn.item.genesis.title", message: "Genesis" }), text: translate({ id: "learn.item.genesis.text", message: "The genesis distribution: how ada was first allocated." }) },
+        { key: "entities", href: "/entities", icon: <FaBuilding />, title: translate({ id: "learn.item.entities.title", message: "Entities" }), text: translate({ id: "learn.item.entities.text", message: "Organizations building on Cardano today." }) },
+        { key: "academy", href: ACADEMY_CARD_URL, icon: <FaGraduationCap />, title: translate({ id: "learn.item.academy.title", message: "Cardano Academy" }), text: translate({ id: "learn.item.academy.text", message: "Free, self-paced courses with certificates." }) },
         { key: "developers", href: "https://developers.cardano.org", icon: <FaCode />, title: translate({ id: "learn.item.developers.title", message: "Developer portal" }), text: translate({ id: "learn.item.developers.text", message: "Build on Cardano, from first transaction to smart contracts." }) },
       ],
     },

--- a/src/data/navbar.js
+++ b/src/data/navbar.js
@@ -54,6 +54,7 @@ function getNavbarItems() {
         {
           title: 'Get to know',
           items: [
+            {to: '/learn', label: 'Learn step by step', description: 'A guided path from beginner to advanced'},
             {to: '/what-is-ada', label: 'What is ada?', description: 'Cardano\'s native token'},
             {to: '/what-is-a-wallet', label: 'What is a Wallet?', description: 'Understand wallet types and security'},
             {to: '/common-scams', label: 'Protect your ada', description: 'Don\'t fall for scams'},

--- a/src/data/quiz/academy.js
+++ b/src/data/quiz/academy.js
@@ -22,14 +22,23 @@ const COURSE_URLS = {
   landing: ACADEMY_LANDING,
 };
 
-export function getAcademyCta(academyKey, quizId) {
+// Academy link with the site's UTM scheme. Every funnel into the Academy
+// (quiz result screens, the learn hub) builds its URL here so the campaign
+// parameters cannot drift between pages.
+export function academyUrl(academyKey, {medium, campaign, content}) {
   const url = new URL(COURSE_URLS[academyKey] || ACADEMY_LANDING);
   url.searchParams.set('utm_source', 'cardano_org');
-  url.searchParams.set('utm_medium', 'quiz');
-  url.searchParams.set('utm_campaign', 'quiz_hub');
-  url.searchParams.set('utm_content', quizId);
+  url.searchParams.set('utm_medium', medium);
+  url.searchParams.set('utm_campaign', campaign);
+  if (content) {
+    url.searchParams.set('utm_content', content);
+  }
+  return url.toString();
+}
+
+export function getAcademyCta(academyKey, quizId) {
   return {
-    href: url.toString(),
+    href: academyUrl(academyKey, {medium: 'quiz', campaign: 'quiz_hub', content: quizId}),
     // Short label for the result screen link, where the surrounding card
     // already makes the destination context clear. ariaLabel names the
     // destination explicitly for assistive tech, since the link leaves the

--- a/src/data/quiz/academy.js
+++ b/src/data/quiz/academy.js
@@ -25,7 +25,7 @@ const COURSE_URLS = {
 // Academy link with the site's UTM scheme. Every funnel into the Academy
 // (quiz result screens, the learn hub) builds its URL here so the campaign
 // parameters cannot drift between pages.
-export function academyUrl(academyKey, {medium, campaign, content}) {
+export function academyUrl(academyKey, {medium, campaign, content} = {}) {
   const url = new URL(COURSE_URLS[academyKey] || ACADEMY_LANDING);
   url.searchParams.set('utm_source', 'cardano_org');
   url.searchParams.set('utm_medium', medium);

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -1,9 +1,9 @@
-// src/pages/learn.js
 import React from "react";
 import Layout from "@theme/Layout";
 import Head from "@docusaurus/Head";
 import { translate } from "@docusaurus/Translate";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import { FaRoute } from "react-icons/fa";
 import SiteHero from "@site/src/components/Layout/SiteHero";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
@@ -16,7 +16,7 @@ import RoleCard from "@site/src/components/Layout/RoleCard";
 import CtaOneColumn from "@site/src/components/Layout/CtaOneColumn";
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
 import { jsonLdString } from "@site/src/utils/jsonLd";
-import { getLearningPath, getLevelLabel, ACADEMY_URL } from "@site/src/data/learningPath";
+import { getLearningPath, getLevelLabel, ACADEMY_CTA_URL } from "@site/src/data/learningPath";
 import styles from "./learn.module.css";
 
 const ACCENT_BY_LEVEL = { beginner: "blue", intermediate: "violet", advanced: "teal" };
@@ -24,8 +24,8 @@ const ACCENT_BY_LEVEL = { beginner: "blue", intermediate: "violet", advanced: "t
 function LearnHero() {
   return (
     <SiteHero
-      title={translate({ id: "learn.hero.title", message: "Learn Cardano" })}
-      description={translate({ id: "learn.hero.description", message: "From your first wallet to on-chain governance, one stage at a time." })}
+      title={translate({ id: "learn.hero.heading", message: "Learn Cardano" })}
+      description={translate({ id: "learn.hero.tagline", message: "From your first wallet to on-chain governance, one stage at a time." })}
       bannerType="dots"
     />
   );
@@ -35,7 +35,12 @@ function Stage({ stage, index }) {
   return (
     <>
       <Divider id={stage.anchor} text={translate({ id: "learn.stage.dividerLabel", message: "Stage {number}" }, { number: index + 1 })} />
-      <span className={styles.stageMeta}>{getLevelLabel(stage.level)}</span>
+      <span
+        className={styles.stageMeta}
+        aria-label={translate({ id: "learn.level.ariaLabel", message: "Level: {label}" }, { label: getLevelLabel(stage.level) })}
+      >
+        {getLevelLabel(stage.level)}
+      </span>
       <TitleWithText title={stage.title} description={stage.intro} headingDot={true} />
       <div className={styles.cardGrid}>
         {stage.items.map((item) => (
@@ -54,10 +59,11 @@ export default function Learn() {
   const { siteConfig } = useDocusaurusContext();
   const stages = getLearningPath();
   const siteUrl = siteConfig.url.replace(/\/$/, "");
+  const learnBaseUrl = useBaseUrl("/learn").replace(/\/$/, "");
   return (
     <Layout
-      title={translate({ id: "learn.layout.title", message: "Learn Cardano, a Guided Path from Beginner to Advanced" })}
-      description={translate({ id: "learn.layout.description", message: "A five-stage learning path through cardano.org: understand the basics, use Cardano safely, learn how the technology works, take part in governance and go deeper with research and courses." })}
+      title={translate({ id: "learn.meta.title", message: "Learn Cardano, a Guided Path from Beginner to Advanced" })}
+      description={translate({ id: "learn.meta.description", message: "A five-stage learning path through cardano.org: understand the basics, use Cardano safely, learn how the technology works, take part in governance and go deeper with research and courses." })}
     >
       <Head>
         <script type="application/ld+json">
@@ -69,7 +75,7 @@ export default function Learn() {
               "@type": "ListItem",
               "position": index + 1,
               "name": stage.title,
-              "url": `${siteUrl}/learn/#${stage.anchor}`,
+              "url": `${siteUrl}${learnBaseUrl}/#${stage.anchor}`,
             })),
           })}
         </script>
@@ -81,7 +87,7 @@ export default function Learn() {
           <BoundaryBox>
             <SpacerBox size="small" />
             <HighlightCallout icon={<FaRoute />}>
-              {translate({ id: "learn.intro.callout", message: "Five stages, each with a handful of pages and a quiz. Read them in order if you are new, or jump in where you already are." })}
+              {translate({ id: "learn.intro.callout", message: "Five stages, each with a handful of pages, and a quiz to check the first four." })}
             </HighlightCallout>
             {stages.map((stage, index) => (
               <Stage key={stage.key} stage={stage} index={index} />
@@ -93,7 +99,7 @@ export default function Learn() {
             <CtaOneColumn
               title={translate({ id: "learn.cta.title", message: "Want a certificate at the end? The Cardano Academy offers free courses on everything above." })}
               buttonLabel={translate({ id: "learn.cta.button", message: "Explore the Academy" })}
-              buttonLink={ACADEMY_URL}
+              buttonLink={ACADEMY_CTA_URL}
             />
             <SpacerBox size="small" />
           </BoundaryBox>

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -4,6 +4,7 @@ import Head from "@docusaurus/Head";
 import { translate } from "@docusaurus/Translate";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useBaseUrl from "@docusaurus/useBaseUrl";
+import Link from "@docusaurus/Link";
 import { FaRoute } from "react-icons/fa";
 import SiteHero from "@site/src/components/Layout/SiteHero";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
@@ -12,14 +13,25 @@ import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
 import Divider from "@site/src/components/Layout/Divider";
 import TitleWithText from "@site/src/components/Layout/TitleWithText";
 import HighlightCallout from "@site/src/components/Layout/HighlightCallout";
-import RoleCard from "@site/src/components/Layout/RoleCard";
 import CtaOneColumn from "@site/src/components/Layout/CtaOneColumn";
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
 import { jsonLdString } from "@site/src/utils/jsonLd";
 import { getLearningPath, getLevelLabel, ACADEMY_CTA_URL } from "@site/src/data/learningPath";
 import styles from "./learn.module.css";
 
-const ACCENT_BY_LEVEL = { beginner: "blue", intermediate: "violet", advanced: "teal" };
+// Compact link card for the stage grids. RoleCard's large icon halo leaves
+// too little room for text in a dense three-column directory.
+function PathCard({ item }) {
+  return (
+    <Link to={item.href} className={styles.card}>
+      <span className={styles.cardIcon} aria-hidden="true">
+        {item.icon}
+      </span>
+      <span className={styles.cardTitle}>{item.title}</span>
+      <span className={styles.cardText}>{item.text}</span>
+    </Link>
+  );
+}
 
 function LearnHero() {
   return (
@@ -44,9 +56,7 @@ function Stage({ stage, index }) {
       <TitleWithText title={stage.title} description={stage.intro} headingDot={true} />
       <div className={styles.cardGrid}>
         {stage.items.map((item) => (
-          <RoleCard key={item.key} accent={ACCENT_BY_LEVEL[stage.level]} icon={item.icon} title={item.title} href={item.href}>
-            {item.text}
-          </RoleCard>
+          <PathCard key={item.key} item={item} />
         ))}
       </div>
       {stage.quiz && <TitleWithText description={stage.quiz} />}

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -1,30 +1,104 @@
+// src/pages/learn.js
+import React from "react";
 import Layout from "@theme/Layout";
+import Head from "@docusaurus/Head";
+import { translate } from "@docusaurus/Translate";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { FaRoute } from "react-icons/fa";
 import SiteHero from "@site/src/components/Layout/SiteHero";
+import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
+import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
 import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
-import {translate} from '@docusaurus/Translate';
+import Divider from "@site/src/components/Layout/Divider";
+import TitleWithText from "@site/src/components/Layout/TitleWithText";
+import HighlightCallout from "@site/src/components/Layout/HighlightCallout";
+import RoleCard from "@site/src/components/Layout/RoleCard";
+import CtaOneColumn from "@site/src/components/Layout/CtaOneColumn";
+import SpacerBox from "@site/src/components/Layout/SpacerBox";
+import { jsonLdString } from "@site/src/utils/jsonLd";
+import { getLearningPath, getLevelLabel, ACADEMY_URL } from "@site/src/data/learningPath";
+import styles from "./learn.module.css";
 
-function HomepageHeader() {
-  const { siteTitle } = "useDocusaurusContext()";
+const ACCENT_BY_LEVEL = { beginner: "blue", intermediate: "violet", advanced: "teal" };
+
+function LearnHero() {
   return (
     <SiteHero
-      title={translate({id: 'learn.hero.title', message: 'Learn'})}
-      description={translate({id: 'learn.hero.description', message: 'Empowering the digital architects of the future.'})}
-      bannerType="default"
+      title={translate({ id: "learn.hero.title", message: "Learn Cardano" })}
+      description={translate({ id: "learn.hero.description", message: "From your first wallet to on-chain governance, one stage at a time." })}
+      bannerType="dots"
     />
   );
 }
 
-export default function Home() {
+function Stage({ stage, index }) {
+  return (
+    <>
+      <Divider id={stage.anchor} text={translate({ id: "learn.stage.dividerLabel", message: "Stage {number}" }, { number: index + 1 })} />
+      <span className={styles.stageMeta}>{getLevelLabel(stage.level)}</span>
+      <TitleWithText title={stage.title} description={stage.intro} headingDot={true} />
+      <div className={styles.cardGrid}>
+        {stage.items.map((item) => (
+          <RoleCard key={item.key} accent={ACCENT_BY_LEVEL[stage.level]} icon={item.icon} title={item.title} href={item.href}>
+            {item.text}
+          </RoleCard>
+        ))}
+      </div>
+      {stage.quiz && <TitleWithText description={stage.quiz} />}
+      <SpacerBox size="small" />
+    </>
+  );
+}
 
+export default function Learn() {
+  const { siteConfig } = useDocusaurusContext();
+  const stages = getLearningPath();
+  const siteUrl = siteConfig.url.replace(/\/$/, "");
   return (
     <Layout
-    title={translate({id: 'learn.layout.title', message: 'Learn About Cardano, Guides, Tutorials and Resources'})}
-    description={translate({id: 'learn.layout.description', message: 'Learn how Cardano works, from proof-of-stake consensus and smart contracts to staking, governance, and building decentralized applications.'})}
+      title={translate({ id: "learn.layout.title", message: "Learn Cardano, a Guided Path from Beginner to Advanced" })}
+      description={translate({ id: "learn.layout.description", message: "A five-stage learning path through cardano.org: understand the basics, use Cardano safely, learn how the technology works, take part in governance and go deeper with research and courses." })}
     >
-      <HomepageHeader />
-      <BoundaryBox>
-          FIXME: Learn
-        </BoundaryBox>
+      <Head>
+        <script type="application/ld+json">
+          {jsonLdString({
+            "@context": "https://schema.org",
+            "@type": "ItemList",
+            "name": "Learn Cardano",
+            "itemListElement": stages.map((stage, index) => ({
+              "@type": "ListItem",
+              "position": index + 1,
+              "name": stage.title,
+              "url": `${siteUrl}/learn/#${stage.anchor}`,
+            })),
+          })}
+        </script>
+      </Head>
+      <OpenGraphInfo />
+      <LearnHero />
+      <main>
+        <BackgroundWrapper backgroundType="zoom">
+          <BoundaryBox>
+            <SpacerBox size="small" />
+            <HighlightCallout icon={<FaRoute />}>
+              {translate({ id: "learn.intro.callout", message: "Five stages, each with a handful of pages and a quiz. Read them in order if you are new, or jump in where you already are." })}
+            </HighlightCallout>
+            {stages.map((stage, index) => (
+              <Stage key={stage.key} stage={stage} index={index} />
+            ))}
+          </BoundaryBox>
+        </BackgroundWrapper>
+        <BackgroundWrapper backgroundType="gradientDark">
+          <BoundaryBox>
+            <CtaOneColumn
+              title={translate({ id: "learn.cta.title", message: "Want a certificate at the end? The Cardano Academy offers free courses on everything above." })}
+              buttonLabel={translate({ id: "learn.cta.button", message: "Explore the Academy" })}
+              buttonLink={ACADEMY_URL}
+            />
+            <SpacerBox size="small" />
+          </BoundaryBox>
+        </BackgroundWrapper>
+      </main>
     </Layout>
   );
 }

--- a/src/pages/learn.module.css
+++ b/src/pages/learn.module.css
@@ -1,0 +1,25 @@
+/* src/pages/learn.module.css */
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.stageMeta {
+  display: inline-block;
+  margin-bottom: 0.75rem;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+  background: rgba(0, 51, 173, 0.1);
+}
+
+[data-theme='dark'] .stageMeta {
+  color: #8fb1ff;
+  background: rgba(119, 161, 255, 0.18);
+}

--- a/src/pages/learn.module.css
+++ b/src/pages/learn.module.css
@@ -1,8 +1,61 @@
 .cardGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1rem;
   margin: 1.5rem 0;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.25rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-background-surface-color);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.card:hover,
+.card:focus-visible {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-2px);
+  color: inherit;
+  text-decoration: none;
+}
+
+.cardIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  font-size: 1.1rem;
+  color: var(--ifm-color-primary);
+  background: rgba(0, 51, 173, 0.1);
+}
+
+.cardTitle {
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+}
+
+.cardText {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-800);
+}
+
+[data-theme='dark'] .cardIcon {
+  color: #8fb1ff;
+  background: rgba(119, 161, 255, 0.18);
+}
+
+[data-theme='dark'] .cardTitle {
+  color: #8fb1ff;
 }
 
 .stageMeta {

--- a/src/pages/learn.module.css
+++ b/src/pages/learn.module.css
@@ -1,4 +1,3 @@
-/* src/pages/learn.module.css */
 .cardGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -10,7 +9,7 @@
   display: inline-block;
   margin-bottom: 0.75rem;
   padding: 0.2rem 0.7rem;
-  border-radius: 999px;
+  border-radius: var(--site-radius-pill);
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.04em;

--- a/src/pages/what-is-cardano.js
+++ b/src/pages/what-is-cardano.js
@@ -261,7 +261,7 @@ function GetStartedSection() {
         headingDot={true}
       />
       <TitleWithText
-        description={translate({ id: "whatIsCardano.start.outro", message: "Prefer a guided walk-through? The getting started page takes you from download to first transaction." })}
+        description={translate({ id: "whatIsCardano.start.outro", message: "Prefer a guided walk-through? The getting started page takes you from download to first transaction, and the [learning path](/learn) continues from there." })}
         buttonLabel={translate({ id: "whatIsCardano.start.button", message: "Start step by step" })}
         buttonLink="/get-started"
       />


### PR DESCRIPTION
- Turns the placeholder `/learn` page into a five-stage learning path from beginner to advanced, with a quiz pointer per stage and an Academy call to action
- Links the learning path from the Learn menu, the footer, the what-is-cardano page and the glossary
- Keeps the dark call-to-action band flush with the footer