### PR TITLE
fix: correct the how-cardano-works claims on scripts, finality, governance and tokens

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -7063,7 +7063,7 @@
     "message": "What is a blockchain?"
   },
   "howCardanoWorks.consensus.blocks.text": {
-    "message": "The winning pool bundles pending transactions into a block of up to about 88 KB, signs it and sends it to its peers, who verify every transaction before passing it on. Blocks are final in practice after a few more blocks have been built on top, and irreversible in the protocol's own terms after a longer window that its security parameters define."
+    "message": "The slot leader bundles pending transactions into a block of up to about 88 KB under current parameters, signs it and sends it to its peers, who verify every transaction before passing it on. Every block built on top makes a rollback less likely, which is why wallets and exchanges treat a transaction as settled after a handful of blocks. The protocol itself only rules out a rollback once a block is deep enough in the chain, a window of about 36 hours on mainnet set by its security parameters."
   },
   "howCardanoWorks.consensus.blocks.title": {
     "message": "Blocks"
@@ -7081,7 +7081,7 @@
     "message": "Why it is secure"
   },
   "howCardanoWorks.consensus.slots.text": {
-    "message": "Time is divided into slots of one second and epochs of 432,000 slots, five days. For every slot, each stake pool runs a private lottery whose odds match its share of the delegated stake. On average only one slot in twenty has a winner, so a new block appears roughly every 20 seconds, and most slots pass without a block."
+    "message": "Time is divided into slots of one second and epochs of 432,000 slots, five days. For every slot, each stake pool runs a private lottery whose odds match its share of the delegated stake, and any pool that wins becomes a slot leader. On average only one slot in twenty has a leader at all, so a new block appears roughly every 20 seconds and most slots pass without a block. Now and then two pools qualify for the same slot, and only one of their blocks stays in the chain."
   },
   "howCardanoWorks.consensus.slots.title": {
     "message": "Slots and epochs"
@@ -7093,7 +7093,7 @@
     "message": "Smart contracts explained"
   },
   "howCardanoWorks.contracts.p1": {
-    "message": "A smart contract on Cardano is a validator: a script that guards outputs and answers one question for each transaction that tries to spend them, valid or not. The transaction itself is built by the user's wallet or the app, including every input, output and piece of data the script needs. The script cannot call other services or change its mind later, which keeps outcomes predictable."
+    "message": "A smart contract on Cardano is a validator: a script that checks a transaction and answers one question, valid or not. Most often it guards outputs and decides whether a transaction may spend them, but scripts also govern minting and burning tokens, withdrawing rewards, certificates and, since the Chang upgrade, governance votes and proposals. The transaction itself is built by the user's wallet or the app, including every input, output and piece of data the script needs. The script cannot call other services or change its mind later, which keeps outcomes predictable."
   },
   "howCardanoWorks.contracts.p2": {
     "message": "Scripts are written in languages such as Plutus and Aiken and compiled to Plutus Core, the language the node executes. Their execution is paid for with a separate budget of memory and steps that is priced in advance, so the cost is known before submission, exactly like the base fee. If a script fails on chain despite the wallet's own check, a small collateral covers the network's work, which is why wallets set aside a few ada for that purpose."
@@ -7165,7 +7165,7 @@
     "message": "What is the difference between a slot and a block?"
   },
   "howCardanoWorks.faq.speed.a": {
-    "message": "A block is produced roughly every 20 seconds, so a transaction normally appears on the chain within a minute. Services wait for several more blocks before treating it as final."
+    "message": "A block is produced roughly every 20 seconds, so a transaction normally appears on the chain within a minute. Services wait for several more blocks before treating it as settled, and the protocol itself only rules out a rollback after a much longer window."
   },
   "howCardanoWorks.faq.speed.q": {
     "message": "How many confirmations does a Cardano transaction need?"
@@ -7183,10 +7183,10 @@
     "message": "The eUTXO model explained"
   },
   "howCardanoWorks.ledger.p1": {
-    "message": "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in has to equal the total out plus the fee, with any remainder coming back to you as change. Your wallet balance is simply the sum of the notes you can unlock."
+    "message": "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in has to equal the total out plus the fee, with any remainder coming back to you as change. The spendable balance your wallet shows is simply the sum of the notes it can unlock. Staking rewards are the one exception: they accumulate in a separate reward account, and withdrawing them into a note is itself a transaction."
   },
   "howCardanoWorks.ledger.p2": {
-    "message": "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so if two transactions try to spend the same note, only one of them can succeed and the other is rejected. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one."
+    "message": "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so if two transactions try to spend the same note, only one of them can succeed. The other is rejected as a whole, even if it passed every check when it was built, and nothing is half-applied. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one."
   },
   "howCardanoWorks.ledger.p3": {
     "message": "The extended part is what makes programs possible: an output can carry data and be locked by a script instead of a key, and the script decides whether a transaction may spend it."
@@ -7240,7 +7240,7 @@
     "message": "[Mithril](/glossary/mithril): signed snapshots for fast node bootstrap."
   },
   "howCardanoWorks.terminology.item.nativeToken": {
-    "message": "[Native token](/glossary/native-token): an asset the ledger handles like ada."
+    "message": "[Native token](/glossary/native-token): an asset the ledger tracks directly, alongside ada."
   },
   "howCardanoWorks.terminology.item.plutusCore": {
     "message": "[Plutus Core](/glossary/plutus-core): the on-chain script language."
@@ -7249,7 +7249,7 @@
     "message": "[Slot](/glossary/slot): one second, the unit of time."
   },
   "howCardanoWorks.terminology.item.slotLeader": {
-    "message": "[Slot leader](/glossary/slot-leader): the pool chosen to produce a block."
+    "message": "[Slot leader](/glossary/slot-leader): a pool that qualifies to produce the block for a slot."
   },
   "howCardanoWorks.terminology.item.stakePool": {
     "message": "[Stake pool](/glossary/stake-pool): a block-producing node with delegated stake."
@@ -7264,10 +7264,10 @@
     "message": "Native tokens in the docs"
   },
   "howCardanoWorks.tokens.p1": {
-    "message": "Tokens on Cardano are native: the ledger handles them with the same rules as ada, so no smart contract is needed to create, send or hold them. A token is defined by a minting policy, a small script or key that says who may create or destroy it. Once minted, tokens travel inside ordinary transaction outputs, alongside ada, and a single transaction can carry many different assets."
+    "message": "Tokens on Cardano are native: the ledger tracks them directly, much as it tracks ada, so no smart contract is needed to create, send or hold them. A token is defined by a minting policy, a small script or key that says who may create or destroy it. Once minted, tokens travel inside ordinary transaction outputs, alongside ada, and a single transaction can carry many different assets. Ada keeps its special roles: only ada pays fees and deposits, only ada is paid out as staking rewards, and every output that carries tokens has to hold some ada as well."
   },
   "howCardanoWorks.tokens.p2": {
-    "message": "An NFT is simply a token minted with a quantity of one under a policy that will not mint it again, plus metadata that describes it. Standards such as CIP-25 and CIP-68 define how wallets and marketplaces read that metadata."
+    "message": "An NFT is simply a token minted with a quantity of one under a policy that will never mint that asset again. What the token stands for, an image or a name for example, is usually described by metadata, and standards such as CIP-25 and CIP-68 define how wallets and marketplaces read it."
   },
   "howCardanoWorks.tokens.title": {
     "message": "How are tokens created?"
@@ -7276,10 +7276,10 @@
     "message": "Fee structure in the docs"
   },
   "howCardanoWorks.transactions.p1": {
-    "message": "A fee is a formula, not an auction: a fixed part plus a per-byte part, both set by protocol parameters. On mainnet today that is 155,381 lovelace plus 44 lovelace per byte, so a typical transfer of a few hundred bytes costs around 0.17 ada. Fees do not rise when the network is busy, transactions simply wait a little longer."
+    "message": "A fee is a formula, not an auction: a fixed part plus a per-byte part, both set by protocol parameters. On mainnet, as of 2026, that is 155,381 lovelace plus 44 lovelace per byte, so a typical transfer of a few hundred bytes costs around 0.17 ada. Like every protocol parameter, these values can change through governance. Fees do not rise when the network is busy, transactions simply wait a little longer."
   },
   "howCardanoWorks.transactions.p2": {
-    "message": "Every output also has to hold a minimum amount of ada, roughly one ada for a simple output, so that the ledger does not fill up with dust. That ada is not a fee: it stays in the output and comes back when the output is spent. Registering a stake key takes a refundable 2 ada deposit for the same reason."
+    "message": "Every output also has to hold a minimum amount of ada, so that the ledger does not fill up with dust. The minimum depends on the size of the output: roughly one ada for a plain ada-only output, more when it carries tokens or data. That ada is not a fee: it stays in the output and comes back when the output is spent. Registering a stake key takes a refundable deposit, currently 2 ada, for the same reason."
   },
   "howCardanoWorks.transactions.p3": {
     "message": "A block is produced roughly every 20 seconds, so a transaction usually appears on the chain within a minute. Wallets and exchanges then wait for more blocks on top before treating it as settled, typically a few minutes for everyday use and longer for large transfers."
@@ -7294,7 +7294,7 @@
     "message": "Cardano upgrades through hard forks, but without the chain splits the term usually implies. The hard fork combinator lets a single node understand every era of the protocol, so the switch from one set of rules to the next happens at an epoch boundary that everyone knows in advance. Each era added something: staking, native tokens, smart contracts, cheaper scripts, and on-chain governance."
   },
   "howCardanoWorks.upgrades.p2": {
-    "message": "Since 2025 an upgrade is itself a governance action: it is proposed on chain, voted on by delegated representatives, stake pool operators and the constitutional committee, and only then enacted. The same process changes protocol parameters such as fees and block size. See [how governance works](/governance)."
+    "message": "Since 2025 a hard fork is itself a governance action: it is proposed on chain and enacted only after the constitutional committee, delegated representatives and stake pool operators have each approved it. Protocol parameters such as fees and block size change through the same on-chain process, though which of the three bodies has to vote depends on the type of action. See [how governance works](/governance)."
   },
   "howCardanoWorks.upgrades.title": {
     "message": "How does Cardano change?"

--- a/src/data/howCardanoWorksFAQ.js
+++ b/src/data/howCardanoWorksFAQ.js
@@ -20,7 +20,7 @@ export function getHowCardanoWorksFAQ() {
         translate({
           id: "howCardanoWorks.faq.speed.a",
           message:
-            "A block is produced roughly every 20 seconds, so a transaction normally appears on the chain within a minute. Services wait for several more blocks before treating it as final.",
+            "A block is produced roughly every 20 seconds, so a transaction normally appears on the chain within a minute. Services wait for several more blocks before treating it as settled, and the protocol itself only rules out a rollback after a much longer window.",
         }),
       ],
     },

--- a/src/pages/how-cardano-works.js
+++ b/src/pages/how-cardano-works.js
@@ -86,7 +86,7 @@ function ConsensusSection() {
           translate({
             id: "howCardanoWorks.consensus.slots.text",
             message:
-              "Time is divided into slots of one second and epochs of 432,000 slots, five days. For every slot, each stake pool runs a private lottery whose odds match its share of the delegated stake. On average only one slot in twenty has a winner, so a new block appears roughly every 20 seconds, and most slots pass without a block.",
+              "Time is divided into slots of one second and epochs of 432,000 slots, five days. For every slot, each stake pool runs a private lottery whose odds match its share of the delegated stake, and any pool that wins becomes a slot leader. On average only one slot in twenty has a leader at all, so a new block appears roughly every 20 seconds and most slots pass without a block. Now and then two pools qualify for the same slot, and only one of their blocks stays in the chain.",
           }),
         ]}
         headingDot={true}
@@ -98,7 +98,7 @@ function ConsensusSection() {
           translate({
             id: "howCardanoWorks.consensus.blocks.text",
             message:
-              "The winning pool bundles pending transactions into a block of up to about 88 KB, signs it and sends it to its peers, who verify every transaction before passing it on. Blocks are final in practice after a few more blocks have been built on top, and irreversible in the protocol's own terms after a longer window that its security parameters define.",
+              "The slot leader bundles pending transactions into a block of up to about 88 KB under current parameters, signs it and sends it to its peers, who verify every transaction before passing it on. Every block built on top makes a rollback less likely, which is why wallets and exchanges treat a transaction as settled after a handful of blocks. The protocol itself only rules out a rollback once a block is deep enough in the chain, a window of about 36 hours on mainnet set by its security parameters.",
           }),
         ]}
         headingDot={true}
@@ -139,12 +139,12 @@ function LedgerSection() {
           translate({
             id: "howCardanoWorks.ledger.p1",
             message:
-              "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in has to equal the total out plus the fee, with any remainder coming back to you as change. Your wallet balance is simply the sum of the notes you can unlock.",
+              "Cardano uses the extended UTXO model, eUTXO for short. Instead of accounts with running balances, the ledger holds unspent transaction outputs: individual notes of value, each locked to an address. A transaction consumes whole notes as inputs and creates new notes as outputs, and the total in has to equal the total out plus the fee, with any remainder coming back to you as change. The spendable balance your wallet shows is simply the sum of the notes it can unlock. Staking rewards are the one exception: they accumulate in a separate reward account, and withdrawing them into a note is itself a transaction.",
           }),
           translate({
             id: "howCardanoWorks.ledger.p2",
             message:
-              "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so if two transactions try to spend the same note, only one of them can succeed and the other is rejected. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one.",
+              "Two consequences matter for users. First, everything a transaction will do is fixed when it is built, so your wallet can tell you the exact outcome and fee before you sign. Second, a note can only be spent once, so if two transactions try to spend the same note, only one of them can succeed. The other is rejected as a whole, even if it passed every check when it was built, and nothing is half-applied. Applications design around this by splitting value across many notes or by batching, which is why some Cardano apps process orders in rounds rather than one by one.",
           }),
           translate({
             id: "howCardanoWorks.ledger.p3",
@@ -176,12 +176,12 @@ function TransactionsSection() {
           translate({
             id: "howCardanoWorks.transactions.p1",
             message:
-              "A fee is a formula, not an auction: a fixed part plus a per-byte part, both set by protocol parameters. On mainnet today that is 155,381 lovelace plus 44 lovelace per byte, so a typical transfer of a few hundred bytes costs around 0.17 ada. Fees do not rise when the network is busy, transactions simply wait a little longer.",
+              "A fee is a formula, not an auction: a fixed part plus a per-byte part, both set by protocol parameters. On mainnet, as of 2026, that is 155,381 lovelace plus 44 lovelace per byte, so a typical transfer of a few hundred bytes costs around 0.17 ada. Like every protocol parameter, these values can change through governance. Fees do not rise when the network is busy, transactions simply wait a little longer.",
           }),
           translate({
             id: "howCardanoWorks.transactions.p2",
             message:
-              "Every output also has to hold a minimum amount of ada, roughly one ada for a simple output, so that the ledger does not fill up with dust. That ada is not a fee: it stays in the output and comes back when the output is spent. Registering a stake key takes a refundable 2 ada deposit for the same reason.",
+              "Every output also has to hold a minimum amount of ada, so that the ledger does not fill up with dust. The minimum depends on the size of the output: roughly one ada for a plain ada-only output, more when it carries tokens or data. That ada is not a fee: it stays in the output and comes back when the output is spent. Registering a stake key takes a refundable deposit, currently 2 ada, for the same reason.",
           }),
           translate({
             id: "howCardanoWorks.transactions.p3",
@@ -210,12 +210,12 @@ function TokensSection() {
           translate({
             id: "howCardanoWorks.tokens.p1",
             message:
-              "Tokens on Cardano are native: the ledger handles them with the same rules as ada, so no smart contract is needed to create, send or hold them. A token is defined by a minting policy, a small script or key that says who may create or destroy it. Once minted, tokens travel inside ordinary transaction outputs, alongside ada, and a single transaction can carry many different assets.",
+              "Tokens on Cardano are native: the ledger tracks them directly, much as it tracks ada, so no smart contract is needed to create, send or hold them. A token is defined by a minting policy, a small script or key that says who may create or destroy it. Once minted, tokens travel inside ordinary transaction outputs, alongside ada, and a single transaction can carry many different assets. Ada keeps its special roles: only ada pays fees and deposits, only ada is paid out as staking rewards, and every output that carries tokens has to hold some ada as well.",
           }),
           translate({
             id: "howCardanoWorks.tokens.p2",
             message:
-              "An NFT is simply a token minted with a quantity of one under a policy that will not mint it again, plus metadata that describes it. Standards such as CIP-25 and CIP-68 define how wallets and marketplaces read that metadata.",
+              "An NFT is simply a token minted with a quantity of one under a policy that will never mint that asset again. What the token stands for, an image or a name for example, is usually described by metadata, and standards such as CIP-25 and CIP-68 define how wallets and marketplaces read it.",
           }),
         ]}
         headingDot={true}
@@ -239,7 +239,7 @@ function SmartContractsSection() {
           translate({
             id: "howCardanoWorks.contracts.p1",
             message:
-              "A smart contract on Cardano is a validator: a script that guards outputs and answers one question for each transaction that tries to spend them, valid or not. The transaction itself is built by the user's wallet or the app, including every input, output and piece of data the script needs. The script cannot call other services or change its mind later, which keeps outcomes predictable.",
+              "A smart contract on Cardano is a validator: a script that checks a transaction and answers one question, valid or not. Most often it guards outputs and decides whether a transaction may spend them, but scripts also govern minting and burning tokens, withdrawing rewards, certificates and, since the Chang upgrade, governance votes and proposals. The transaction itself is built by the user's wallet or the app, including every input, output and piece of data the script needs. The script cannot call other services or change its mind later, which keeps outcomes predictable.",
           }),
           translate({
             id: "howCardanoWorks.contracts.p2",
@@ -307,7 +307,7 @@ function UpgradesSection() {
           translate({
             id: "howCardanoWorks.upgrades.p2",
             message:
-              "Since 2025 an upgrade is itself a governance action: it is proposed on chain, voted on by delegated representatives, stake pool operators and the constitutional committee, and only then enacted. The same process changes protocol parameters such as fees and block size. See [how governance works](/governance).",
+              "Since 2025 a hard fork is itself a governance action: it is proposed on chain and enacted only after the constitutional committee, delegated representatives and stake pool operators have each approved it. Protocol parameters such as fees and block size change through the same on-chain process, though which of the three bodies has to vote depends on the type of action. See [how governance works](/governance).",
           }),
         ]}
         headingDot={true}
@@ -352,7 +352,7 @@ function TerminologySection() {
               }),
               translate({
                 id: "howCardanoWorks.terminology.item.slotLeader",
-                message: "[Slot leader](/glossary/slot-leader): the pool chosen to produce a block.",
+                message: "[Slot leader](/glossary/slot-leader): a pool that qualifies to produce the block for a slot.",
               }),
               translate({
                 id: "howCardanoWorks.terminology.item.stakePool",
@@ -360,7 +360,7 @@ function TerminologySection() {
               }),
               translate({
                 id: "howCardanoWorks.terminology.item.nativeToken",
-                message: "[Native token](/glossary/native-token): an asset the ledger handles like ada.",
+                message: "[Native token](/glossary/native-token): an asset the ledger tracks directly, alongside ada.",
               }),
               translate({
                 id: "howCardanoWorks.terminology.item.plutusCore",


### PR DESCRIPTION
- Smart contracts are described as validators for any transaction action, not only for spending outputs: minting, reward withdrawals, certificates and governance votes are named as well
- Finality now separates a rollback becoming unlikely after a few blocks from the protocol's own guarantee after its stability window of about 36 hours
- Governance section states that hard forks need all three bodies, while which bodies vote on a parameter change depends on the action type
- Native tokens are described as tracked directly by the ledger, with ada keeping its special roles for fees, deposits, rewards and the minimum ada in outputs
- Wallet balance is described as the spendable UTXO balance, with staking rewards accumulating in a separate reward account
- Slot section explains that a slot can have no, one or several leaders instead of exactly one winner
- NFT definition no longer treats metadata as a requirement
- Fee, block size, minimum ada and deposit figures are dated as current parameters that governance can change, and the minimum ada is described as size dependent
- A transaction that loses a race for the same input is described as rejected as a whole