### PR TITLE
fix: correct smart contract explainer wording

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -7093,10 +7093,10 @@
     "message": "Smart contracts explained"
   },
   "howCardanoWorks.contracts.p1": {
-    "message": "A smart contract on Cardano is a validator: a script that guards outputs and answers one question for each transaction that tries to spend them, valid or not. The transaction itself is built by the user's wallet or the app, including every input, output and piece of data the script needs. The script cannot call other services or change its mind later, which keeps outcomes predictable."
+    "message": "A smart contract on Cardano is a validator: a script that answers one question for each transaction that involves it, valid or not. Most validators guard outputs and decide whether a transaction may spend them, and a script can also authorize minting, reward withdrawals, certificates and governance votes. The transaction itself is built by the user's wallet or the app, including every input, output and piece of data the script needs. The script cannot call other services or change its mind later, which keeps outcomes predictable."
   },
   "howCardanoWorks.contracts.p2": {
-    "message": "Scripts are written in languages such as Plutus and Aiken and compiled to Plutus Core, the language the node executes. Their execution is paid for with a separate budget of memory and steps that is priced in advance, so the cost is known before submission, exactly like the base fee. If a script fails on chain despite the wallet's own check, a small collateral covers the network's work, which is why wallets set aside a few ada for that purpose."
+    "message": "Scripts are written in languages such as Aiken and Plinth and compiled to Plutus Core, the language the node executes. Their execution is paid for with a separate budget of memory and steps that is priced in advance, so the cost is known before submission, exactly like the base fee. The app or wallet normally evaluates a script before asking for a signature, so failures on chain are rare. If a script still fails there, a small collateral covers the network's work, which is why wallets that connect to DApps set aside some ada for that purpose."
   },
   "howCardanoWorks.contracts.title": {
     "message": "How do smart contracts run?"
@@ -7321,7 +7321,7 @@
     "message": "A smart contract is a program stored on a blockchain that enforces an agreement without a middleman. The classic picture is a vending machine: you put in coins, you pick a product, and the machine hands it over. Nobody behind a counter decides whether you deserve the snack, the rules are built into the machine, and they work the same for everyone."
   },
   "smartContracts.what.p2": {
-    "message": "Take a buyer and a seller who do not know each other. Without a contract they either trust each other or pay an escrow agent. With a contract the payment sits in a script that releases it once the agreed condition is recorded. Neither can back out, and nobody in the middle takes a cut or changes the terms."
+    "message": "Take a buyer and a seller who do not know each other. Without a contract they either trust each other or pay an escrow agent. With a contract the payment sits in a script that releases it only once the agreed condition is recorded. Whether either side can cancel, whether a fee is taken and who can change the terms is fixed by the script's rules rather than decided by someone in the middle."
   },
   "smartContracts.what.p3": {
     "message": "A contract only sees what is inside the transaction that calls it and what is already on the chain. Facts from the outside world, such as a race result or an exchange rate, have to be brought on chain by a service called an oracle, and the contract can only be as reliable as that feed."
@@ -7336,7 +7336,7 @@
     "message": "How does Cardano run smart contracts?"
   },
   "smartContracts.how.intro": {
-    "message": "On Cardano a contract is a validator: a script attached to funds on the ledger. Three things follow from that."
+    "message": "On Cardano a contract is a validator: a script that a transaction has to satisfy. Most validators are attached to funds on the ledger, and a script can also authorize minting, reward withdrawals, certificates and governance votes. Three things follow from that."
   },
   "smartContracts.how.guard.title": {
     "message": "The script guards the funds"
@@ -7348,13 +7348,13 @@
     "message": "The transaction is built before it runs"
   },
   "smartContracts.how.built.text": {
-    "message": "Your wallet or the app builds the complete transaction first, including every input, output and the data the script needs, and runs the script locally. Only a transaction that passes is signed and sent. The network then runs the same check, and because the inputs are fixed, the result is the same."
+    "message": "Your wallet or the app builds the complete transaction first, including every input, output and the data the script needs, and can evaluate the script before asking you to sign. The network then runs the same check on the same inputs and gets the same result. The transaction can still be rejected if one of its inputs was spent in the meantime, in which case nothing happens."
   },
   "smartContracts.how.cost.title": {
     "message": "The cost is known before you sign"
   },
   "smartContracts.how.cost.text": {
-    "message": "Script execution is paid for with a budget of memory and processing steps that is priced by protocol parameters, so the fee is fixed when the transaction is built, not discovered afterwards. If a script still fails on chain, which the wallet's own check makes rare, a [collateral](/glossary/collateral) of one and a half times the fee covers the network's work. Wallets typically set aside a few ada for that."
+    "message": "Script execution is paid for with a budget of memory and processing steps that is priced by protocol parameters, so the fee is fixed when the transaction is built, not discovered afterwards. If a script still fails on chain, which evaluating it before signing makes rare, a [collateral](/glossary/collateral) covers the network's work. Its minimum is a share of the fee set by a protocol parameter, currently one and a half times the fee, and wallets that connect to DApps set aside some ada for it."
   },
   "smartContracts.how.outro": {
     "message": "The full mechanics, from slots to ledger, are on the [how Cardano works](/how-cardano-works) page."
@@ -7366,7 +7366,7 @@
     "message": "Which languages do developers use?"
   },
   "smartContracts.languages.p1": {
-    "message": "Contracts are written in a high-level language and compiled to Plutus Core, the small language the Cardano node executes. Plutus, embedded in Haskell, was the first and is still used for protocols that want the full power of Haskell's type system. Aiken is a newer language built only for Cardano, with a simpler syntax and tooling that most new projects now pick. Both produce the same kind of on-chain script."
+    "message": "Contracts are written in a high-level language and compiled to Plutus Core, the small language the Cardano node executes. Plinth, formerly called Plutus Tx, is embedded in Haskell, was the first and is still used by teams that want the full power of Haskell's type system. Aiken is a newer language built only for Cardano, with a simpler syntax and tooling that most new projects now pick. Plutarch, a Haskell library that stays close to the compiled code, is chosen when execution cost matters most. All of them produce the same kind of on-chain script."
   },
   "smartContracts.languages.p2": {
     "message": "Not everything needs a full contract. Native scripts handle common cases such as multi-signature wallets and time locks without any Plutus code, and native tokens can be minted under such a script as well."
@@ -7396,7 +7396,7 @@
     "message": "How do I use a DApp safely?"
   },
   "smartContracts.safety.p1": {
-    "message": "Read what you are about to sign. Most Cardano wallets show the outputs of a transaction, that is, where ada and tokens will go, so a swap that suddenly sends your whole balance to an unknown address is visible before you confirm. There are no open-ended token approvals on Cardano: a DApp can only spend what the transaction you sign spends, and there is nothing to revoke later. What you do send to a contract stays under that contract's rules until those rules release it."
+    "message": "Read what you are about to sign. Most Cardano wallets show the outputs of a transaction, that is, where ada and tokens will go, so a swap that suddenly sends your whole balance to an unknown address is visible before you confirm. Your signature commits to the exact transaction, so check the inputs, outputs and any warnings your wallet shows. There are no open-ended token approvals on Cardano: a DApp can only spend what the transaction you sign spends, and there is nothing to revoke later. What you do send to a contract stays under that contract's rules until those rules release it."
   },
   "smartContracts.safety.p2": {
     "message": "Beyond that, the usual rules apply. Reach the app through a bookmark or the link on its official channels, not through a search ad or a message. Prefer apps whose contracts have been audited and whose code is public. Try a small amount first. And treat any request to enter your recovery phrase as an attack, no DApp needs it."
@@ -7426,7 +7426,7 @@
     "message": "How do I build one?"
   },
   "smartContracts.build.p1": {
-    "message": "The developer portal walks you from a first transaction to a deployed contract, with tutorials for Aiken and Plutus, the test networks to try things safely, and the tooling most teams use. A contract reaches the chain as part of a transaction, either attached to the transaction that uses it or stored once in an output that later transactions point to. There is no separate deployment step or registry."
+    "message": "The developer portal walks you from a first transaction to a deployed contract, with tutorials for Aiken and Plutus, the test networks to try things safely, and the tooling most teams use. A contract reaches the chain as part of a transaction, either attached to the transaction that uses it or published once in an output that later transactions reference. There is no global contract registry."
   },
   "smartContracts.build.button": {
     "message": "Developer portal"
@@ -7438,7 +7438,7 @@
     "message": "What a smart contract is, how Cardano runs contracts as validator scripts on the eUTXO ledger, which languages developers use, what a DApp is and how to use one safely."
   },
   "smartContracts.intro.callout": {
-    "message": "A smart contract on Cardano is a script that decides whether a transaction may spend the funds it guards. It cannot act on its own and it cannot reach outside the chain. It can only say yes or no."
+    "message": "A smart contract on Cardano is a script that approves or rejects a transaction, most often one that spends the funds the script guards. It cannot act on its own and it cannot reach outside the chain. It can only say yes or no."
   },
   "smartContracts.cta.title": {
     "message": "Ready to test yourself? Take the technical quiz."
@@ -7450,7 +7450,7 @@
     "message": "Are smart contracts on Cardano the same as on Ethereum?"
   },
   "smartContracts.faq.ethereum.a": {
-    "message": "They solve the same problem but work differently. On Ethereum a contract is an account with its own state that executes when called. On Cardano a contract is a validator that guards outputs on the ledger and approves or rejects transactions that spend them. The Cardano model gives you the exact outcome and cost before you sign, at the price of designing around outputs rather than shared state."
+    "message": "They solve the same problem but work differently. On Ethereum a contract is an account with its own state that executes when called. On Cardano a contract is a validator that approves or rejects a transaction, most often one that spends outputs the script guards. The Cardano model tells you the script result and the cost before you sign, though the transaction can still be rejected if an input it needs was spent first. The price is designing around outputs rather than shared state."
   },
   "smartContracts.faq.signature.q": {
     "message": "Can a smart contract take my ada without my signature?"
@@ -7462,13 +7462,13 @@
     "message": "What happens if a script fails?"
   },
   "smartContracts.faq.failure.a": {
-    "message": "Your wallet runs the script before submitting, so a failing transaction is normally never sent. If a transaction is submitted and its script fails on chain anyway, the collateral your wallet set aside covers the network's work, and the rest of the transaction does not happen."
+    "message": "The app or wallet normally evaluates the script before you sign, so a failing transaction is rarely sent. If a transaction is submitted and its script fails on chain anyway, the collateral your wallet set aside covers the network's work, and the rest of the transaction does not happen."
   },
   "smartContracts.faq.approvals.q": {
     "message": "Do I need to approve tokens for a DApp?"
   },
   "smartContracts.faq.approvals.a": {
-    "message": "No. Cardano has no allowance system. Every transaction you sign spends exactly what it shows, and a DApp cannot spend anything else from your wallet afterwards."
+    "message": "No. Cardano has no allowance system. Your signature commits to the exact transaction you sign and nothing more, so review the inputs, outputs and warnings your wallet shows. A DApp cannot spend anything else from your wallet afterwards."
   },
   "smartContracts.faq.upgrades.q": {
     "message": "Can a smart contract be changed after it is deployed?"
@@ -7480,7 +7480,7 @@
     "message": "Which language should I learn?"
   },
   "smartContracts.faq.language.a": {
-    "message": "Aiken is the fastest way in for most developers, with a familiar syntax and good tooling. Plutus is the choice if you already know Haskell or want the deepest control. Both compile to the same on-chain language."
+    "message": "Aiken is the fastest way in for most developers, with a familiar syntax and good tooling. Plinth, formerly Plutus Tx, is the choice if you already know Haskell, and Plutarch if you want fine control over execution cost. All of them compile to the same on-chain language."
   },
   "learn.item.smartContracts.title": {
     "message": "Smart contracts and DApps"
@@ -9709,7 +9709,7 @@
     "message": "Do I need to approve tokens for a DApp on Cardano?"
   },
   "defi.faq.approvals.a": {
-    "message": "No. Cardano has no allowance system, so the revoke-approvals housekeeping you may know from other chains does not exist here. Each transaction you sign spends exactly what it shows, and a DApp cannot spend anything else from your wallet later."
+    "message": "No. Cardano has no allowance system, so the revoke-approvals housekeeping you may know from other chains does not exist here. Your signature commits to the exact transaction you sign and nothing more, so review the inputs, outputs and warnings your wallet shows. A DApp cannot spend anything else from your wallet later."
   },
   "defi.faq.yields.q": {
     "message": "Are DeFi yields guaranteed?"

--- a/src/data/defiFAQ.js
+++ b/src/data/defiFAQ.js
@@ -26,7 +26,7 @@ export function getDefiFAQ() {
         translate({
           id: "defi.faq.approvals.a",
           message:
-            "No. Cardano has no allowance system, so the revoke-approvals housekeeping you may know from other chains does not exist here. Each transaction you sign spends exactly what it shows, and a DApp cannot spend anything else from your wallet later.",
+            "No. Cardano has no allowance system, so the revoke-approvals housekeeping you may know from other chains does not exist here. Your signature commits to the exact transaction you sign and nothing more, so review the inputs, outputs and warnings your wallet shows. A DApp cannot spend anything else from your wallet later.",
         }),
       ],
     },

--- a/src/data/smartContractsFAQ.js
+++ b/src/data/smartContractsFAQ.js
@@ -13,7 +13,7 @@ export function getSmartContractsFAQ() {
         translate({
           id: "smartContracts.faq.ethereum.a",
           message:
-            "They solve the same problem but work differently. On Ethereum a contract is an account with its own state that executes when called. On Cardano a contract is a validator that guards outputs on the ledger and approves or rejects transactions that spend them. The Cardano model gives you the exact outcome and cost before you sign, at the price of designing around outputs rather than shared state.",
+            "They solve the same problem but work differently. On Ethereum a contract is an account with its own state that executes when called. On Cardano a contract is a validator that approves or rejects a transaction, most often one that spends outputs the script guards. The Cardano model tells you the script result and the cost before you sign, though the transaction can still be rejected if an input it needs was spent first. The price is designing around outputs rather than shared state.",
         }),
       ],
     },
@@ -39,7 +39,7 @@ export function getSmartContractsFAQ() {
         translate({
           id: "smartContracts.faq.failure.a",
           message:
-            "Your wallet runs the script before submitting, so a failing transaction is normally never sent. If a transaction is submitted and its script fails on chain anyway, the collateral your wallet set aside covers the network's work, and the rest of the transaction does not happen.",
+            "The app or wallet normally evaluates the script before you sign, so a failing transaction is rarely sent. If a transaction is submitted and its script fails on chain anyway, the collateral your wallet set aside covers the network's work, and the rest of the transaction does not happen.",
         }),
       ],
     },
@@ -52,7 +52,7 @@ export function getSmartContractsFAQ() {
         translate({
           id: "smartContracts.faq.approvals.a",
           message:
-            "No. Cardano has no allowance system. Every transaction you sign spends exactly what it shows, and a DApp cannot spend anything else from your wallet afterwards.",
+            "No. Cardano has no allowance system. Your signature commits to the exact transaction you sign and nothing more, so review the inputs, outputs and warnings your wallet shows. A DApp cannot spend anything else from your wallet afterwards.",
         }),
       ],
     },
@@ -78,7 +78,7 @@ export function getSmartContractsFAQ() {
         translate({
           id: "smartContracts.faq.language.a",
           message:
-            "Aiken is the fastest way in for most developers, with a familiar syntax and good tooling. Plutus is the choice if you already know Haskell or want the deepest control. Both compile to the same on-chain language.",
+            "Aiken is the fastest way in for most developers, with a familiar syntax and good tooling. Plinth, formerly Plutus Tx, is the choice if you already know Haskell, and Plutarch if you want fine control over execution cost. All of them compile to the same on-chain language.",
         }),
       ],
     },

--- a/src/pages/how-cardano-works.js
+++ b/src/pages/how-cardano-works.js
@@ -218,12 +218,12 @@ function SmartContractsSection() {
           translate({
             id: "howCardanoWorks.contracts.p1",
             message:
-              "A smart contract on Cardano is a validator: a script that guards outputs and answers one question for each transaction that tries to spend them, valid or not. The transaction itself is built by the user's wallet or the app, including every input, output and piece of data the script needs. The script cannot call other services or change its mind later, which keeps outcomes predictable.",
+              "A smart contract on Cardano is a validator: a script that answers one question for each transaction that involves it, valid or not. Most validators guard outputs and decide whether a transaction may spend them, and a script can also authorize minting, reward withdrawals, certificates and governance votes. The transaction itself is built by the user's wallet or the app, including every input, output and piece of data the script needs. The script cannot call other services or change its mind later, which keeps outcomes predictable.",
           }),
           translate({
             id: "howCardanoWorks.contracts.p2",
             message:
-              "Scripts are written in languages such as Plutus and Aiken and compiled to Plutus Core, the language the node executes. Their execution is paid for with a separate budget of memory and steps that is priced in advance, so the cost is known before submission, exactly like the base fee. If a script fails on chain despite the wallet's own check, a small collateral covers the network's work, which is why wallets set aside a few ada for that purpose.",
+              "Scripts are written in languages such as Aiken and Plinth and compiled to Plutus Core, the language the node executes. Their execution is paid for with a separate budget of memory and steps that is priced in advance, so the cost is known before submission, exactly like the base fee. The app or wallet normally evaluates a script before asking for a signature, so failures on chain are rare. If a script still fails there, a small collateral covers the network's work, which is why wallets that connect to DApps set aside some ada for that purpose.",
           }),
         ]}
         headingDot={true}

--- a/src/pages/smart-contracts.js
+++ b/src/pages/smart-contracts.js
@@ -28,7 +28,7 @@ function WhatSection() {
           translate({
             id: "smartContracts.what.p2",
             message:
-              "Take a buyer and a seller who do not know each other. Without a contract they either trust each other or pay an escrow agent. With a contract the payment sits in a script that releases it once the agreed condition is recorded. Neither can back out, and nobody in the middle takes a cut or changes the terms.",
+              "Take a buyer and a seller who do not know each other. Without a contract they either trust each other or pay an escrow agent. With a contract the payment sits in a script that releases it only once the agreed condition is recorded. Whether either side can cancel, whether a fee is taken and who can change the terms is fixed by the script's rules rather than decided by someone in the middle.",
           }),
           translate({
             id: "smartContracts.what.p3",
@@ -59,7 +59,7 @@ function HowSection() {
         description={translate({
           id: "smartContracts.how.intro",
           message:
-            "On Cardano a contract is a validator: a script attached to funds on the ledger. Three things follow from that.",
+            "On Cardano a contract is a validator: a script that a transaction has to satisfy. Most validators are attached to funds on the ledger, and a script can also authorize minting, reward withdrawals, certificates and governance votes. Three things follow from that.",
         })}
         headingDot={true}
       />
@@ -85,7 +85,7 @@ function HowSection() {
           translate({
             id: "smartContracts.how.built.text",
             message:
-              "Your wallet or the app builds the complete transaction first, including every input, output and the data the script needs, and runs the script locally. Only a transaction that passes is signed and sent. The network then runs the same check, and because the inputs are fixed, the result is the same.",
+              "Your wallet or the app builds the complete transaction first, including every input, output and the data the script needs, and can evaluate the script before asking you to sign. The network then runs the same check on the same inputs and gets the same result. The transaction can still be rejected if one of its inputs was spent in the meantime, in which case nothing happens.",
           }),
         ]}
         headingDot={true}
@@ -97,7 +97,7 @@ function HowSection() {
           translate({
             id: "smartContracts.how.cost.text",
             message:
-              "Script execution is paid for with a budget of memory and processing steps that is priced by protocol parameters, so the fee is fixed when the transaction is built, not discovered afterwards. If a script still fails on chain, which the wallet's own check makes rare, a [collateral](/glossary/collateral) of one and a half times the fee covers the network's work. Wallets typically set aside a few ada for that.",
+              "Script execution is paid for with a budget of memory and processing steps that is priced by protocol parameters, so the fee is fixed when the transaction is built, not discovered afterwards. If a script still fails on chain, which evaluating it before signing makes rare, a [collateral](/glossary/collateral) covers the network's work. Its minimum is a share of the fee set by a protocol parameter, currently one and a half times the fee, and wallets that connect to DApps set aside some ada for it.",
           }),
         ]}
         headingDot={true}
@@ -126,7 +126,7 @@ function LanguagesSection() {
           translate({
             id: "smartContracts.languages.p1",
             message:
-              "Contracts are written in a high-level language and compiled to Plutus Core, the small language the Cardano node executes. Plutus, embedded in Haskell, was the first and is still used for protocols that want the full power of Haskell's type system. Aiken is a newer language built only for Cardano, with a simpler syntax and tooling that most new projects now pick. Both produce the same kind of on-chain script.",
+              "Contracts are written in a high-level language and compiled to Plutus Core, the small language the Cardano node executes. Plinth, formerly called Plutus Tx, is embedded in Haskell, was the first and is still used by teams that want the full power of Haskell's type system. Aiken is a newer language built only for Cardano, with a simpler syntax and tooling that most new projects now pick. Plutarch, a Haskell library that stays close to the compiled code, is chosen when execution cost matters most. All of them produce the same kind of on-chain script.",
           }),
           translate({
             id: "smartContracts.languages.p2",
@@ -184,7 +184,7 @@ function SafetySection() {
           translate({
             id: "smartContracts.safety.p1",
             message:
-              "Read what you are about to sign. Most Cardano wallets show the outputs of a transaction, that is, where ada and tokens will go, so a swap that suddenly sends your whole balance to an unknown address is visible before you confirm. There are no open-ended token approvals on Cardano: a DApp can only spend what the transaction you sign spends, and there is nothing to revoke later. What you do send to a contract stays under that contract's rules until those rules release it.",
+              "Read what you are about to sign. Most Cardano wallets show the outputs of a transaction, that is, where ada and tokens will go, so a swap that suddenly sends your whole balance to an unknown address is visible before you confirm. Your signature commits to the exact transaction, so check the inputs, outputs and any warnings your wallet shows. There are no open-ended token approvals on Cardano: a DApp can only spend what the transaction you sign spends, and there is nothing to revoke later. What you do send to a contract stays under that contract's rules until those rules release it.",
           }),
           translate({
             id: "smartContracts.safety.p2",
@@ -251,7 +251,7 @@ function BuildSection() {
           translate({
             id: "smartContracts.build.p1",
             message:
-              "The developer portal walks you from a first transaction to a deployed contract, with tutorials for Aiken and Plutus, the test networks to try things safely, and the tooling most teams use. A contract reaches the chain as part of a transaction, either attached to the transaction that uses it or stored once in an output that later transactions point to. There is no separate deployment step or registry.",
+              "The developer portal walks you from a first transaction to a deployed contract, with tutorials for Aiken and Plutus, the test networks to try things safely, and the tooling most teams use. A contract reaches the chain as part of a transaction, either attached to the transaction that uses it or published once in an output that later transactions reference. There is no global contract registry.",
           }),
         ]}
         headingDot={true}
@@ -294,7 +294,7 @@ export default function SmartContracts() {
         {translate({
           id: "smartContracts.intro.callout",
           message:
-            "A smart contract on Cardano is a script that decides whether a transaction may spend the funds it guards. It cannot act on its own and it cannot reach outside the chain. It can only say yes or no.",
+            "A smart contract on Cardano is a script that approves or rejects a transaction, most often one that spends the funds the script guards. It cannot act on its own and it cannot reach outside the chain. It can only say yes or no.",
         })}
       </HighlightCallout>
       <SpacerBox size="small" />


### PR DESCRIPTION
- Smart contracts are no longer described only as scripts that guard funds. The text now says most validators do, and that scripts also authorize minting, reward withdrawals, certificates and governance votes.
- Script evaluation before signing is attributed to the app or wallet rather than mandated wallet-side, and the possibility of a rejected transaction due to an already spent input is stated.
- The collateral requirement is described as a protocol parameter, currently one and a half times the fee, instead of a fixed constant.
- The escrow example no longer promises that nobody can cancel or take a fee. Those depend on the contract's rules.
- Reference scripts are described as published in an output by an earlier transaction. The claim that there is no deployment step is removed.
- Language guidance names Plinth (formerly Plutus Tx) for Haskell teams and Plutarch for fine control over execution cost.
- Token-approval answers on the smart contracts and DeFi pages now say the signature commits to the exact transaction body and ask readers to review what the wallet shows.