### PR TITLE
feat: add a how-cardano-works explainer page

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -6423,10 +6423,10 @@
     "message": "Tokens on Cardano are built into the ledger. Creating or transferring a token uses the same rules as ada, with no smart contract needed. Smart contracts are validator scripts that approve or reject a transaction someone has already built, written in languages such as Plutus and Aiken."
   },
   "whatIsCardano.how.outro": {
-    "message": "Want the full picture, from slot leaders to the energy footprint? Start with the consensus protocol."
+    "message": "Want the full picture, from slots to hard forks? Read how Cardano works step by step."
   },
   "whatIsCardano.how.button": {
-    "message": "Explore Ouroboros"
+    "message": "Read how Cardano works"
   },
   "whatIsCardano.divider.different": {
     "message": "Why Cardano"

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -6903,7 +6903,7 @@
     "message": "Why it is secure"
   },
   "howCardanoWorks.consensus.slots.text": {
-    "message": "Time is divided into slots of one second and epochs of 432,000 slots, five days. For every slot, each stake pool runs a private lottery whose odds match its share of the delegated stake. On average one pool in twenty slots wins, so a new block appears roughly every 20 seconds, and most slots pass without a block."
+    "message": "Time is divided into slots of one second and epochs of 432,000 slots, five days. For every slot, each stake pool runs a private lottery whose odds match its share of the delegated stake. On average only one slot in twenty has a winner, so a new block appears roughly every 20 seconds, and most slots pass without a block."
   },
   "howCardanoWorks.consensus.slots.title": {
     "message": "Slots and epochs"
@@ -7008,7 +7008,7 @@
     "message": "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in must cover the total out plus the fee. Your wallet balance is simply the sum of the notes you can unlock."
   },
   "howCardanoWorks.ledger.p2": {
-    "message": "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so two transactions cannot both spend the same note in the same block. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one."
+    "message": "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so if two transactions try to spend the same note, only one of them can succeed and the other is rejected. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one."
   },
   "howCardanoWorks.ledger.p3": {
     "message": "The extended part is what makes programs possible: an output can carry data and be locked by a script instead of a key, and the script decides whether a transaction may spend it."
@@ -7104,7 +7104,7 @@
     "message": "Every output also has to hold a minimum amount of ada, roughly one ada for a simple output, so that the ledger does not fill up with dust. That ada is not a fee: it stays in the output and comes back when the output is spent. Registering a stake key takes a refundable 2 ada deposit for the same reason."
   },
   "howCardanoWorks.transactions.p3": {
-    "message": "A transaction usually appears in a block within about 20 seconds. Wallets and exchanges then wait for more blocks on top before treating it as settled, typically a few minutes for everyday use and longer for large transfers."
+    "message": "A block is produced roughly every 20 seconds, so a transaction usually appears on the chain within a minute. Wallets and exchanges then wait for more blocks on top before treating it as settled, typically a few minutes for everyday use and longer for large transfers."
   },
   "howCardanoWorks.transactions.title": {
     "message": "What does a transaction cost, and how long does it take?"

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -6871,5 +6871,260 @@
   },
   "learn.level.ariaLabel": {
     "message": "Level: {label}"
+  },
+  "howCardanoWorks.blockchain.button": {
+    "message": "New to the idea? Start with what Cardano is"
+  },
+  "howCardanoWorks.blockchain.p1": {
+    "message": "A blockchain is a ledger that many computers keep in sync without a central operator. Transactions are collected into blocks, each block references the one before it, and every participant can check the whole history for themselves. Changing an old block would break every reference after it, which is what makes the record tamper-evident."
+  },
+  "howCardanoWorks.blockchain.p2": {
+    "message": "What differs between blockchains is how they decide who writes the next block, how they represent ownership, and how they change their own rules. The rest of this page walks through Cardano's answers to those three questions, and then through the things you can do on top: tokens, programs and running the network yourself."
+  },
+  "howCardanoWorks.blockchain.title": {
+    "message": "What is a blockchain?"
+  },
+  "howCardanoWorks.consensus.blocks.text": {
+    "message": "The winning pool bundles pending transactions into a block of up to about 88 KB, signs it and sends it to its peers, who verify every transaction before passing it on. Blocks are final in practice after a few more blocks have been built on top, and provably final after a longer window that the protocol's security proofs define."
+  },
+  "howCardanoWorks.consensus.blocks.title": {
+    "message": "Blocks"
+  },
+  "howCardanoWorks.consensus.button": {
+    "message": "Explore Ouroboros"
+  },
+  "howCardanoWorks.consensus.intro": {
+    "message": "Cardano uses Ouroboros, a proof-of-stake protocol. Instead of competing with computing power, participants are chosen to produce blocks in proportion to the ada delegated to them."
+  },
+  "howCardanoWorks.consensus.secure.text": {
+    "message": "Ouroboros was published and peer-reviewed before it was deployed, and its guarantees hold as long as honest participants control the majority of the stake. There is no slashing: a pool that misbehaves earns no rewards, but delegated ada is never at risk."
+  },
+  "howCardanoWorks.consensus.secure.title": {
+    "message": "Why it is secure"
+  },
+  "howCardanoWorks.consensus.slots.text": {
+    "message": "Time is divided into slots of one second and epochs of 432,000 slots, five days. For every slot, each stake pool runs a private lottery whose odds match its share of the delegated stake. On average one pool in twenty slots wins, so a new block appears roughly every 20 seconds, and most slots pass without a block."
+  },
+  "howCardanoWorks.consensus.slots.title": {
+    "message": "Slots and epochs"
+  },
+  "howCardanoWorks.consensus.title": {
+    "message": "How does Cardano reach agreement?"
+  },
+  "howCardanoWorks.contracts.button": {
+    "message": "Build on Cardano"
+  },
+  "howCardanoWorks.contracts.p1": {
+    "message": "A smart contract on Cardano is a validator: a script that guards outputs and answers one question for each transaction that tries to spend them, valid or not. The transaction itself is built by the user's wallet or the app, including every input, output and piece of data the script needs. The script cannot call other services or change its mind later, which keeps outcomes predictable."
+  },
+  "howCardanoWorks.contracts.p2": {
+    "message": "Scripts are written in languages such as Plutus and Aiken and compiled to Plutus Core, the language the node executes. Their execution is paid for with a separate budget of memory and steps that is priced in advance, so the cost is known before submission, exactly like the base fee. If a script fails on chain despite the wallet's own check, a small collateral covers the network's work, which is why wallets set aside a few ada for that purpose."
+  },
+  "howCardanoWorks.contracts.title": {
+    "message": "How do smart contracts run?"
+  },
+  "howCardanoWorks.cta.button": {
+    "message": "Take the quiz"
+  },
+  "howCardanoWorks.cta.title": {
+    "message": "Ready to test yourself? Take the technical quiz."
+  },
+  "howCardanoWorks.divider.blockchain": {
+    "message": "Basics"
+  },
+  "howCardanoWorks.divider.consensus": {
+    "message": "Consensus"
+  },
+  "howCardanoWorks.divider.contracts": {
+    "message": "Smart contracts"
+  },
+  "howCardanoWorks.divider.ledger": {
+    "message": "Ledger"
+  },
+  "howCardanoWorks.divider.network": {
+    "message": "Network"
+  },
+  "howCardanoWorks.divider.terminology": {
+    "message": "Terminology"
+  },
+  "howCardanoWorks.divider.tokens": {
+    "message": "Tokens"
+  },
+  "howCardanoWorks.divider.transactions": {
+    "message": "Transactions"
+  },
+  "howCardanoWorks.divider.upgrades": {
+    "message": "Upgrades"
+  },
+  "howCardanoWorks.faq.gas.a": {
+    "message": "Not in the auction sense. Fees are a fixed formula based on transaction size, and script execution has a separately priced budget, so the cost is known before you sign and does not rise with demand."
+  },
+  "howCardanoWorks.faq.gas.q": {
+    "message": "Does Cardano have gas?"
+  },
+  "howCardanoWorks.faq.haskell.a": {
+    "message": "The node and ledger are written in Haskell, a functional language that lets the code stay close to the formal specifications the protocol is based on. Applications on Cardano can be written in many languages, and the on-chain scripts in Plutus or Aiken."
+  },
+  "howCardanoWorks.faq.haskell.q": {
+    "message": "Why is Cardano written in Haskell?"
+  },
+  "howCardanoWorks.faq.pos.a": {
+    "message": "Yes. Blocks are produced by stake pools chosen in proportion to the ada delegated to them, through the Ouroboros protocol. Cardano has never used mining."
+  },
+  "howCardanoWorks.faq.pos.q": {
+    "message": "Is Cardano proof of stake?"
+  },
+  "howCardanoWorks.faq.slashing.a": {
+    "message": "No. Cardano has no slashing. Delegated ada stays in your wallet, and a badly run pool only costs you rewards."
+  },
+  "howCardanoWorks.faq.slashing.q": {
+    "message": "Can my ada be slashed?"
+  },
+  "howCardanoWorks.faq.slot.a": {
+    "message": "A slot is a one-second time unit. On average only one slot in twenty has a leader who produces a block, so blocks arrive about every 20 seconds."
+  },
+  "howCardanoWorks.faq.slot.q": {
+    "message": "What is the difference between a slot and a block?"
+  },
+  "howCardanoWorks.faq.speed.a": {
+    "message": "A block is produced roughly every 20 seconds, so a transaction normally appears on the chain within a minute. Services wait for several more blocks before treating it as final."
+  },
+  "howCardanoWorks.faq.speed.q": {
+    "message": "How long does a transaction take?"
+  },
+  "howCardanoWorks.hero.description": {
+    "message": "Blocks, ledger, tokens, programs and upgrades, explained step by step."
+  },
+  "howCardanoWorks.hero.title": {
+    "message": "How Cardano works"
+  },
+  "howCardanoWorks.intro.callout": {
+    "message": "Stake pools produce the blocks, a UTXO ledger records who owns what, tokens and smart contracts run on that ledger, and the whole system upgrades through hard forks that the community decides on."
+  },
+  "howCardanoWorks.ledger.button": {
+    "message": "The eUTXO model explained"
+  },
+  "howCardanoWorks.ledger.p1": {
+    "message": "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in must cover the total out plus the fee. Your wallet balance is simply the sum of the notes you can unlock."
+  },
+  "howCardanoWorks.ledger.p2": {
+    "message": "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so two transactions cannot both spend the same note in the same block. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one."
+  },
+  "howCardanoWorks.ledger.p3": {
+    "message": "The extended part is what makes programs possible: an output can carry data and be locked by a script instead of a key, and the script decides whether a transaction may spend it."
+  },
+  "howCardanoWorks.ledger.title": {
+    "message": "How does Cardano keep track of who owns what?"
+  },
+  "howCardanoWorks.meta.description": {
+    "message": "A plain-language tour of the Cardano blockchain: how blocks are produced, how the extended UTXO ledger tracks ownership, what transactions cost, how native tokens and smart contracts run, who operates the network and how it upgrades."
+  },
+  "howCardanoWorks.meta.title": {
+    "message": "How Cardano Works: Consensus, Ledger, Tokens and Upgrades Explained"
+  },
+  "howCardanoWorks.network.button": {
+    "message": "Delegate your ada"
+  },
+  "howCardanoWorks.network.p1": {
+    "message": "Anyone can run a Cardano node. Stake pools are nodes that produce blocks, operated by individuals, companies and communities. Delegating ada to a pool increases its chance of being chosen and earns you a share of its rewards, without moving your ada anywhere. Rewards are paid every epoch from newly released reserve ada and from transaction fees."
+  },
+  "howCardanoWorks.network.p2": {
+    "message": "The protocol rewards pools most when they stay below a saturation point, which discourages any single pool from growing too large, and pool operators pledge some of their own ada as a commitment. Around three thousand pools are registered, and roughly a thousand produce blocks in a given epoch."
+  },
+  "howCardanoWorks.network.p3": {
+    "message": "New nodes catch up with the chain either by replaying its full history or by starting from a signed snapshot produced by Mithril, a network of signers backed by the same stake distribution. Or [run a stake pool yourself](/stake-pool-operation)."
+  },
+  "howCardanoWorks.network.title": {
+    "message": "Who runs the network?"
+  },
+  "howCardanoWorks.terminology.button": {
+    "message": "Open the glossary"
+  },
+  "howCardanoWorks.terminology.intro": {
+    "message": "The words this page uses, each linked to its glossary entry."
+  },
+  "howCardanoWorks.terminology.item.collateral": {
+    "message": "[Collateral](/glossary/collateral): ada set aside in case a script fails on chain."
+  },
+  "howCardanoWorks.terminology.item.drep": {
+    "message": "[DRep](/glossary/drep): a delegated representative in governance."
+  },
+  "howCardanoWorks.terminology.item.epoch": {
+    "message": "[Epoch](/glossary/epoch): five days, 432,000 slots."
+  },
+  "howCardanoWorks.terminology.item.eutxo": {
+    "message": "[eUTXO](/glossary/eutxo): the extended model with data and scripts on outputs."
+  },
+  "howCardanoWorks.terminology.item.hardForkCombinator": {
+    "message": "[Hard fork combinator](/glossary/hard-fork-combinator): the mechanism that lets one node run every era."
+  },
+  "howCardanoWorks.terminology.item.mithril": {
+    "message": "[Mithril](/glossary/mithril): signed snapshots for fast node bootstrap."
+  },
+  "howCardanoWorks.terminology.item.nativeToken": {
+    "message": "[Native token](/glossary/native-token): an asset the ledger handles like ada."
+  },
+  "howCardanoWorks.terminology.item.plutusCore": {
+    "message": "[Plutus Core](/glossary/plutus-core): the on-chain script language."
+  },
+  "howCardanoWorks.terminology.item.slot": {
+    "message": "[Slot](/glossary/slot): one second, the unit of time."
+  },
+  "howCardanoWorks.terminology.item.slotLeader": {
+    "message": "[Slot leader](/glossary/slot-leader): the pool chosen to produce a block."
+  },
+  "howCardanoWorks.terminology.item.stakePool": {
+    "message": "[Stake pool](/glossary/stake-pool): a block-producing node with delegated stake."
+  },
+  "howCardanoWorks.terminology.item.utxo": {
+    "message": "[UTXO](/glossary/utxo): an unspent output, one note of value."
+  },
+  "howCardanoWorks.terminology.title": {
+    "message": "Terminology"
+  },
+  "howCardanoWorks.tokens.button": {
+    "message": "Native tokens in the docs"
+  },
+  "howCardanoWorks.tokens.p1": {
+    "message": "Tokens on Cardano are native: the ledger handles them with the same rules as ada, so no smart contract is needed to create, send or hold them. A token is defined by a minting policy, a small script or key that says who may create or destroy it. Once minted, tokens travel inside ordinary transaction outputs, alongside ada, and a single transaction can carry many different assets."
+  },
+  "howCardanoWorks.tokens.p2": {
+    "message": "An NFT is simply a token minted with a quantity of one under a policy that will not mint it again, plus metadata that describes it. Standards such as CIP-25 and CIP-68 define how wallets and marketplaces read that metadata."
+  },
+  "howCardanoWorks.tokens.title": {
+    "message": "How are tokens created?"
+  },
+  "howCardanoWorks.transactions.button": {
+    "message": "Fee structure in the docs"
+  },
+  "howCardanoWorks.transactions.p1": {
+    "message": "A fee is a formula, not an auction: a fixed part plus a per-byte part, both set by protocol parameters. On mainnet today that is 155,381 lovelace plus 44 lovelace per byte, so a typical transfer of a few hundred bytes costs around 0.17 ada. Fees do not rise when the network is busy, transactions simply wait a little longer."
+  },
+  "howCardanoWorks.transactions.p2": {
+    "message": "Every output also has to hold a minimum amount of ada, roughly one ada for a simple output, so that the ledger does not fill up with dust. That ada is not a fee: it stays in the output and comes back when the output is spent. Registering a stake key takes a refundable 2 ada deposit for the same reason."
+  },
+  "howCardanoWorks.transactions.p3": {
+    "message": "A transaction usually appears in a block within about 20 seconds. Wallets and exchanges then wait for more blocks on top before treating it as settled, typically a few minutes for everyday use and longer for large transfers."
+  },
+  "howCardanoWorks.transactions.title": {
+    "message": "What does a transaction cost, and how long does it take?"
+  },
+  "howCardanoWorks.upgrades.button": {
+    "message": "Every upgrade so far"
+  },
+  "howCardanoWorks.upgrades.p1": {
+    "message": "Cardano upgrades through hard forks, but without the chain splits the term usually implies. The hard fork combinator lets a single node understand every era of the protocol, so the switch from one set of rules to the next happens at an epoch boundary that everyone knows in advance. Each era added something: staking, native tokens, smart contracts, cheaper scripts, and on-chain governance."
+  },
+  "howCardanoWorks.upgrades.p2": {
+    "message": "Since 2025 an upgrade is itself a governance action: it is proposed on chain, voted on by delegated representatives, stake pool operators and the constitutional committee, and only then enacted. The same process changes protocol parameters such as fees and block size. See [how governance works](/governance)."
+  },
+  "howCardanoWorks.upgrades.title": {
+    "message": "How does Cardano change?"
+  },
+  "learn.item.howCardanoWorks.text": {
+    "message": "Consensus, ledger, tokens, programs and upgrades, step by step."
+  },
+  "learn.item.howCardanoWorks.title": {
+    "message": "How Cardano works"
   }
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -6351,7 +6351,7 @@
     "message": "Not sure what Cardano is yet? [Start with the overview](/what-is-cardano)."
   },
   "ouroboros.vision.backLink": {
-    "message": "Back to the big picture: [What is Cardano?](/what-is-cardano)"
+    "message": "Back to the big picture: [What is Cardano?](/what-is-cardano), or see [how Cardano works](/how-cardano-works) end to end."
   },
   "whatIsAda.section.platformLink": {
     "message": "New to the platform itself? Read [what Cardano is](/what-is-cardano)."
@@ -6885,7 +6885,7 @@
     "message": "What is a blockchain?"
   },
   "howCardanoWorks.consensus.blocks.text": {
-    "message": "The winning pool bundles pending transactions into a block of up to about 88 KB, signs it and sends it to its peers, who verify every transaction before passing it on. Blocks are final in practice after a few more blocks have been built on top, and provably final after a longer window that the protocol's security proofs define."
+    "message": "The winning pool bundles pending transactions into a block of up to about 88 KB, signs it and sends it to its peers, who verify every transaction before passing it on. Blocks are final in practice after a few more blocks have been built on top, and irreversible in the protocol's own terms after a longer window that its security parameters define."
   },
   "howCardanoWorks.consensus.blocks.title": {
     "message": "Blocks"
@@ -6963,16 +6963,16 @@
     "message": "Does Cardano have gas?"
   },
   "howCardanoWorks.faq.haskell.a": {
-    "message": "The node and ledger are written in Haskell, a functional language that lets the code stay close to the formal specifications the protocol is based on. Applications on Cardano can be written in many languages, and the on-chain scripts in Plutus or Aiken."
+    "message": "Cardano's reference node and its ledger rules are written in Haskell, a functional language that lets the code stay close to the formal specifications the protocol is based on. Applications on Cardano can be written in many languages, and the on-chain scripts in Plutus or Aiken."
   },
   "howCardanoWorks.faq.haskell.q": {
     "message": "Why is Cardano written in Haskell?"
   },
   "howCardanoWorks.faq.pos.a": {
-    "message": "Yes. Blocks are produced by stake pools chosen in proportion to the ada delegated to them, through the Ouroboros protocol. Cardano has never used mining."
+    "message": "Through Ouroboros, its proof-of-stake protocol. Blocks are produced by stake pools chosen in proportion to the ada delegated to them. Cardano has never used mining."
   },
   "howCardanoWorks.faq.pos.q": {
-    "message": "Is Cardano proof of stake?"
+    "message": "How does Cardano choose who produces the next block?"
   },
   "howCardanoWorks.faq.slashing.a": {
     "message": "No. Cardano has no slashing. Delegated ada stays in your wallet, and a badly run pool only costs you rewards."
@@ -6990,7 +6990,7 @@
     "message": "A block is produced roughly every 20 seconds, so a transaction normally appears on the chain within a minute. Services wait for several more blocks before treating it as final."
   },
   "howCardanoWorks.faq.speed.q": {
-    "message": "How long does a transaction take?"
+    "message": "How many confirmations does a Cardano transaction need?"
   },
   "howCardanoWorks.hero.description": {
     "message": "Blocks, ledger, tokens, programs and upgrades, explained step by step."
@@ -7005,7 +7005,7 @@
     "message": "The eUTXO model explained"
   },
   "howCardanoWorks.ledger.p1": {
-    "message": "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in must cover the total out plus the fee. Your wallet balance is simply the sum of the notes you can unlock."
+    "message": "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in has to equal the total out plus the fee, with any remainder coming back to you as change. Your wallet balance is simply the sum of the notes you can unlock."
   },
   "howCardanoWorks.ledger.p2": {
     "message": "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so if two transactions try to spend the same note, only one of them can succeed and the other is rejected. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one."
@@ -7017,10 +7017,10 @@
     "message": "How does Cardano keep track of who owns what?"
   },
   "howCardanoWorks.meta.description": {
-    "message": "A plain-language tour of the Cardano blockchain: how blocks are produced, how the extended UTXO ledger tracks ownership, what transactions cost, how native tokens and smart contracts run, who operates the network and how it upgrades."
+    "message": "How Cardano works, in plain language: block production, the eUTXO ledger, transaction costs, native tokens, smart contracts and protocol upgrades."
   },
   "howCardanoWorks.meta.title": {
-    "message": "How Cardano Works: Consensus, Ledger, Tokens and Upgrades Explained"
+    "message": "How Cardano Works: Consensus, Ledger and Upgrades"
   },
   "howCardanoWorks.network.button": {
     "message": "Delegate your ada"
@@ -7029,10 +7029,10 @@
     "message": "Anyone can run a Cardano node. Stake pools are nodes that produce blocks, operated by individuals, companies and communities. Delegating ada to a pool increases its chance of being chosen and earns you a share of its rewards, without moving your ada anywhere. Rewards are paid every epoch from newly released reserve ada and from transaction fees."
   },
   "howCardanoWorks.network.p2": {
-    "message": "The protocol rewards pools most when they stay below a saturation point, which discourages any single pool from growing too large, and pool operators pledge some of their own ada as a commitment. Around three thousand pools are registered, and roughly a thousand produce blocks in a given epoch."
+    "message": "The protocol rewards pools most when they stay below a saturation point, which discourages any single pool from growing too large, and pool operators pledge some of their own ada as a commitment. Close to three thousand pools are registered, and roughly a thousand produce blocks in a given epoch."
   },
   "howCardanoWorks.network.p3": {
-    "message": "New nodes catch up with the chain either by replaying its full history or by starting from a signed snapshot produced by Mithril, a network of signers backed by the same stake distribution. Or [run a stake pool yourself](/stake-pool-operation)."
+    "message": "New nodes catch up with the chain either by replaying its full history or by starting from a signed snapshot produced by Mithril, a network of signers backed by the same stake distribution. If you would rather help produce blocks than delegate, you can [run a stake pool yourself](/stake-pool-operation)."
   },
   "howCardanoWorks.network.title": {
     "message": "Who runs the network?"
@@ -7080,7 +7080,7 @@
     "message": "[UTXO](/glossary/utxo): an unspent output, one note of value."
   },
   "howCardanoWorks.terminology.title": {
-    "message": "Terminology"
+    "message": "What do these words mean?"
   },
   "howCardanoWorks.tokens.button": {
     "message": "Native tokens in the docs"

--- a/src/data/howCardanoWorksFAQ.js
+++ b/src/data/howCardanoWorksFAQ.js
@@ -5,17 +5,17 @@ import { translate } from "@docusaurus/Translate";
 export function getHowCardanoWorksFAQ() {
   return [
     {
-      question: translate({ id: "howCardanoWorks.faq.pos.q", message: "Is Cardano proof of stake?" }),
+      question: translate({ id: "howCardanoWorks.faq.pos.q", message: "How does Cardano choose who produces the next block?" }),
       answer: [
         translate({
           id: "howCardanoWorks.faq.pos.a",
           message:
-            "Yes. Blocks are produced by stake pools chosen in proportion to the ada delegated to them, through the Ouroboros protocol. Cardano has never used mining.",
+            "Through Ouroboros, its proof-of-stake protocol. Blocks are produced by stake pools chosen in proportion to the ada delegated to them. Cardano has never used mining.",
         }),
       ],
     },
     {
-      question: translate({ id: "howCardanoWorks.faq.speed.q", message: "How long does a transaction take?" }),
+      question: translate({ id: "howCardanoWorks.faq.speed.q", message: "How many confirmations does a Cardano transaction need?" }),
       answer: [
         translate({
           id: "howCardanoWorks.faq.speed.a",
@@ -60,7 +60,7 @@ export function getHowCardanoWorksFAQ() {
         translate({
           id: "howCardanoWorks.faq.haskell.a",
           message:
-            "The node and ledger are written in Haskell, a functional language that lets the code stay close to the formal specifications the protocol is based on. Applications on Cardano can be written in many languages, and the on-chain scripts in Plutus or Aiken.",
+            "Cardano's reference node and its ledger rules are written in Haskell, a functional language that lets the code stay close to the formal specifications the protocol is based on. Applications on Cardano can be written in many languages, and the on-chain scripts in Plutus or Aiken.",
         }),
       ],
     },

--- a/src/data/howCardanoWorksFAQ.js
+++ b/src/data/howCardanoWorksFAQ.js
@@ -1,0 +1,68 @@
+import { translate } from "@docusaurus/Translate";
+
+// Same shape as the JSON FAQ files, but as literal translate() calls so the
+// strings reach Crowdin. FAQSection renders it through its data prop.
+export function getHowCardanoWorksFAQ() {
+  return [
+    {
+      question: translate({ id: "howCardanoWorks.faq.pos.q", message: "Is Cardano proof of stake?" }),
+      answer: [
+        translate({
+          id: "howCardanoWorks.faq.pos.a",
+          message:
+            "Yes. Blocks are produced by stake pools chosen in proportion to the ada delegated to them, through the Ouroboros protocol. Cardano has never used mining.",
+        }),
+      ],
+    },
+    {
+      question: translate({ id: "howCardanoWorks.faq.speed.q", message: "How long does a transaction take?" }),
+      answer: [
+        translate({
+          id: "howCardanoWorks.faq.speed.a",
+          message:
+            "A block is produced roughly every 20 seconds, so a transaction normally appears on the chain within a minute. Services wait for several more blocks before treating it as final.",
+        }),
+      ],
+    },
+    {
+      question: translate({ id: "howCardanoWorks.faq.slashing.q", message: "Can my ada be slashed?" }),
+      answer: [
+        translate({
+          id: "howCardanoWorks.faq.slashing.a",
+          message:
+            "No. Cardano has no slashing. Delegated ada stays in your wallet, and a badly run pool only costs you rewards.",
+        }),
+      ],
+    },
+    {
+      question: translate({ id: "howCardanoWorks.faq.gas.q", message: "Does Cardano have gas?" }),
+      answer: [
+        translate({
+          id: "howCardanoWorks.faq.gas.a",
+          message:
+            "Not in the auction sense. Fees are a fixed formula based on transaction size, and script execution has a separately priced budget, so the cost is known before you sign and does not rise with demand.",
+        }),
+      ],
+    },
+    {
+      question: translate({ id: "howCardanoWorks.faq.slot.q", message: "What is the difference between a slot and a block?" }),
+      answer: [
+        translate({
+          id: "howCardanoWorks.faq.slot.a",
+          message:
+            "A slot is a one-second time unit. On average only one slot in twenty has a leader who produces a block, so blocks arrive about every 20 seconds.",
+        }),
+      ],
+    },
+    {
+      question: translate({ id: "howCardanoWorks.faq.haskell.q", message: "Why is Cardano written in Haskell?" }),
+      answer: [
+        translate({
+          id: "howCardanoWorks.faq.haskell.a",
+          message:
+            "The node and ledger are written in Haskell, a functional language that lets the code stay close to the formal specifications the protocol is based on. Applications on Cardano can be written in many languages, and the on-chain scripts in Plutus or Aiken.",
+        }),
+      ],
+    },
+  ];
+}

--- a/src/data/learningPath.js
+++ b/src/data/learningPath.js
@@ -3,7 +3,7 @@ import { academyUrl } from "@site/src/data/quiz/academy";
 import {
   FaInfoCircle, FaCoins, FaWallet, FaPlay,
   FaSearch, FaShoppingCart, FaShieldAlt, FaHandshake, FaLayerGroup, FaThLarge,
-  FaCog, FaCogs, FaBalanceScale, FaCodeBranch, FaBook,
+  FaCog, FaProjectDiagram, FaBalanceScale, FaCodeBranch, FaBook,
   FaVoteYea, FaUsers, FaPiggyBank, FaScroll, FaServer, FaCalculator,
   FaFlask, FaChartLine, FaHistory, FaBuilding, FaGraduationCap, FaCode,
 } from "react-icons/fa";
@@ -56,7 +56,7 @@ export function getLearningPath() {
       intro: translate({ id: "learn.stage.technology.intro", message: "How the network reaches agreement, how it scales and how it changes over time." }),
       quiz: translate({ id: "learn.stage.technology.quiz", message: "Check what you learned with the [technical quiz](/quiz)." }),
       items: [
-        { key: "how-cardano-works", href: "/how-cardano-works", icon: <FaCogs />, title: translate({ id: "learn.item.howCardanoWorks.title", message: "How Cardano works" }), text: translate({ id: "learn.item.howCardanoWorks.text", message: "Consensus, ledger, tokens, programs and upgrades, step by step." }) },
+        { key: "how-cardano-works", href: "/how-cardano-works", icon: <FaProjectDiagram />, title: translate({ id: "learn.item.howCardanoWorks.title", message: "How Cardano works" }), text: translate({ id: "learn.item.howCardanoWorks.text", message: "Consensus, ledger, tokens, programs and upgrades, step by step." }) },
         { key: "ouroboros", href: "/ouroboros", icon: <FaCog />, title: translate({ id: "learn.item.ouroboros.title", message: "Ouroboros" }), text: translate({ id: "learn.item.ouroboros.text", message: "The proof-of-stake protocol behind every block." }) },
         { key: "stablecoins", href: "/stablecoins", icon: <FaBalanceScale />, title: translate({ id: "learn.item.stablecoins.title", message: "Stablecoins" }), text: translate({ id: "learn.item.stablecoins.text", message: "Stable value on Cardano: how the main stablecoins work and where to use them." }) },
         { key: "layer-2", href: "/layer-2", icon: <FaLayerGroup />, title: translate({ id: "learn.item.layer2.title", message: "Layer 2" }), text: translate({ id: "learn.item.layer2.text", message: "Hydra, Midnight and the other networks that extend Cardano." }) },

--- a/src/data/learningPath.js
+++ b/src/data/learningPath.js
@@ -3,7 +3,7 @@ import { academyUrl } from "@site/src/data/quiz/academy";
 import {
   FaInfoCircle, FaCoins, FaWallet, FaPlay,
   FaSearch, FaShoppingCart, FaShieldAlt, FaHandshake, FaLayerGroup, FaThLarge,
-  FaCog, FaBalanceScale, FaCodeBranch, FaBook,
+  FaCog, FaCogs, FaBalanceScale, FaCodeBranch, FaBook,
   FaVoteYea, FaUsers, FaPiggyBank, FaScroll, FaServer, FaCalculator,
   FaFlask, FaChartLine, FaHistory, FaBuilding, FaGraduationCap, FaCode,
 } from "react-icons/fa";
@@ -56,6 +56,7 @@ export function getLearningPath() {
       intro: translate({ id: "learn.stage.technology.intro", message: "How the network reaches agreement, how it scales and how it changes over time." }),
       quiz: translate({ id: "learn.stage.technology.quiz", message: "Check what you learned with the [technical quiz](/quiz)." }),
       items: [
+        { key: "how-cardano-works", href: "/how-cardano-works", icon: <FaCogs />, title: translate({ id: "learn.item.howCardanoWorks.title", message: "How Cardano works" }), text: translate({ id: "learn.item.howCardanoWorks.text", message: "Consensus, ledger, tokens, programs and upgrades, step by step." }) },
         { key: "ouroboros", href: "/ouroboros", icon: <FaCog />, title: translate({ id: "learn.item.ouroboros.title", message: "Ouroboros" }), text: translate({ id: "learn.item.ouroboros.text", message: "The proof-of-stake protocol behind every block." }) },
         { key: "stablecoins", href: "/stablecoins", icon: <FaBalanceScale />, title: translate({ id: "learn.item.stablecoins.title", message: "Stablecoins" }), text: translate({ id: "learn.item.stablecoins.text", message: "Stable value on Cardano: how the main stablecoins work and where to use them." }) },
         { key: "layer-2", href: "/layer-2", icon: <FaLayerGroup />, title: translate({ id: "learn.item.layer2.title", message: "Layer 2" }), text: translate({ id: "learn.item.layer2.text", message: "Hydra, Midnight and the other networks that extend Cardano." }) },

--- a/src/data/navbar.js
+++ b/src/data/navbar.js
@@ -65,6 +65,7 @@ function getNavbarItems() {
         {
           title: 'Go deeper',
           items: [
+            {to: '/how-cardano-works', label: 'How Cardano works', description: 'Consensus, ledger, tokens and upgrades in plain terms'},
             {href: 'https://academy.cardanofoundation.org/', label: 'Cardano Academy', description: 'Free, self-paced blockchain courses'},
             {to: '/research', label: 'Cardano Research', description: 'Peer-reviewed research and papers'},
             {href: '/insights', label: 'Cardano Insights', description: 'On-chain or regularly refreshed data'},

--- a/src/pages/how-cardano-works.js
+++ b/src/pages/how-cardano-works.js
@@ -98,7 +98,7 @@ function ConsensusSection() {
           translate({
             id: "howCardanoWorks.consensus.blocks.text",
             message:
-              "The winning pool bundles pending transactions into a block of up to about 88 KB, signs it and sends it to its peers, who verify every transaction before passing it on. Blocks are final in practice after a few more blocks have been built on top, and provably final after a longer window that the protocol's security proofs define.",
+              "The winning pool bundles pending transactions into a block of up to about 88 KB, signs it and sends it to its peers, who verify every transaction before passing it on. Blocks are final in practice after a few more blocks have been built on top, and irreversible in the protocol's own terms after a longer window that its security parameters define.",
           }),
         ]}
         headingDot={true}
@@ -139,7 +139,7 @@ function LedgerSection() {
           translate({
             id: "howCardanoWorks.ledger.p1",
             message:
-              "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in must cover the total out plus the fee. Your wallet balance is simply the sum of the notes you can unlock.",
+              "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in has to equal the total out plus the fee, with any remainder coming back to you as change. Your wallet balance is simply the sum of the notes you can unlock.",
           }),
           translate({
             id: "howCardanoWorks.ledger.p2",
@@ -273,12 +273,12 @@ function NetworkSection() {
           translate({
             id: "howCardanoWorks.network.p2",
             message:
-              "The protocol rewards pools most when they stay below a saturation point, which discourages any single pool from growing too large, and pool operators pledge some of their own ada as a commitment. Around three thousand pools are registered, and roughly a thousand produce blocks in a given epoch.",
+              "The protocol rewards pools most when they stay below a saturation point, which discourages any single pool from growing too large, and pool operators pledge some of their own ada as a commitment. Close to three thousand pools are registered, and roughly a thousand produce blocks in a given epoch.",
           }),
           translate({
             id: "howCardanoWorks.network.p3",
             message:
-              "New nodes catch up with the chain either by replaying its full history or by starting from a signed snapshot produced by Mithril, a network of signers backed by the same stake distribution. Or [run a stake pool yourself](/stake-pool-operation).",
+              "New nodes catch up with the chain either by replaying its full history or by starting from a signed snapshot produced by Mithril, a network of signers backed by the same stake distribution. If you would rather help produce blocks than delegate, you can [run a stake pool yourself](/stake-pool-operation).",
           }),
         ]}
         headingDot={true}
@@ -326,7 +326,7 @@ function TerminologySection() {
         text={translate({ id: "howCardanoWorks.divider.terminology", message: "Terminology" })}
       />
       <TitleWithText
-        title={translate({ id: "howCardanoWorks.terminology.title", message: "Terminology" })}
+        title={translate({ id: "howCardanoWorks.terminology.title", message: "What do these words mean?" })}
         description={[
           translate({
             id: "howCardanoWorks.terminology.intro",
@@ -400,12 +400,12 @@ export default function HowCardanoWorks() {
     <Layout
       title={translate({
         id: "howCardanoWorks.meta.title",
-        message: "How Cardano Works: Consensus, Ledger, Tokens and Upgrades Explained",
+        message: "How Cardano Works: Consensus, Ledger and Upgrades",
       })}
       description={translate({
         id: "howCardanoWorks.meta.description",
         message:
-          "A plain-language tour of the Cardano blockchain: how blocks are produced, how the extended UTXO ledger tracks ownership, what transactions cost, how native tokens and smart contracts run, who operates the network and how it upgrades.",
+          "How Cardano works, in plain language: block production, the eUTXO ledger, transaction costs, native tokens, smart contracts and protocol upgrades.",
       })}
     >
       <Head>

--- a/src/pages/how-cardano-works.js
+++ b/src/pages/how-cardano-works.js
@@ -86,7 +86,7 @@ function ConsensusSection() {
           translate({
             id: "howCardanoWorks.consensus.slots.text",
             message:
-              "Time is divided into slots of one second and epochs of 432,000 slots, five days. For every slot, each stake pool runs a private lottery whose odds match its share of the delegated stake. On average one pool in twenty slots wins, so a new block appears roughly every 20 seconds, and most slots pass without a block.",
+              "Time is divided into slots of one second and epochs of 432,000 slots, five days. For every slot, each stake pool runs a private lottery whose odds match its share of the delegated stake. On average only one slot in twenty has a winner, so a new block appears roughly every 20 seconds, and most slots pass without a block.",
           }),
         ]}
         headingDot={true}
@@ -144,7 +144,7 @@ function LedgerSection() {
           translate({
             id: "howCardanoWorks.ledger.p2",
             message:
-              "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so two transactions cannot both spend the same note in the same block. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one.",
+              "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so if two transactions try to spend the same note, only one of them can succeed and the other is rejected. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one.",
           }),
           translate({
             id: "howCardanoWorks.ledger.p3",
@@ -186,7 +186,7 @@ function TransactionsSection() {
           translate({
             id: "howCardanoWorks.transactions.p3",
             message:
-              "A transaction usually appears in a block within about 20 seconds. Wallets and exchanges then wait for more blocks on top before treating it as settled, typically a few minutes for everyday use and longer for large transfers.",
+              "A block is produced roughly every 20 seconds, so a transaction usually appears on the chain within a minute. Wallets and exchanges then wait for more blocks on top before treating it as settled, typically a few minutes for everyday use and longer for large transfers.",
           }),
         ]}
         headingDot={true}

--- a/src/pages/how-cardano-works.js
+++ b/src/pages/how-cardano-works.js
@@ -16,7 +16,6 @@ import FAQSection from "@site/src/components/FAQSection";
 import CtaOneColumn from "@site/src/components/Layout/CtaOneColumn";
 import { jsonLdString } from "@site/src/utils/jsonLd";
 import { getHowCardanoWorksFAQ } from "@site/src/data/howCardanoWorksFAQ";
-import styles from "./how-cardano-works.module.css";
 
 function HomepageHeader() {
   return (

--- a/src/pages/how-cardano-works.js
+++ b/src/pages/how-cardano-works.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Layout from "@theme/Layout";
+import Head from "@docusaurus/Head";
 import { translate } from "@docusaurus/Translate";
 import { FaCogs } from "react-icons/fa";
 import SiteHero from "@site/src/components/Layout/SiteHero";
@@ -11,6 +12,10 @@ import TitleWithText from "@site/src/components/Layout/TitleWithText";
 import HighlightCallout from "@site/src/components/Layout/HighlightCallout";
 import DottedImageWithText from "@site/src/components/Layout/DottedImageWithText";
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
+import FAQSection from "@site/src/components/FAQSection";
+import CtaOneColumn from "@site/src/components/Layout/CtaOneColumn";
+import { jsonLdString } from "@site/src/utils/jsonLd";
+import { getHowCardanoWorksFAQ } from "@site/src/data/howCardanoWorksFAQ";
 import styles from "./how-cardano-works.module.css";
 
 function HomepageHeader() {
@@ -391,6 +396,7 @@ function TerminologySection() {
 }
 
 export default function HowCardanoWorks() {
+  const faq = getHowCardanoWorksFAQ();
   return (
     <Layout
       title={translate({
@@ -403,6 +409,20 @@ export default function HowCardanoWorks() {
           "A plain-language tour of the Cardano blockchain: how blocks are produced, how the extended UTXO ledger tracks ownership, what transactions cost, how native tokens and smart contracts run, who operates the network and how it upgrades.",
       })}
     >
+      <Head>
+        <script type="application/ld+json">
+          {jsonLdString({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            "mainEntity": faq.map((item) => ({
+              "@type": "Question",
+              "name": item.question,
+              // Structured data must be plain text, so strip markdown links before joining.
+              "acceptedAnswer": { "@type": "Answer", "text": item.answer.join(" ").replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") },
+            })),
+          })}
+        </script>
+      </Head>
       <OpenGraphInfo />
       <HomepageHeader />
       <main>
@@ -425,6 +445,18 @@ export default function HowCardanoWorks() {
             <NetworkSection />
             <UpgradesSection />
             <TerminologySection />
+            <FAQSection data={faq} />
+            <SpacerBox size="medium" />
+          </BoundaryBox>
+        </BackgroundWrapper>
+        <BackgroundWrapper backgroundType="gradientDark">
+          <BoundaryBox>
+            <CtaOneColumn
+              title={translate({ id: "howCardanoWorks.cta.title", message: "Ready to test yourself? Take the technical quiz." })}
+              buttonLabel={translate({ id: "howCardanoWorks.cta.button", message: "Take the quiz" })}
+              buttonLink="/quiz"
+            />
+            <SpacerBox size="small" />
           </BoundaryBox>
         </BackgroundWrapper>
       </main>

--- a/src/pages/how-cardano-works.js
+++ b/src/pages/how-cardano-works.js
@@ -14,7 +14,7 @@ import DottedImageWithText from "@site/src/components/Layout/DottedImageWithText
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
 import FAQSection from "@site/src/components/FAQSection";
 import CtaOneColumn from "@site/src/components/Layout/CtaOneColumn";
-import { jsonLdString } from "@site/src/utils/jsonLd";
+import { faqJsonLd } from "@site/src/utils/jsonLd";
 import { getHowCardanoWorksFAQ } from "@site/src/data/howCardanoWorksFAQ";
 
 function HomepageHeader() {
@@ -409,18 +409,7 @@ export default function HowCardanoWorks() {
       })}
     >
       <Head>
-        <script type="application/ld+json">
-          {jsonLdString({
-            "@context": "https://schema.org",
-            "@type": "FAQPage",
-            "mainEntity": faq.map((item) => ({
-              "@type": "Question",
-              "name": item.question,
-              // Structured data must be plain text, so strip markdown links before joining.
-              "acceptedAnswer": { "@type": "Answer", "text": item.answer.join(" ").replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") },
-            })),
-          })}
-        </script>
+        <script type="application/ld+json">{faqJsonLd(faq)}</script>
       </Head>
       <OpenGraphInfo />
       <HomepageHeader />

--- a/src/pages/how-cardano-works.js
+++ b/src/pages/how-cardano-works.js
@@ -1,0 +1,231 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import { translate } from "@docusaurus/Translate";
+import { FaCogs } from "react-icons/fa";
+import SiteHero from "@site/src/components/Layout/SiteHero";
+import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
+import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
+import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
+import Divider from "@site/src/components/Layout/Divider";
+import TitleWithText from "@site/src/components/Layout/TitleWithText";
+import HighlightCallout from "@site/src/components/Layout/HighlightCallout";
+import DottedImageWithText from "@site/src/components/Layout/DottedImageWithText";
+import SpacerBox from "@site/src/components/Layout/SpacerBox";
+import styles from "./how-cardano-works.module.css";
+
+function HomepageHeader() {
+  return (
+    <SiteHero
+      title={translate({ id: "howCardanoWorks.hero.title", message: "How Cardano works" })}
+      description={translate({
+        id: "howCardanoWorks.hero.description",
+        message: "Blocks, ledger, tokens, programs and upgrades, explained step by step.",
+      })}
+      bannerType="waves"
+    />
+  );
+}
+
+function BlockchainSection() {
+  return (
+    <>
+      <Divider
+        id="blockchain"
+        text={translate({ id: "howCardanoWorks.divider.blockchain", message: "Basics" })}
+      />
+      <TitleWithText
+        title={translate({ id: "howCardanoWorks.blockchain.title", message: "What is a blockchain?" })}
+        description={translate({
+          id: "howCardanoWorks.blockchain.p1",
+          message:
+            "A blockchain is a ledger that many computers keep in sync without a central operator. Transactions are collected into blocks, each block references the one before it, and every participant can check the whole history for themselves. Changing an old block would break every reference after it, which is what makes the record tamper-evident.",
+        })}
+        headingDot={true}
+      />
+      <SpacerBox size="small" />
+      <TitleWithText
+        description={translate({
+          id: "howCardanoWorks.blockchain.p2",
+          message:
+            "What differs between blockchains is how they decide who writes the next block, how they represent ownership, and how they change their own rules. The rest of this page walks through Cardano's answers to those three questions, and then through the things you can do on top: tokens, programs and running the network yourself.",
+        })}
+        buttonLabel={translate({
+          id: "howCardanoWorks.blockchain.button",
+          message: "New to the idea? Start with what Cardano is",
+        })}
+        buttonLink="/what-is-cardano"
+      />
+    </>
+  );
+}
+
+function ConsensusSection() {
+  return (
+    <>
+      <Divider
+        id="consensus"
+        text={translate({ id: "howCardanoWorks.divider.consensus", message: "Consensus" })}
+      />
+      <TitleWithText
+        title={translate({ id: "howCardanoWorks.consensus.title", message: "How does Cardano reach agreement?" })}
+        description={translate({
+          id: "howCardanoWorks.consensus.intro",
+          message:
+            "Cardano uses Ouroboros, a proof-of-stake protocol. Instead of competing with computing power, participants are chosen to produce blocks in proportion to the ada delegated to them.",
+        })}
+        headingDot={true}
+      />
+      <DottedImageWithText
+        imageName="dots-with-line"
+        title={translate({ id: "howCardanoWorks.consensus.slots.title", message: "Slots and epochs" })}
+        text={[
+          translate({
+            id: "howCardanoWorks.consensus.slots.text",
+            message:
+              "Time is divided into slots of one second and epochs of 432,000 slots, five days. For every slot, each stake pool runs a private lottery whose odds match its share of the delegated stake. On average one pool in twenty slots wins, so a new block appears roughly every 20 seconds, and most slots pass without a block.",
+          }),
+        ]}
+        headingDot={true}
+      />
+      <DottedImageWithText
+        imageName="chains"
+        title={translate({ id: "howCardanoWorks.consensus.blocks.title", message: "Blocks" })}
+        text={[
+          translate({
+            id: "howCardanoWorks.consensus.blocks.text",
+            message:
+              "The winning pool bundles pending transactions into a block of up to about 88 KB, signs it and sends it to its peers, who verify every transaction before passing it on. Blocks are final in practice after a few more blocks have been built on top, and provably final after a longer window that the protocol's security proofs define.",
+          }),
+        ]}
+        headingDot={true}
+      />
+      <DottedImageWithText
+        imageName="proof-of-stake"
+        title={translate({ id: "howCardanoWorks.consensus.secure.title", message: "Why it is secure" })}
+        text={[
+          translate({
+            id: "howCardanoWorks.consensus.secure.text",
+            message:
+              "Ouroboros was published and peer-reviewed before it was deployed, and its guarantees hold as long as honest participants control the majority of the stake. There is no slashing: a pool that misbehaves earns no rewards, but delegated ada is never at risk.",
+          }),
+        ]}
+        headingDot={true}
+      />
+      <TitleWithText
+        buttonLabel={translate({ id: "howCardanoWorks.consensus.button", message: "Explore Ouroboros" })}
+        buttonLink="/ouroboros"
+      />
+    </>
+  );
+}
+
+function LedgerSection() {
+  return (
+    <>
+      <Divider
+        id="ledger"
+        text={translate({ id: "howCardanoWorks.divider.ledger", message: "Ledger" })}
+      />
+      <TitleWithText
+        title={translate({
+          id: "howCardanoWorks.ledger.title",
+          message: "How does Cardano keep track of who owns what?",
+        })}
+        description={[
+          translate({
+            id: "howCardanoWorks.ledger.p1",
+            message:
+              "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in must cover the total out plus the fee. Your wallet balance is simply the sum of the notes you can unlock.",
+          }),
+          translate({
+            id: "howCardanoWorks.ledger.p2",
+            message:
+              "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so two transactions cannot both spend the same note in the same block. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one.",
+          }),
+          translate({
+            id: "howCardanoWorks.ledger.p3",
+            message:
+              "The extended part is what makes programs possible: an output can carry data and be locked by a script instead of a key, and the script decides whether a transaction may spend it.",
+          }),
+        ]}
+        headingDot={true}
+        buttonLabel={translate({ id: "howCardanoWorks.ledger.button", message: "The eUTXO model explained" })}
+        buttonLink="https://docs.cardano.org/about-cardano/learn/eutxo-explainer"
+      />
+    </>
+  );
+}
+
+function TransactionsSection() {
+  return (
+    <>
+      <Divider
+        id="transactions"
+        text={translate({ id: "howCardanoWorks.divider.transactions", message: "Transactions" })}
+      />
+      <TitleWithText
+        title={translate({
+          id: "howCardanoWorks.transactions.title",
+          message: "What does a transaction cost, and how long does it take?",
+        })}
+        description={[
+          translate({
+            id: "howCardanoWorks.transactions.p1",
+            message:
+              "A fee is a formula, not an auction: a fixed part plus a per-byte part, both set by protocol parameters. On mainnet today that is 155,381 lovelace plus 44 lovelace per byte, so a typical transfer of a few hundred bytes costs around 0.17 ada. Fees do not rise when the network is busy, transactions simply wait a little longer.",
+          }),
+          translate({
+            id: "howCardanoWorks.transactions.p2",
+            message:
+              "Every output also has to hold a minimum amount of ada, roughly one ada for a simple output, so that the ledger does not fill up with dust. That ada is not a fee: it stays in the output and comes back when the output is spent. Registering a stake key takes a refundable 2 ada deposit for the same reason.",
+          }),
+          translate({
+            id: "howCardanoWorks.transactions.p3",
+            message:
+              "A transaction usually appears in a block within about 20 seconds. Wallets and exchanges then wait for more blocks on top before treating it as settled, typically a few minutes for everyday use and longer for large transfers.",
+          }),
+        ]}
+        headingDot={true}
+        buttonLabel={translate({ id: "howCardanoWorks.transactions.button", message: "Fee structure in the docs" })}
+        buttonLink="https://docs.cardano.org/about-cardano/explore-more/fee-structure"
+      />
+    </>
+  );
+}
+
+export default function HowCardanoWorks() {
+  return (
+    <Layout
+      title={translate({
+        id: "howCardanoWorks.meta.title",
+        message: "How Cardano Works: Consensus, Ledger, Tokens and Upgrades Explained",
+      })}
+      description={translate({
+        id: "howCardanoWorks.meta.description",
+        message:
+          "A plain-language tour of the Cardano blockchain: how blocks are produced, how the extended UTXO ledger tracks ownership, what transactions cost, how native tokens and smart contracts run, who operates the network and how it upgrades.",
+      })}
+    >
+      <OpenGraphInfo />
+      <HomepageHeader />
+      <main>
+        <BackgroundWrapper backgroundType="zoom">
+          <BoundaryBox>
+            <HighlightCallout icon={<FaCogs />}>
+              {translate({
+                id: "howCardanoWorks.intro.callout",
+                message:
+                  "Stake pools produce the blocks, a UTXO ledger records who owns what, tokens and smart contracts run on that ledger, and the whole system upgrades through hard forks that the community decides on.",
+              })}
+            </HighlightCallout>
+            <SpacerBox size="small" />
+            <BlockchainSection />
+            <ConsensusSection />
+            <LedgerSection />
+            <TransactionsSection />
+          </BoundaryBox>
+        </BackgroundWrapper>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/how-cardano-works.js
+++ b/src/pages/how-cardano-works.js
@@ -193,6 +193,203 @@ function TransactionsSection() {
   );
 }
 
+function TokensSection() {
+  return (
+    <>
+      <Divider
+        id="tokens"
+        text={translate({ id: "howCardanoWorks.divider.tokens", message: "Tokens" })}
+      />
+      <TitleWithText
+        title={translate({ id: "howCardanoWorks.tokens.title", message: "How are tokens created?" })}
+        description={[
+          translate({
+            id: "howCardanoWorks.tokens.p1",
+            message:
+              "Tokens on Cardano are native: the ledger handles them with the same rules as ada, so no smart contract is needed to create, send or hold them. A token is defined by a minting policy, a small script or key that says who may create or destroy it. Once minted, tokens travel inside ordinary transaction outputs, alongside ada, and a single transaction can carry many different assets.",
+          }),
+          translate({
+            id: "howCardanoWorks.tokens.p2",
+            message:
+              "An NFT is simply a token minted with a quantity of one under a policy that will not mint it again, plus metadata that describes it. Standards such as CIP-25 and CIP-68 define how wallets and marketplaces read that metadata.",
+          }),
+        ]}
+        headingDot={true}
+        buttonLabel={translate({ id: "howCardanoWorks.tokens.button", message: "Native tokens in the docs" })}
+        buttonLink="https://docs.cardano.org/developer-resources/native-tokens"
+      />
+    </>
+  );
+}
+
+function SmartContractsSection() {
+  return (
+    <>
+      <Divider
+        id="smart-contracts"
+        text={translate({ id: "howCardanoWorks.divider.contracts", message: "Smart contracts" })}
+      />
+      <TitleWithText
+        title={translate({ id: "howCardanoWorks.contracts.title", message: "How do smart contracts run?" })}
+        description={[
+          translate({
+            id: "howCardanoWorks.contracts.p1",
+            message:
+              "A smart contract on Cardano is a validator: a script that guards outputs and answers one question for each transaction that tries to spend them, valid or not. The transaction itself is built by the user's wallet or the app, including every input, output and piece of data the script needs. The script cannot call other services or change its mind later, which keeps outcomes predictable.",
+          }),
+          translate({
+            id: "howCardanoWorks.contracts.p2",
+            message:
+              "Scripts are written in languages such as Plutus and Aiken and compiled to Plutus Core, the language the node executes. Their execution is paid for with a separate budget of memory and steps that is priced in advance, so the cost is known before submission, exactly like the base fee. If a script fails on chain despite the wallet's own check, a small collateral covers the network's work, which is why wallets set aside a few ada for that purpose.",
+          }),
+        ]}
+        headingDot={true}
+        buttonLabel={translate({ id: "howCardanoWorks.contracts.button", message: "Build on Cardano" })}
+        buttonLink="https://developers.cardano.org"
+      />
+    </>
+  );
+}
+
+function NetworkSection() {
+  return (
+    <>
+      <Divider
+        id="network"
+        text={translate({ id: "howCardanoWorks.divider.network", message: "Network" })}
+      />
+      <TitleWithText
+        title={translate({ id: "howCardanoWorks.network.title", message: "Who runs the network?" })}
+        description={[
+          translate({
+            id: "howCardanoWorks.network.p1",
+            message:
+              "Anyone can run a Cardano node. Stake pools are nodes that produce blocks, operated by individuals, companies and communities. Delegating ada to a pool increases its chance of being chosen and earns you a share of its rewards, without moving your ada anywhere. Rewards are paid every epoch from newly released reserve ada and from transaction fees.",
+          }),
+          translate({
+            id: "howCardanoWorks.network.p2",
+            message:
+              "The protocol rewards pools most when they stay below a saturation point, which discourages any single pool from growing too large, and pool operators pledge some of their own ada as a commitment. Around three thousand pools are registered, and roughly a thousand produce blocks in a given epoch.",
+          }),
+          translate({
+            id: "howCardanoWorks.network.p3",
+            message:
+              "New nodes catch up with the chain either by replaying its full history or by starting from a signed snapshot produced by Mithril, a network of signers backed by the same stake distribution. Or [run a stake pool yourself](/stake-pool-operation).",
+          }),
+        ]}
+        headingDot={true}
+        buttonLabel={translate({ id: "howCardanoWorks.network.button", message: "Delegate your ada" })}
+        buttonLink="/stake-pool-delegation"
+      />
+    </>
+  );
+}
+
+function UpgradesSection() {
+  return (
+    <>
+      <Divider
+        id="upgrades"
+        text={translate({ id: "howCardanoWorks.divider.upgrades", message: "Upgrades" })}
+      />
+      <TitleWithText
+        title={translate({ id: "howCardanoWorks.upgrades.title", message: "How does Cardano change?" })}
+        description={[
+          translate({
+            id: "howCardanoWorks.upgrades.p1",
+            message:
+              "Cardano upgrades through hard forks, but without the chain splits the term usually implies. The hard fork combinator lets a single node understand every era of the protocol, so the switch from one set of rules to the next happens at an epoch boundary that everyone knows in advance. Each era added something: staking, native tokens, smart contracts, cheaper scripts, and on-chain governance.",
+          }),
+          translate({
+            id: "howCardanoWorks.upgrades.p2",
+            message:
+              "Since 2025 an upgrade is itself a governance action: it is proposed on chain, voted on by delegated representatives, stake pool operators and the constitutional committee, and only then enacted. The same process changes protocol parameters such as fees and block size. See [how governance works](/governance).",
+          }),
+        ]}
+        headingDot={true}
+        buttonLabel={translate({ id: "howCardanoWorks.upgrades.button", message: "Every upgrade so far" })}
+        buttonLink="/hardforks"
+      />
+    </>
+  );
+}
+
+function TerminologySection() {
+  return (
+    <>
+      <Divider
+        id="terminology"
+        text={translate({ id: "howCardanoWorks.divider.terminology", message: "Terminology" })}
+      />
+      <TitleWithText
+        title={translate({ id: "howCardanoWorks.terminology.title", message: "Terminology" })}
+        description={[
+          translate({
+            id: "howCardanoWorks.terminology.intro",
+            message: "The words this page uses, each linked to its glossary entry.",
+          }),
+          {
+            list: [
+              translate({
+                id: "howCardanoWorks.terminology.item.utxo",
+                message: "[UTXO](/glossary/utxo): an unspent output, one note of value.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.eutxo",
+                message: "[eUTXO](/glossary/eutxo): the extended model with data and scripts on outputs.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.epoch",
+                message: "[Epoch](/glossary/epoch): five days, 432,000 slots.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.slot",
+                message: "[Slot](/glossary/slot): one second, the unit of time.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.slotLeader",
+                message: "[Slot leader](/glossary/slot-leader): the pool chosen to produce a block.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.stakePool",
+                message: "[Stake pool](/glossary/stake-pool): a block-producing node with delegated stake.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.nativeToken",
+                message: "[Native token](/glossary/native-token): an asset the ledger handles like ada.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.plutusCore",
+                message: "[Plutus Core](/glossary/plutus-core): the on-chain script language.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.collateral",
+                message: "[Collateral](/glossary/collateral): ada set aside in case a script fails on chain.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.hardForkCombinator",
+                message:
+                  "[Hard fork combinator](/glossary/hard-fork-combinator): the mechanism that lets one node run every era.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.mithril",
+                message: "[Mithril](/glossary/mithril): signed snapshots for fast node bootstrap.",
+              }),
+              translate({
+                id: "howCardanoWorks.terminology.item.drep",
+                message: "[DRep](/glossary/drep): a delegated representative in governance.",
+              }),
+            ],
+          },
+        ]}
+        headingDot={true}
+        buttonLabel={translate({ id: "howCardanoWorks.terminology.button", message: "Open the glossary" })}
+        buttonLink="/glossary"
+      />
+    </>
+  );
+}
+
 export default function HowCardanoWorks() {
   return (
     <Layout
@@ -223,6 +420,11 @@ export default function HowCardanoWorks() {
             <ConsensusSection />
             <LedgerSection />
             <TransactionsSection />
+            <TokensSection />
+            <SmartContractsSection />
+            <NetworkSection />
+            <UpgradesSection />
+            <TerminologySection />
           </BoundaryBox>
         </BackgroundWrapper>
       </main>

--- a/src/pages/how-cardano-works.module.css
+++ b/src/pages/how-cardano-works.module.css
@@ -1,6 +1,0 @@
-.termGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
-  margin: 1.5rem 0;
-}

--- a/src/pages/how-cardano-works.module.css
+++ b/src/pages/how-cardano-works.module.css
@@ -1,0 +1,6 @@
+.termGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}

--- a/src/pages/ouroboros.js
+++ b/src/pages/ouroboros.js
@@ -90,7 +90,7 @@ export default function Home() {
                 headingDot={true}
               />
         <TitleWithText
-          description={translate({id: 'ouroboros.vision.backLink', message: 'Back to the big picture: [What is Cardano?](/what-is-cardano)'})}
+          description={translate({id: 'ouroboros.vision.backLink', message: 'Back to the big picture: [What is Cardano?](/what-is-cardano), or see [how Cardano works](/how-cardano-works) end to end.'})}
         />
         </BoundaryBox>
       </BackgroundWrapper>

--- a/src/pages/what-is-cardano.js
+++ b/src/pages/what-is-cardano.js
@@ -157,10 +157,10 @@ function HowItWorksSection() {
       <TitleWithText
         description={translate({
           id: "whatIsCardano.how.outro",
-          message: "Want the full picture, from slot leaders to the energy footprint? Start with the consensus protocol.",
+          message: "Want the full picture, from slots to hard forks? Read how Cardano works step by step.",
         })}
-        buttonLabel={translate({ id: "whatIsCardano.how.button", message: "Explore Ouroboros" })}
-        buttonLink="/ouroboros"
+        buttonLabel={translate({ id: "whatIsCardano.how.button", message: "Read how Cardano works" })}
+        buttonLink="/how-cardano-works"
       />
     </>
   );

--- a/src/pages/what-is-cardano.js
+++ b/src/pages/what-is-cardano.js
@@ -18,7 +18,7 @@ import ProofPointsList from "@site/src/components/ProofPointsList";
 import FAQSection from "@site/src/components/FAQSection";
 import CtaOneColumn from "@site/src/components/Layout/CtaOneColumn";
 import { getProofPoints } from "@site/src/data/whatIsCardanoProofPoints";
-import { jsonLdString } from "@site/src/utils/jsonLd";
+import { faqJsonLd } from "@site/src/utils/jsonLd";
 import { getWhatIsCardanoFAQ } from "@site/src/data/whatIsCardanoFAQ";
 import styles from "./what-is-cardano.module.css";
 
@@ -313,18 +313,7 @@ export default function WhatIsCardano() {
       })}
     >
       <Head>
-        <script type="application/ld+json">
-          {jsonLdString({
-            "@context": "https://schema.org",
-            "@type": "FAQPage",
-            "mainEntity": faq.map((item) => ({
-              "@type": "Question",
-              "name": item.question,
-              // Structured data must be plain text, so strip markdown links before joining.
-              "acceptedAnswer": { "@type": "Answer", "text": item.answer.join(" ").replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") },
-            })),
-          })}
-        </script>
+        <script type="application/ld+json">{faqJsonLd(faq)}</script>
       </Head>
       <OpenGraphInfo />
       <HomepageHeader />

--- a/src/utils/jsonLd.js
+++ b/src/utils/jsonLd.js
@@ -3,7 +3,7 @@
 // react-helmet-async (used by Docusaurus <Head>) writes <script> children
 // verbatim, so a "</script>" sequence inside any string value would terminate
 // the script tag early and let following markup execute. Escaping "<" to its
-// JSON unicode form is enough to prevent that; the browser's JSON-LD parser
+// JSON unicode form is enough to prevent that. The browser's JSON-LD parser
 // decodes < transparently, so the structured data is unchanged.
 export function jsonLdString(data) {
   return JSON.stringify(data).replace(/</g, "\\u003c");

--- a/src/utils/jsonLd.js
+++ b/src/utils/jsonLd.js
@@ -8,3 +8,21 @@
 export function jsonLdString(data) {
   return JSON.stringify(data).replace(/</g, "\\u003c");
 }
+
+// FAQPage structured data for the FAQSection shape ({question, answer[]}).
+// Structured data must be plain text, so markdown links in answers are
+// reduced to their label before joining.
+export function faqJsonLd(faq) {
+  return jsonLdString({
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": faq.map((item) => ({
+      "@type": "Question",
+      "name": item.question,
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": item.answer.join(" ").replace(/\[([^\]]+)\]\([^)]+\)/g, "$1"),
+      },
+    })),
+  });
+}


### PR DESCRIPTION
- Adds `/how-cardano-works`, a plain-language tour of consensus, the extended UTXO ledger, transaction costs, native tokens, smart contracts, network operation and upgrades, with a glossary section and an FAQ
- Links the page from the learning path, the Learn menu, the what-is-cardano page and the Ouroboros page
- The fee section links to the docs until the fees page ships, and the page uses the site default Open Graph image