### PR TITLE
feat: point homepage hero cta to what-is-cardano

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -1099,8 +1099,8 @@
   "home.hero.description": {
     "message": "Cardano is the most secure, reliable and censorship-resistant blockchain for mission critical applications to power economies and societies of the future."
   },
-  "home.hero.ctaWhatIsAda": {
-    "message": "What is ada?"
+  "home.hero.ctaWhatIsCardano": {
+    "message": "What is Cardano?"
   },
   "home.hero.ctaGetStarted": {
     "message": "Get Started"
@@ -6826,7 +6826,7 @@
     "message": "What makes Cardano different?"
   },
   "home.proofPoints.cta": {
-    "message": "What is Cardano?"
+    "message": "See all differences"
   },
   "learn.stage.dividerLabel": {
     "message": "Stage {number}"

--- a/src/components/HomeProofPointsSection/index.js
+++ b/src/components/HomeProofPointsSection/index.js
@@ -21,7 +21,7 @@ export default function HomeProofPointsSection() {
       <ProofPointsList
         points={points}
         cta={{
-          label: translate({ id: "home.proofPoints.cta", message: "What is Cardano?" }),
+          label: translate({ id: "home.proofPoints.cta", message: "See all differences" }),
           to: "/what-is-cardano",
         }}
       />

--- a/src/components/Layout/WelcomeHero/index.js
+++ b/src/components/Layout/WelcomeHero/index.js
@@ -63,9 +63,9 @@ function WelcomeHero({ title, description }) {
           <div className={styles.cta}>
             <Link
               className={clsx("button button--primary button--lg", styles.heroCtaButton)}
-              to="/what-is-ada"
+              to="/what-is-cardano"
             >
-              {translate({id: 'home.hero.ctaWhatIsAda', message: 'What is ada?'})}
+              {translate({id: 'home.hero.ctaWhatIsCardano', message: 'What is Cardano?'})}
             </Link>
             <Link
               className={clsx("button button--primary button--lg", styles.heroCtaButton)}


### PR DESCRIPTION
Homepage hero now leads to the Cardano overview instead of the ada page.