### PR TITLE
feat: cross-link the older pages to the explainers, the learning path and the quiz

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -931,12 +931,8 @@
   "whereToGetAda.staking.title": {
     "message": "Staking rewards"
   },
-  "whereToGetAda.staking.description1": {
-    "message": "If you already have some [ada](/what-is-ada/), you can earn more by [delegating your ada to a stake pool](/stake-pool-delegation/). This allows you to participate in the network's proof-of-stake system and earn rewards. Alternatively, you can [run your own stake pool](/stake-pool-operation/), which requires more effort and technical knowledge but can be more rewarding."
-  },
-  "whereToGetAda.staking.description2": {
-    "message": "Cardano offers several advantages for staking: there is no minimum amount of [ada](/what-is-ada/) required to stake, no risk of slashing (losing your staked [ada](/what-is-ada/)), and no locking period. You always maintain custody over your delegated [ada](/what-is-ada/), ensuring that your funds remain secure and accessible at all times. Additionally, rewards are distributed by the protocol itself, not by the pools, ensuring a fair and transparent distribution process."
-  },
+  "whereToGetAda.staking.description1": {"message": "If you already have some [ada](/what-is-ada/), you can earn more by [delegating your ada to a stake pool](/stake-pool-delegation/). This allows you to participate in the network's [proof-of-stake](/glossary/proof-of-stake) system and earn rewards. Alternatively, you can [run your own stake pool](/stake-pool-operation/), which requires more effort and technical knowledge but can be more rewarding."},
+  "whereToGetAda.staking.description2": {"message": "Cardano offers several advantages for [staking](/glossary/staking): there is no minimum amount of [ada](/what-is-ada/) required to stake, no risk of slashing (losing your staked [ada](/what-is-ada/)), and no locking period. You always maintain custody over your delegated [ada](/what-is-ada/), ensuring that your funds remain secure and accessible at all times. Additionally, rewards are distributed by the protocol itself, not by the pools, ensuring a fair and transparent distribution process."},
   "commonScams.hero.title": {
     "message": "Common Cardano scams"
   },
@@ -6413,10 +6409,7 @@
     "message": "Your recovery phrase is the master key",
     "description": "Recovery section title"
   },
-  "whatIsAWallet.recovery.text1": {
-    "message": "When you create a non-custodial wallet you receive a list of 12, 15, or 24 words. This is your **recovery phrase**, also called a seed phrase. It is a human-readable form of your private key.",
-    "description": "Recovery paragraph 1"
-  },
+  "whatIsAWallet.recovery.text1": {"message": "When you create a non-custodial wallet you receive a list of 12, 15, or 24 words. This is your **recovery phrase**, also called a [seed phrase](/glossary/seed-phrase). It is a human-readable form of your private key.", "description": "Recovery paragraph 1"},
   "whatIsAWallet.recovery.text2": {
     "message": "Anyone with these words can restore your wallet on any device and take your funds. Write the phrase down and store it offline. Never type it into a website, never store it in a photo or cloud note, and never share it with anyone.",
     "description": "Recovery paragraph 2"
@@ -6449,10 +6442,7 @@
     "message": "Connecting to apps",
     "description": "dApps section title"
   },
-  "whatIsAWallet.dapps.text1": {
-    "message": "Most Cardano wallets include a **dApp connector**. It lets a website ask your wallet to sign a transaction without ever seeing your private keys.",
-    "description": "dApps paragraph 1"
-  },
+  "whatIsAWallet.dapps.text1": {"message": "Most Cardano wallets include a **DApp connector**. It lets a website or [DApp](/glossary/dapp) ask your wallet to sign a transaction without ever seeing your private keys.", "description": "dApps paragraph 1"},
   "whatIsAWallet.dapps.text2": {
     "message": "You stay in control: the wallet shows you exactly what you are approving, and nothing happens until you confirm. Always check the site address and review each request before you sign.",
     "description": "dApps paragraph 2"
@@ -9743,5 +9733,16 @@
   },
   "stablecoins.ecosystem.defiLink": {
     "message": "Stablecoins are one building block of [DeFi on Cardano](/defi), and most trading and lending on Cardano is priced in them."
-  }
+  },
+  "whereToGetAda.learn.description": {"message": "New to Cardano? [What is Cardano](/what-is-cardano#get-started) explains the platform in plain terms, and the [learning path](/learn) takes you on from there step by step."},
+  "whereToGetAda.quiz.title": {"message": "Test what you learned"},
+  "whereToGetAda.quiz.buttonText": {"message": "Start quiz"},
+  "whatIsAWallet.dapps.text3": {"message": "How DApps work, and how to use them safely, is explained in the [smart contracts](/smart-contracts#safety) explainer."},
+  "whatIsAWallet.next.description": {"message": "Next step: find out [where to get ada](/where-to-get-ada). New to Cardano altogether? Start with [what Cardano is](/what-is-cardano#get-started) and follow the [learning path](/learn)."},
+  "whatIsAWallet.quiz.title": {"message": "Test what you learned"},
+  "whatIsAWallet.quiz.buttonText": {"message": "Start quiz"},
+  "walletFinder.nextTeaser.text": {"message": "Already have a wallet? The next step is getting some ada into it."},
+  "walletFinder.nextTeaser.cta": {"message": "Where to get ada"},
+  "whatIsAda.quiz.title": {"message": "Test what you learned"},
+  "whatIsAda.quiz.buttonText": {"message": "Start quiz"}
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -2576,9 +2576,7 @@
   "hardforks.content.title": {
     "message": "Cardano Hard Forks"
   },
-  "hardforks.content.description": {
-    "message": "Hard forks in Cardano do not signify division and differences within the ecosystem. On the contrary, they define a specific and collectively agreed-upon exact time (slot) when all nodes switch from the current era to a new one, applying new functions, validation rules, or parameter values. All stake pool operators need to install the upgrade, and they also have a say and must agree to it. A Cardano hard fork is, therefore, not a separation but a precise collective evolution."
-  },
+  "hardforks.content.description": {"message": "[Hard forks](/glossary/hard-fork) in Cardano do not signify division and differences within the ecosystem. On the contrary, they define a specific and collectively agreed-upon exact time ([slot](/glossary/slot)) when all nodes switch from the current era to a new one, applying new functions, validation rules, or parameter values. All stake pool operators need to install the upgrade, and they also have a say and must agree to it. A Cardano hard fork is, therefore, not a separation but a precise collective evolution."},
   "hardforks.divider.timeline": {
     "message": "Timeline"
   },
@@ -9735,5 +9733,10 @@
   "stakePoolDelegation.quiz.title": {"message": "Test what you learned"},
   "stakePoolDelegation.quiz.buttonText": {"message": "Start quiz"},
   "stakePoolOperation.goDeeper.description": {"message": "How a pool is chosen to produce a block, and how rewards are calculated and paid out, is explained step by step in [how Cardano works](/how-cardano-works#consensus)."},
-  "calculator.context.description": {"message": "Rewards are paid out once per [epoch](/glossary/epoch), five days on Cardano. Where they come from is explained on the [stake delegation](/stake-pool-delegation) page and, in more depth, in [how Cardano works](/how-cardano-works#network)."}
+  "calculator.context.description": {"message": "Rewards are paid out once per [epoch](/glossary/epoch), five days on Cardano. Where they come from is explained on the [stake delegation](/stake-pool-delegation) page and, in more depth, in [how Cardano works](/how-cardano-works#network)."},
+  "hardforks.upgrades.description": {"message": "Every upgrade so far went live through the [hard fork combinator](/glossary/hard-fork-combinator) while the network kept running. How an upgrade is proposed, approved through [governance](/governance) and rolled out is explained in [how Cardano works](/how-cardano-works#upgrades)."},
+  "research.intro.description": {"message": "Cardano's design rests on peer-reviewed research, from the [Ouroboros](/ouroboros) family of [proof-of-stake](/glossary/proof-of-stake) protocols to the on-chain [governance](/governance) model. The papers and specifications below are grouped by development era. For a plain-language account of what they add up to, read [how Cardano works](/how-cardano-works)."},
+  "governance.onboarding.background": {"message": "New to the topic? [Who created Cardano and who runs it now](/what-is-cardano#history) gives the background in plain language, and the glossary explains what a [DRep](/glossary/drep), a [governance action](/glossary/governance-action) and the [constitution](/glossary/constitution) are."},
+  "apps.guidedPaths.smartContracts": {"message": "How DApps work"},
+  "layer2.context.description": {"message": "A [layer 2](/glossary/layer-2) processes transactions off the main chain and settles the outcome on the [layer 1](/glossary/layer-1). New to how the main chain runs programs? Start with the [smart contracts](/smart-contracts) explainer and [how Cardano works](/how-cardano-works)."}
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -2927,12 +2927,8 @@
   "stakePoolDelegation.whatIsStake.divider": {
     "message": "What is stake?"
   },
-  "stakePoolDelegation.whatIsStake.text1": {
-    "message": "Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to delegate or pledge a stake is fundamental to how Cardano works."
-  },
-  "stakePoolDelegation.whatIsStake.text2": {
-    "message": "There are two ways an ada holder can earn rewards: by delegating their stake to a stake pool run by someone else, or running their own stake pool. The amount of stake delegated to a given stake pool is the primary way the Ouroboros protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so."
-  },
+  "stakePoolDelegation.whatIsStake.text1": {"message": "Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to [delegate](/glossary/delegation) or pledge a stake is fundamental to how Cardano works."},
+  "stakePoolDelegation.whatIsStake.text2": {"message": "There are two ways an ada holder can earn rewards: by delegating their stake to a [stake pool](/glossary/stake-pool) run by someone else, or running their own stake pool. The amount of stake delegated to a given stake pool is the primary way the [Ouroboros](/glossary/ouroboros) protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so."},
   "stakePoolDelegation.whatIsStake.text3": {
     "message": "The more stake is delegated to a stake pool (up to a certain point), the more likely it is to make the next block – and the rewards are shared between everyone who delegated their stake to that stake pool."
   },
@@ -2984,12 +2980,8 @@
   "stakePoolOperation.whatIsStaking.leftText": {
     "message": "Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to delegate or pledge a stake is fundamental to how Cardano works."
   },
-  "stakePoolOperation.whatIsStaking.rightText1": {
-    "message": "There are two ways an ada holder can earn rewards: by delegating their stake to a stake pool run by someone else, or by running their own stake pool."
-  },
-  "stakePoolOperation.whatIsStaking.rightText2": {
-    "message": "The amount of stake delegated to a given stake pool is the primary way the Ouroboros protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so."
-  },
+  "stakePoolOperation.whatIsStaking.rightText1": {"message": "There are two ways an ada holder can earn rewards: by delegating their stake to a [stake pool](/glossary/stake-pool) run by someone else, or by running their own stake pool."},
+  "stakePoolOperation.whatIsStaking.rightText2": {"message": "The amount of stake delegated to a given stake pool is the primary way the [Ouroboros](/glossary/ouroboros) protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so."},
   "stakePoolOperation.whatIsStaking.rightText3": {
     "message": "The more stake is delegated to a stake pool (up to a certain point), the more likely it is to make the next block – and the rewards that it earns are shared between everyone who delegated their stake to that stake pool."
   },
@@ -3002,18 +2994,14 @@
   "stakePoolOperation.whatIsStakePool.text2": {
     "message": "Stake pools are run by a reliable operator: an individual or business with the knowledge and resources to run the node on a consistent basis. Ada holders can delegate to public stake pools if they wish to participate in the protocol and receive rewards, but do not wish to operate a Cardano network node themselves."
   },
-  "stakePoolOperation.whatIsStakePool.text3": {
-    "message": "The more stake that is delegated to a stake pool, the greater chance it has of being selected as a slot leader. Each time it is selected and produces a block that is accepted onto the blockchain, it is rewarded, and these rewards are shared between the stake pool operator and stake pool delegators."
-  },
+  "stakePoolOperation.whatIsStakePool.text3": {"message": "The more stake that is delegated to a stake pool, the greater chance it has of being selected as a [slot leader](/glossary/slot-leader). Each time it is selected and produces a block that is accepted onto the blockchain, it is rewarded, and these rewards are shared between the stake pool operator and stake pool delegators."},
   "stakePoolOperation.whatIsStakePool.text4": {
     "message": "Extensive research and development has gone into ensuring a fair, competitive marketplace that proportionately incentivizes participation, and rewards the investment of time, energy, and resources. The key technical parameters influencing stake pools and the rewards received are:"
   },
   "stakePoolOperation.pledging.title": {
     "message": "Pledging Mechanism"
   },
-  "stakePoolOperation.pledging.text": {
-    "message": "While there is no required minimum pledge amount, pool operators can optionally pledge some or all of their stake to their pool to make their pool more attractive. The higher the amount of ada pledged, the more rewards the pool will receive, which will attract more delegation. The a0 protocol parameter defines the influence of the pledge on the pool reward."
-  },
+  "stakePoolOperation.pledging.text": {"message": "While there is no required minimum pledge amount, pool operators can optionally [pledge](/glossary/pledge) some or all of their stake to their pool to make their pool more attractive. The higher the amount of ada pledged, the more rewards the pool will receive, which will attract more delegation. The a0 protocol parameter defines the influence of the pledge on the pool reward."},
   "stakePoolOperation.desirability.title": {
     "message": "Desirability Index"
   },
@@ -3023,9 +3011,7 @@
   "stakePoolOperation.saturation.title": {
     "message": "Saturation Parameter (K)"
   },
-  "stakePoolOperation.saturation.text": {
-    "message": "Saturation is a term used to indicate that a particular stake pool has more stake delegated to it than is ideal for the network, while k is the targeted number of desired pools. Once a pool reaches the point of saturation, it will offer diminishing rewards. The saturation mechanism was designed to prevent centralization by encouraging delegators to delegate to different stake pools, and to incentivize operators to set up alternative pools so that they can continue earning maximum rewards. Saturation, therefore, exists to preserve the interests of both ada holders delegating their stake and stake pool operators, and to prevent any single pool from becoming too large."
-  },
+  "stakePoolOperation.saturation.text": {"message": "[Saturation](/glossary/pool-saturation) is a term used to indicate that a particular stake pool has more stake delegated to it than is ideal for the network, while k is the targeted number of desired pools. Once a pool reaches the point of saturation, it will offer diminishing rewards. The saturation mechanism was designed to prevent centralization by encouraging delegators to delegate to different stake pools, and to incentivize operators to set up alternative pools so that they can continue earning maximum rewards. Saturation, therefore, exists to preserve the interests of both ada holders delegating their stake and stake pool operators, and to prevent any single pool from becoming too large."},
   "stakePoolOperation.setupCta.title": {
     "message": "How do I set up a stake pool?"
   },
@@ -9744,5 +9730,10 @@
   "walletFinder.nextTeaser.text": {"message": "Already have a wallet? The next step is getting some ada into it."},
   "walletFinder.nextTeaser.cta": {"message": "Where to get ada"},
   "whatIsAda.quiz.title": {"message": "Test what you learned"},
-  "whatIsAda.quiz.buttonText": {"message": "Start quiz"}
+  "whatIsAda.quiz.buttonText": {"message": "Start quiz"},
+  "stakePoolDelegation.goDeeper.description": {"message": "Go deeper: [how the protocol picks who produces the next block](/how-cardano-works#consensus) and [how rewards flow through the network](/how-cardano-works#network)."},
+  "stakePoolDelegation.quiz.title": {"message": "Test what you learned"},
+  "stakePoolDelegation.quiz.buttonText": {"message": "Start quiz"},
+  "stakePoolOperation.goDeeper.description": {"message": "How a pool is chosen to produce a block, and how rewards are calculated and paid out, is explained step by step in [how Cardano works](/how-cardano-works#consensus)."},
+  "calculator.context.description": {"message": "Rewards are paid out once per [epoch](/glossary/epoch), five days on Cardano. Where they come from is explained on the [stake delegation](/stake-pool-delegation) page and, in more depth, in [how Cardano works](/how-cardano-works#network)."}
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -9738,5 +9738,6 @@
   "research.intro.description": {"message": "Cardano's design rests on peer-reviewed research, from the [Ouroboros](/ouroboros) family of [proof-of-stake](/glossary/proof-of-stake) protocols to the on-chain [governance](/governance) model. The papers and specifications below are grouped by development era. For a plain-language account of what they add up to, read [how Cardano works](/how-cardano-works)."},
   "governance.onboarding.background": {"message": "New to the topic? [Who created Cardano and who runs it now](/what-is-cardano#history) gives the background in plain language, and the glossary explains what a [DRep](/glossary/drep), a [governance action](/glossary/governance-action) and the [constitution](/glossary/constitution) are."},
   "apps.guidedPaths.smartContracts": {"message": "How DApps work"},
-  "layer2.context.description": {"message": "A [layer 2](/glossary/layer-2) processes transactions off the main chain and settles the outcome on the [layer 1](/glossary/layer-1). New to how the main chain runs programs? Start with the [smart contracts](/smart-contracts) explainer and [how Cardano works](/how-cardano-works)."}
+  "layer2.context.description": {"message": "A [layer 2](/glossary/layer-2) processes transactions off the main chain and settles the outcome on the [layer 1](/glossary/layer-1). New to how the main chain runs programs? Start with the [smart contracts](/smart-contracts) explainer and [how Cardano works](/how-cardano-works)."},
+  "quiz.hub.backToLearn": {"message": "Back to the learning path"}
 }

--- a/src/pages/apps/index.js
+++ b/src/pages/apps/index.js
@@ -466,6 +466,13 @@ function GuidedPathsBanner() {
       }),
     },
     {
+      to: "/smart-contracts#dapps",
+      label: translate({
+        id: "apps.guidedPaths.smartContracts",
+        message: "How DApps work",
+      }),
+    },
+    {
       to: "/governance#paths",
       label: translate({
         id: "apps.guidedPaths.governance",

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -5,6 +5,7 @@ import TitleWithText from "@site/src/components/Layout/TitleWithText";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
 import React, { useEffect, useRef } from "react";
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { translate } from '@docusaurus/Translate';
 
 // Translation dictionary for calculator-specific content
 const translations = {
@@ -84,6 +85,9 @@ export default function Home() {
             titleType="black"
             description={t.rewardDescription}
             headingDot={true}
+          />
+          <TitleWithText
+            description={translate({id: 'calculator.context.description', message: "Rewards are paid out once per [epoch](/glossary/epoch), five days on Cardano. Where they come from is explained on the [stake delegation](/stake-pool-delegation) page and, in more depth, in [how Cardano works](/how-cardano-works#network)."})}
           />
         </BoundaryBox>
         {/* Pass the lang parameter dynamically */}

--- a/src/pages/governance.js
+++ b/src/pages/governance.js
@@ -15,6 +15,7 @@ import DelegationFlow from "@site/src/components/DelegationFlow";
 import RoleCard from "@site/src/components/Layout/RoleCard";
 import ConnectionLine from "@site/src/components/Layout/ConnectionLine";
 import HighlightCallout from "@site/src/components/Layout/HighlightCallout";
+import TitleWithText from "@site/src/components/Layout/TitleWithText";
 import AppTile, { StarBadge } from "@site/src/components/AppTile";
 import { Showcases } from "@site/src/data/apps";
 import { compareByActivityThenPick } from "@site/src/utils/appStats";
@@ -84,6 +85,9 @@ function GovernanceRolesSection() {
       <p className="black-text">
         {translate({id: 'governance.onboarding.intro', message: 'Cardano is governed by its community. Three groups vote on proposals that shape the network. Together, they decide on everything from protocol upgrades to treasury funding.'})}
       </p>
+      <TitleWithText
+        description={translate({id: 'governance.onboarding.background', message: "New to the topic? [Who created Cardano and who runs it now](/what-is-cardano#history) gives the background in plain language, and the glossary explains what a [DRep](/glossary/drep), a [governance action](/glossary/governance-action) and the [constitution](/glossary/constitution) are."})}
+      />
       <SpacerBox size="small" />
 
       <div className={styles.rolesTriangle}>

--- a/src/pages/hardforks.js
+++ b/src/pages/hardforks.js
@@ -254,9 +254,16 @@ export default function Home() {
             description={translate({
               id: "hardforks.content.description",
               message:
-                "Hard forks in Cardano do not signify division and differences within the ecosystem. On the contrary, they define a specific and collectively agreed-upon exact time (slot) when all nodes switch from the current era to a new one, applying new functions, validation rules, or parameter values. All stake pool operators need to install the upgrade, and they also have a say and must agree to it. A Cardano hard fork is, therefore, not a separation but a precise collective evolution.",
+                "[Hard forks](/glossary/hard-fork) in Cardano do not signify division and differences within the ecosystem. On the contrary, they define a specific and collectively agreed-upon exact time ([slot](/glossary/slot)) when all nodes switch from the current era to a new one, applying new functions, validation rules, or parameter values. All stake pool operators need to install the upgrade, and they also have a say and must agree to it. A Cardano hard fork is, therefore, not a separation but a precise collective evolution.",
             })}
             headingDot={true}
+          />
+          <TitleWithText
+            description={translate({
+              id: "hardforks.upgrades.description",
+              message:
+                "Every upgrade so far went live through the [hard fork combinator](/glossary/hard-fork-combinator) while the network kept running. How an upgrade is proposed, approved through [governance](/governance) and rolled out is explained in [how Cardano works](/how-cardano-works#upgrades).",
+            })}
           />
           <Divider
             text={translate({ id: "hardforks.divider.timeline", message: "Timeline" })}

--- a/src/pages/layer-2.js
+++ b/src/pages/layer-2.js
@@ -85,6 +85,15 @@ export default function Layer2() {
             <CategoryHeader category={Sidechains} />
             <CardGrid projects={Sidechains.projects} />
           </BoundaryBox>
+          <BoundaryBox>
+            <TitleWithText
+              description={translate({
+                id: "layer2.context.description",
+                message:
+                  "A [layer 2](/glossary/layer-2) processes transactions off the main chain and settles the outcome on the [layer 1](/glossary/layer-1). New to how the main chain runs programs? Start with the [smart contracts](/smart-contracts) explainer and [how Cardano works](/how-cardano-works).",
+              })}
+            />
+          </BoundaryBox>
           <SpacerBox size="medium" />
         </BackgroundWrapper>
 

--- a/src/pages/quiz.js
+++ b/src/pages/quiz.js
@@ -30,6 +30,11 @@ export default function QuizPage() {
         <BoundaryBox>
           <QuizHub />
           <SpacerBox size="medium" />
+          <p className={styles.learnLink}>
+            <Link to="/learn">
+              {translate({id: 'quiz.hub.backToLearn', message: 'Back to the learning path'})}
+            </Link>
+          </p>
           <div className={styles.academyBanner}>
             <p>{translate({id: 'quiz.hub.academyBanner', message: 'Ready for the next step? The Cardano Academy offers free courses with real certificates.'})}</p>
             {/* The paragraph above already names the Academy, so the button

--- a/src/pages/quiz.module.css
+++ b/src/pages/quiz.module.css
@@ -1,3 +1,9 @@
+.learnLink {
+  margin: 0 0 var(--site-space-md);
+  text-align: center;
+  font-weight: 600;
+}
+
 .academyBanner {
   display: flex;
   flex-wrap: wrap;

--- a/src/pages/research.js
+++ b/src/pages/research.js
@@ -3,6 +3,7 @@ import SiteHero from "@site/src/components/Layout/SiteHero";
 import ResearchSection from "@site/src/components/ResearchSection";
 import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
 import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
+import TitleWithText from "@site/src/components/Layout/TitleWithText";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
 import {translate} from '@docusaurus/Translate';
 
@@ -29,6 +30,9 @@ export default function Home() {
       <main>
         <BackgroundWrapper backgroundType="zoom">
           <BoundaryBox>
+            <TitleWithText
+              description={translate({id: 'research.intro.description', message: "Cardano's design rests on peer-reviewed research, from the [Ouroboros](/ouroboros) family of [proof-of-stake](/glossary/proof-of-stake) protocols to the on-chain [governance](/governance) model. The papers and specifications below are grouped by development era. For a plain-language account of what they add up to, read [how Cardano works](/how-cardano-works)."})}
+            />
             <ResearchSection />
           </BoundaryBox>
         </BackgroundWrapper>

--- a/src/pages/stake-pool-delegation.js
+++ b/src/pages/stake-pool-delegation.js
@@ -3,6 +3,7 @@ import Layout from "@theme/Layout";
 import SiteHero from "@site/src/components/Layout/SiteHero";
 import Divider from "@site/src/components/Layout/Divider";
 import OneColumnBox from "@site/src/components/Layout/OneColumnBox";
+import TitleWithText from "@site/src/components/Layout/TitleWithText";
 import TwoColumnBox from "@site/src/components/Layout/TwoColumnBox";
 import BackgroundWrapper from "@site/src/components/Layout/BackgroundWrapper";
 import CtaOneColumn from "@site/src/components/Layout/CtaOneColumn";
@@ -11,6 +12,9 @@ import FAQSection from "@site/src/components/FAQSection";
 import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
+import QuizCard from "@site/src/components/QuizCard";
+import { getQuizData as getStakingQuiz } from "@site/src/data/quiz/generated/staking";
+import { parseMarkdownLikeText } from "@site/src/utils/textUtils";
 import {translate} from '@docusaurus/Translate';
 
 function getDelegationFAQData() {
@@ -112,6 +116,7 @@ function HomepageHeader() {
 }
 
 export default function Home() {
+  const stakingQuiz = getStakingQuiz();
 
   return (
     <Layout
@@ -124,12 +129,13 @@ export default function Home() {
         <BackgroundWrapper backgroundType={"solidGrey"}>
           <BoundaryBox>
             <Divider text={translate({id: 'stakePoolDelegation.whatIsStake.divider', message: 'What is stake?'})} />
+            {/* OneColumnBox renders plain strings, so the glossary links are parsed here */}
             <OneColumnBox
-              text={[
-                translate({id: 'stakePoolDelegation.whatIsStake.text1', message: 'Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to delegate or pledge a stake is fundamental to how Cardano works.'}),
-                translate({id: 'stakePoolDelegation.whatIsStake.text2', message: 'There are two ways an ada holder can earn rewards: by delegating their stake to a stake pool run by someone else, or running their own stake pool. The amount of stake delegated to a given stake pool is the primary way the Ouroboros protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so.'}),
+              text={parseMarkdownLikeText([
+                translate({id: 'stakePoolDelegation.whatIsStake.text1', message: 'Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to [delegate](/glossary/delegation) or pledge a stake is fundamental to how Cardano works.'}),
+                translate({id: 'stakePoolDelegation.whatIsStake.text2', message: 'There are two ways an ada holder can earn rewards: by delegating their stake to a [stake pool](/glossary/stake-pool) run by someone else, or running their own stake pool. The amount of stake delegated to a given stake pool is the primary way the [Ouroboros](/glossary/ouroboros) protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so.'}),
                 translate({id: 'stakePoolDelegation.whatIsStake.text3', message: 'The more stake is delegated to a stake pool (up to a certain point), the more likely it is to make the next block – and the rewards are shared between everyone who delegated their stake to that stake pool.'}),
-              ]}
+              ])}
             />
           </BoundaryBox>
         </BackgroundWrapper>
@@ -148,6 +154,9 @@ export default function Home() {
               leftText={[
                 translate({id: 'stakePoolDelegation.whyIncentives.text', message: 'Incentives are used to ensure the longevity and health of the Cardano network and ecosystem. The incentive mechanism is underpinned by scientific research that combines mathematics, economic theory, and game theory.'}),
               ]}
+            />
+            <TitleWithText
+              description={translate({id: 'stakePoolDelegation.goDeeper.description', message: "Go deeper: [how the protocol picks who produces the next block](/how-cardano-works#consensus) and [how rewards flow through the network](/how-cardano-works#network)."})}
             />
           </BoundaryBox>
         </BackgroundWrapper>
@@ -177,6 +186,15 @@ export default function Home() {
 
         <BoundaryBox>
           <FAQSection data={getDelegationFAQData()} />
+          <SpacerBox size="medium" />
+          <QuizCard
+            quizData={stakingQuiz}
+            title={translate({id: 'stakePoolDelegation.quiz.title', message: "Test what you learned"})}
+            description={stakingQuiz.description}
+            buttonText={translate({id: 'stakePoolDelegation.quiz.buttonText', message: "Start quiz"})}
+            questionCount={stakingQuiz.questionCount}
+            allowRetry={false}
+          />
           <SpacerBox size="medium" />
         </BoundaryBox>
       </main>

--- a/src/pages/stake-pool-operation.js
+++ b/src/pages/stake-pool-operation.js
@@ -3,6 +3,7 @@ import SiteHero from "@site/src/components/Layout/SiteHero";
 import Divider from "@site/src/components/Layout/Divider";
 import OneColumnBox from "@site/src/components/Layout/OneColumnBox";
 import TwoColumnBox from "@site/src/components/Layout/TwoColumnBox";
+import TitleWithText from "@site/src/components/Layout/TitleWithText";
 import CtaOneColumn from "@site/src/components/Layout/CtaOneColumn";
 import CtaTwoColumn from "@site/src/components/Layout/CtaTwoColumn";
 import DottedImageWithText from "@site/src/components/Layout/DottedImageWithText";
@@ -11,6 +12,7 @@ import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
 import FAQSection from "@site/src/components/FAQSection";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
+import { parseMarkdownLikeText } from "@site/src/utils/textUtils";
 import { translate } from '@docusaurus/Translate';
 
 function HomepageHeader() {
@@ -41,15 +43,19 @@ export default function Home() {
         <BackgroundWrapper backgroundType={"solidGrey"}>
           <BoundaryBox>
             <Divider text={translate({ id: 'stakePoolOperation.whatIsStaking.divider', message: 'What is staking?' })} />
+            {/* TwoColumnBox renders plain strings, so the glossary links are parsed here */}
             <TwoColumnBox
-              leftText={[
+              leftText={parseMarkdownLikeText([
                 translate({ id: 'stakePoolOperation.whatIsStaking.leftText', message: 'Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to delegate or pledge a stake is fundamental to how Cardano works.' }),
-              ]}
-              rightText={[
-                translate({ id: 'stakePoolOperation.whatIsStaking.rightText1', message: 'There are two ways an ada holder can earn rewards: by delegating their stake to a stake pool run by someone else, or by running their own stake pool.' }),
-                translate({ id: 'stakePoolOperation.whatIsStaking.rightText2', message: 'The amount of stake delegated to a given stake pool is the primary way the Ouroboros protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so.' }),
+              ])}
+              rightText={parseMarkdownLikeText([
+                translate({ id: 'stakePoolOperation.whatIsStaking.rightText1', message: 'There are two ways an ada holder can earn rewards: by delegating their stake to a [stake pool](/glossary/stake-pool) run by someone else, or by running their own stake pool.' }),
+                translate({ id: 'stakePoolOperation.whatIsStaking.rightText2', message: 'The amount of stake delegated to a given stake pool is the primary way the [Ouroboros](/glossary/ouroboros) protocol chooses who should add the next block to the blockchain, and receive a monetary reward for doing so.' }),
                 translate({ id: 'stakePoolOperation.whatIsStaking.rightText3', message: 'The more stake is delegated to a stake pool (up to a certain point), the more likely it is to make the next block – and the rewards that it earns are shared between everyone who delegated their stake to that stake pool.' }),
-              ]}
+              ])}
+            />
+            <TitleWithText
+              description={translate({id: 'stakePoolOperation.goDeeper.description', message: "How a pool is chosen to produce a block, and how rewards are calculated and paid out, is explained step by step in [how Cardano works](/how-cardano-works#consensus)."})}
             />
           </BoundaryBox>
         </BackgroundWrapper>
@@ -58,18 +64,18 @@ export default function Home() {
           <BoundaryBox>
             <Divider text={translate({ id: 'stakePoolOperation.whatIsStakePool.divider', message: 'What is stake pool?' })} />
             <OneColumnBox
-              text={[
+              text={parseMarkdownLikeText([
                 translate({ id: 'stakePoolOperation.whatIsStakePool.text1', message: 'Stake pools may be either public or private. A public stake pool is a Cardano network node with a public address that other users can delegate to, and receive rewards. Private stake pools only deliver rewards to their owners.' }),
                 translate({ id: 'stakePoolOperation.whatIsStakePool.text2', message: 'Stake pools are run by a reliable operator: an individual or business with the knowledge and resources to run the node on a consistent basis. Ada holders can delegate to public stake pools if they wish to participate in the protocol and receive rewards, but do not wish to operate a Cardano network node themselves.' }),
-                translate({ id: 'stakePoolOperation.whatIsStakePool.text3', message: 'The more stake that is delegated to a stake pool, the greater chance it has of being selected as a slot leader. Each time it is selected and produces a block that is accepted onto the blockchain, it is rewarded, and these rewards are shared between the stake pool operator and stake pool delegators.' }),
+                translate({ id: 'stakePoolOperation.whatIsStakePool.text3', message: 'The more stake that is delegated to a stake pool, the greater chance it has of being selected as a [slot leader](/glossary/slot-leader). Each time it is selected and produces a block that is accepted onto the blockchain, it is rewarded, and these rewards are shared between the stake pool operator and stake pool delegators.' }),
                 translate({ id: 'stakePoolOperation.whatIsStakePool.text4', message: 'Extensive research and development has gone into ensuring a fair, competitive marketplace that proportionately incentivizes participation, and rewards the investment of time, energy, and resources. The key technical parameters influencing stake pools and the rewards received are:' }),
-              ]}
+              ])}
             />
             <DottedImageWithText
               imageName="pledging"
               title={translate({ id: 'stakePoolOperation.pledging.title', message: 'Pledging Mechanism' })}
               text={[
-                translate({ id: 'stakePoolOperation.pledging.text', message: 'While there is no required minimum pledge amount, pool operators can optionally pledge some or all of their stake to their pool to make their pool more attractive. The higher the amount of ada pledged, the more rewards the pool will receive, which will attract more delegation. The a0 protocol parameter defines the influence of the pledge on the pool reward.' }),
+                translate({ id: 'stakePoolOperation.pledging.text', message: 'While there is no required minimum pledge amount, pool operators can optionally [pledge](/glossary/pledge) some or all of their stake to their pool to make their pool more attractive. The higher the amount of ada pledged, the more rewards the pool will receive, which will attract more delegation. The a0 protocol parameter defines the influence of the pledge on the pool reward.' }),
               ]}
             />
             <DottedImageWithText
@@ -83,7 +89,7 @@ export default function Home() {
               imageName="saturation"
               title={translate({ id: 'stakePoolOperation.saturation.title', message: 'Saturation Parameter (K)' })}
               text={[
-                translate({ id: 'stakePoolOperation.saturation.text', message: 'Saturation is a term used to indicate that a particular stake pool has more stake delegated to it than is ideal for the network, while k is the targeted number of desired pools. Once a pool reaches the point of saturation, it will offer diminishing rewards. The saturation mechanism was designed to prevent centralization by encouraging delegators to delegate to different stake pools, and to incentivize operators to set up alternative pools so that they can continue earning maximum rewards. Saturation, therefore, exists to preserve the interests of both ada holders delegating their stake and stake pool operators, and to prevent any single pool from becoming too large.' }),
+                translate({ id: 'stakePoolOperation.saturation.text', message: '[Saturation](/glossary/pool-saturation) is a term used to indicate that a particular stake pool has more stake delegated to it than is ideal for the network, while k is the targeted number of desired pools. Once a pool reaches the point of saturation, it will offer diminishing rewards. The saturation mechanism was designed to prevent centralization by encouraging delegators to delegate to different stake pools, and to incentivize operators to set up alternative pools so that they can continue earning maximum rewards. Saturation, therefore, exists to preserve the interests of both ada holders delegating their stake and stake pool operators, and to prevent any single pool from becoming too large.' }),
               ]}
             />
           </BoundaryBox>

--- a/src/pages/wallets/index.js
+++ b/src/pages/wallets/index.js
@@ -306,6 +306,17 @@ export default function WalletFinder() {
               {translate({ id: "walletFinder.learnTeaser.cta", message: "What is a Wallet?" })}
             </Link>
           </div>
+          <div className={styles.learnTeaser}>
+            <p className={styles.learnTeaserText}>
+              {translate({
+                id: "walletFinder.nextTeaser.text",
+                message: "Already have a wallet? The next step is getting some ada into it.",
+              })}
+            </p>
+            <Link className="button button--primary" to="/where-to-get-ada">
+              {translate({ id: "walletFinder.nextTeaser.cta", message: "Where to get ada" })}
+            </Link>
+          </div>
         </BoundaryBox>
         <SpacerBox size="medium" />
       </main>

--- a/src/pages/what-is-a-wallet.js
+++ b/src/pages/what-is-a-wallet.js
@@ -10,6 +10,8 @@ import DottedImageWithText from "@site/src/components/Layout/DottedImageWithText
 import Divider from "@site/src/components/Layout/Divider";
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
 import FAQSection from "@site/src/components/FAQSection";
+import QuizCard from "@site/src/components/QuizCard";
+import { getQuizData as getWalletsQuiz } from "@site/src/data/quiz/generated/wallets";
 
 const META_TITLE = translate({
   id: "whatIsAWallet.meta.title",
@@ -22,6 +24,7 @@ const META_DESCRIPTION = translate({
 });
 
 export default function WhatIsAWallet() {
+  const walletsQuiz = getWalletsQuiz();
   return (
     <Layout title={META_TITLE} description={META_DESCRIPTION}>
       <OpenGraphInfo pageName="what-is-a-wallet" />
@@ -143,7 +146,7 @@ export default function WhatIsAWallet() {
                 translate({
                   id: "whatIsAWallet.recovery.text1",
                   message:
-                    "When you create a non-custodial wallet you receive a list of 12, 15, or 24 words. This is your **recovery phrase**, also called a seed phrase. It is a human-readable form of your private key.",
+                    "When you create a non-custodial wallet you receive a list of 12, 15, or 24 words. This is your **recovery phrase**, also called a [seed phrase](/glossary/seed-phrase). It is a human-readable form of your private key.",
                 }),
                 translate({
                   id: "whatIsAWallet.recovery.text2",
@@ -195,12 +198,17 @@ export default function WhatIsAWallet() {
               translate({
                 id: "whatIsAWallet.dapps.text1",
                 message:
-                  "Most Cardano wallets include a **dApp connector**. It lets a website ask your wallet to sign a transaction without ever seeing your private keys.",
+                  "Most Cardano wallets include a **DApp connector**. It lets a website or [DApp](/glossary/dapp) ask your wallet to sign a transaction without ever seeing your private keys.",
               }),
               translate({
                 id: "whatIsAWallet.dapps.text2",
                 message:
                   "You stay in control: the wallet shows you exactly what you are approving, and nothing happens until you confirm. Always check the site address and review each request before you sign.",
+              }),
+              translate({
+                id: "whatIsAWallet.dapps.text3",
+                message:
+                  "How DApps work, and how to use them safely, is explained in the [smart contracts](/smart-contracts#safety) explainer.",
               }),
             ]}
             titleType="black"
@@ -298,6 +306,23 @@ export default function WhatIsAWallet() {
                 ],
               },
             ]}
+          />
+          <SpacerBox size="medium" />
+          <TitleWithText
+            description={translate({
+              id: "whatIsAWallet.next.description",
+              message:
+                "Next step: find out [where to get ada](/where-to-get-ada). New to Cardano altogether? Start with [what Cardano is](/what-is-cardano#get-started) and follow the [learning path](/learn).",
+            })}
+          />
+          <SpacerBox size="small" />
+          <QuizCard
+            quizData={walletsQuiz}
+            title={translate({ id: "whatIsAWallet.quiz.title", message: "Test what you learned" })}
+            description={walletsQuiz.description}
+            buttonText={translate({ id: "whatIsAWallet.quiz.buttonText", message: "Start quiz" })}
+            questionCount={walletsQuiz.questionCount}
+            allowRetry={false}
           />
           <SpacerBox size="medium" />
           <TitleWithText

--- a/src/pages/what-is-ada.js
+++ b/src/pages/what-is-ada.js
@@ -7,6 +7,8 @@ import BoundaryBox from "@site/src/components/Layout/BoundaryBox";
 import TitleWithText from "@site/src/components/Layout/TitleWithText";
 import OpenGraphInfo from "@site/src/components/Layout/OpenGraphInfo";
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
+import QuizCard from "@site/src/components/QuizCard";
+import { getQuizData as getBasicsQuiz } from "@site/src/data/quiz/generated/basics";
 import {translate} from '@docusaurus/Translate';
 
 function HomepageHeader() {
@@ -24,6 +26,7 @@ function HomepageHeader() {
 }
 
 export default function Home() {
+  const basicsQuiz = getBasicsQuiz();
 
   return (
     <Layout
@@ -51,6 +54,16 @@ export default function Home() {
         <HowToBuyAdaSection />
         <BoundaryBox>
           <WalletSection />
+        </BoundaryBox>
+        <BoundaryBox>
+          <QuizCard
+            quizData={basicsQuiz}
+            title={translate({id: 'whatIsAda.quiz.title', message: "Test what you learned"})}
+            description={basicsQuiz.description}
+            buttonText={translate({id: 'whatIsAda.quiz.buttonText', message: "Start quiz"})}
+            questionCount={basicsQuiz.questionCount}
+            allowRetry={false}
+          />
         </BoundaryBox>
         <SpacerBox size="medium" />
       </main>

--- a/src/pages/where-to-get-ada.js
+++ b/src/pages/where-to-get-ada.js
@@ -8,6 +8,8 @@ import Divider from "@site/src/components/Layout/Divider";
 import SpacerBox from "@site/src/components/Layout/SpacerBox";
 import ExchangePicker from "@site/src/components/ExchangePicker";
 import AppGrid from "@site/src/components/AppGrid";
+import QuizCard from "@site/src/components/QuizCard";
+import { getQuizData as getSecurityQuiz } from "@site/src/data/quiz/generated/security";
 import {translate} from '@docusaurus/Translate';
 
 function HomepageHeader() {
@@ -23,6 +25,7 @@ function HomepageHeader() {
 }
 
 export default function Home() {
+  const securityQuiz = getSecurityQuiz();
 
   return (
     <Layout
@@ -125,12 +128,27 @@ export default function Home() {
                 title={translate({id: 'whereToGetAda.staking.title', message: 'Staking rewards'})}
                 description={[
 
-                 translate({id: 'whereToGetAda.staking.description1', message: 'If you already have some [ada](/what-is-ada/), you can earn more by [delegating your ada to a stake pool](/stake-pool-delegation/). This allows you to participate in the network\'s proof-of-stake system and earn rewards. Alternatively, you can [run your own stake pool](/stake-pool-operation/), which requires more effort and technical knowledge but can be more rewarding.'}),
-                 translate({id: 'whereToGetAda.staking.description2', message: 'Cardano offers several advantages for staking: there is no minimum amount of [ada](/what-is-ada/) required to stake, no risk of slashing (losing your staked [ada](/what-is-ada/)), and no locking period. You always maintain custody over your delegated [ada](/what-is-ada/), ensuring that your funds remain secure and accessible at all times. Additionally, rewards are distributed by the protocol itself, not by the pools, ensuring a fair and transparent distribution process.'})
+                 translate({id: 'whereToGetAda.staking.description1', message: 'If you already have some [ada](/what-is-ada/), you can earn more by [delegating your ada to a stake pool](/stake-pool-delegation/). This allows you to participate in the network\'s [proof-of-stake](/glossary/proof-of-stake) system and earn rewards. Alternatively, you can [run your own stake pool](/stake-pool-operation/), which requires more effort and technical knowledge but can be more rewarding.'}),
+                 translate({id: 'whereToGetAda.staking.description2', message: 'Cardano offers several advantages for [staking](/glossary/staking): there is no minimum amount of [ada](/what-is-ada/) required to stake, no risk of slashing (losing your staked [ada](/what-is-ada/)), and no locking period. You always maintain custody over your delegated [ada](/what-is-ada/), ensuring that your funds remain secure and accessible at all times. Additionally, rewards are distributed by the protocol itself, not by the pools, ensuring a fair and transparent distribution process.'})
 
                 ]}
                 headingDot={true}
               />
+        </BoundaryBox>
+
+        <BoundaryBox>
+            <TitleWithText
+              description={translate({id: 'whereToGetAda.learn.description', message: "New to Cardano? [What is Cardano](/what-is-cardano#get-started) explains the platform in plain terms, and the [learning path](/learn) takes you on from there step by step."})}
+            />
+            <SpacerBox size="small"/>
+            <QuizCard
+              quizData={securityQuiz}
+              title={translate({id: 'whereToGetAda.quiz.title', message: "Test what you learned"})}
+              description={securityQuiz.description}
+              buttonText={translate({id: 'whereToGetAda.quiz.buttonText', message: "Start quiz"})}
+              questionCount={securityQuiz.questionCount}
+              allowRetry={false}
+            />
         </BoundaryBox>
         <SpacerBox size="medium"/>
       </main>


### PR DESCRIPTION
- Adds contextual links from the older pages (wallets, where to get ada, delegation, pool operation, calculator, hard forks, research, governance, apps, layer 2) to the matching explainer sections and the learning path
- Adds a "Test what you learned" quiz card to the ada, wallet, where-to-get-ada and delegation pages, using the hub quizzes
- Adds a "Back to the learning path" link on the quiz hub
- Links the first mention of core terms on the older pages to their glossary entries
- The wallet finder now points onward to getting ada, so the newcomer path no longer stops there
- Fixes the "dApp connector" spelling on the wallet explainer
- Part of #831