### PR TITLE
feat: link defi instead of stablecoins in the use menu

### DIFF
--- a/src/data/navbar.js
+++ b/src/data/navbar.js
@@ -93,7 +93,7 @@ function getNavbarItems() {
           items: [
             {to: '/stake-pool-delegation', label: 'Delegate your ada', description: 'Be a part of it and earn rewards'},
             {to: '/governance/delegate', label: 'Delegate your vote', description: 'Lend your voting power to a DRep'},
-            {to: '/stablecoins', label: 'Stablecoins', description: 'Stablecoins on Cardano and their live data'},
+            {to: '/defi', label: 'DeFi', description: 'Swap, lend and earn with open applications'},
           ],
         },
       ],


### PR DESCRIPTION
The Use menu now links DeFi instead of Stablecoins. The stablecoins page stays reachable from the DeFi page and the learn hub.