### PR TITLE
docs: fix the contributor docs entry points and describe the Luma event sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Not suitable (without prior discussion):
 ### Start here
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
-- [AGENTS.md](AGENTS.md) – Onboarding & Guardrails for AI agents
-- [docs/](https://cardano.org/docs/) for content
+- [AGENTS.md](AGENTS.md) for onboarding and guardrails for AI agents
+- [docs/get-involved/](https://cardano.org/docs/get-involved/) for the contributor guides. The `docs/` folder also holds the use case pages (`docs/use-cases/`) and the community channel list (`docs/communities.md`)
 - [Discussions](https://github.com/cardano-foundation/cardano-org/discussions) for idea-level conversations
 
 
@@ -67,7 +67,7 @@ yarn start
 
 This command starts a local development server and opens up a browser window to http://localhost:3000. Most changes are reflected live without having to restart the server.
 
-To browse the documentation visit http://localhost:3000/docs/.
+To browse the contributor guides visit http://localhost:3000/docs/get-involved/.
 
 ## Build
 
@@ -85,7 +85,7 @@ With this command you are making it listen on all network interfaces (IP address
 
 ## Internationalization (i18n)
 
-The site supports multiple locales: English (default), Japanese (`ja`), and German (`de`).
+The site supports five locales: English (default), Japanese (`ja`), German (`de`), Spanish (`es`), and Vietnamese (`vi`). The list lives in the `i18n` block of `docusaurus.config.js`.
 
 ### Testing a specific locale in development
 
@@ -94,13 +94,15 @@ The dev server only serves one locale at a time. To test a specific locale:
 ```bash
 yarn start --locale ja   # Japanese
 yarn start --locale de   # German
+yarn start --locale es   # Spanish
+yarn start --locale vi   # Vietnamese
 ```
 
 This serves the locale at `http://localhost:3000/` (without a locale prefix).
 
 ### Testing multi-locale URL structure
 
-The `/ja/` and `/de/` URL prefixes only work in production builds. To test the full structure:
+The locale URL prefixes (`/ja/`, `/de/`, `/es/`, `/vi/`) only work in production builds. To test the full structure:
 
 ```bash
 yarn build && yarn serve
@@ -110,3 +112,5 @@ Then access:
 - `http://localhost:3000/` - English
 - `http://localhost:3000/ja/` - Japanese
 - `http://localhost:3000/de/` - German
+- `http://localhost:3000/es/` - Spanish
+- `http://localhost:3000/vi/` - Vietnamese

--- a/docs/get-involved/create-a-event.md
+++ b/docs/get-involved/create-a-event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 title: Create an Event Highlight
-description: Add a Cardano event to the events page. Required metadata, image guidelines, and how event entries are reviewed and merged.
+description: Feature a Cardano event on the events page. How the Luma calendar and the curated highlights fit together, the JSON fields, image guidelines, and how entries are reviewed.
 ---
 
 ## Create a Event Highlight
@@ -14,9 +14,33 @@ In case you’re not familiar with making pull requests, please submit your requ
 
 ## Guiding Principles
 
-The [cardano.org/events](https://cardano.org/events) page is a curated showcase of highlights from the community calendar at [lu.ma/CardanoEvents](https://lu.ma/CardanoEvents).
+The [cardano.org/events](https://cardano.org/events) page shows the live community calendar from [lu.ma/CardanoEvents](https://lu.ma/CardanoEvents) together with a curated set of highlights that live in this repository.
 
 Its purpose is to amplify events that offer value to a broader audience, showcase major ecosystem progress, or represent Cardano on a global stage. All events featured here must first be submitted to and approved for the Luma calendar and then meet the highlight criteria below.
+
+## How the events page gets its data
+
+The page merges two sources at runtime:
+
+*   **The Luma calendar.** Upcoming events on [lu.ma/CardanoEvents](https://lu.ma/CardanoEvents) are fetched from the official Luma API through the `data.cardano.org` proxy (`src/utils/events/useLumaEvents.js`). This is the full list of meetups, working group calls, and community events. Nothing in the repository needs to change for a Luma event to appear.
+*   **Curated highlights.** `src/data/events.json` holds the hand-picked conferences and summits, plus the recap videos of past events. These entries feed the "Featured upcoming events" row at the top of the page and the "Recent event recaps" row at the bottom, and they are also part of the main list.
+
+A few merge rules are worth knowing before you edit the JSON (`src/utils/events/eventModel.js`):
+
+*   **Luma wins on duplicates.** If a curated entry and a Luma event share the same title and start day, the Luma version is shown and the JSON entry is dropped. Use the exact Luma title if you want the two to match.
+*   **Recurring series are collapsed.** Events that repeat under the same title (for example the weekly working group calls) are shown as a single row with their next occurrence.
+*   **Past events come from the JSON only.** The Luma feed only returns upcoming events, so once an event is over it stays on the page only if it has a curated entry. Past entries with a `recapVideo` appear in "Recent event recaps" and under the "Past" filter.
+*   **Featured means curated and upcoming.** The featured row shows the next upcoming curated entries (up to 10). It has no separate flag, so every upcoming JSON entry is a highlight.
+
+## When to add a JSON entry
+
+Add the event on Luma first, in every case. Then add an entry to `events.json` only if the event meets the highlight criteria below and one of these applies:
+
+*   It should be featured in the highlights row above the full list.
+*   It is over and you want to add a recap video.
+*   It has an external registration page that should be linked instead of the Luma page.
+
+Everything else (regular meetups, working group calls, online community events) belongs on Luma only.
 
 ## Criteria for a Highlight
 
@@ -40,7 +64,7 @@ To be featured on cardano.org, an event should represent a significant moment fo
 
     *Examples:* A developer workshop on core technology, a hackathon, or an academic symposium presenting new, peer-reviewed research on Cardano.
 
-**What is Explicitly Excluded from Highlights:** To maintain focus, the following event types will typically only be listed on lu.ma/cardanoevents and not on the main highlights page:
+**What is Explicitly Excluded from Highlights:** To maintain focus, the following event types will typically only be listed on lu.ma/cardanoevents and not as a highlight:
 
 *   General networking events or social gatherings.
 *   Recurring events that don’t meet the highlight criteria.
@@ -54,7 +78,7 @@ For your event to be considered, the submission must contain the following:
 *   **Date:** The exact start and end date (if different than start date). For single-day events, provide the startDate and leave the endDate field empty ("").
 *   **Location/Platform:** Venue, City and country.
 *   **Organizer(s):** The name of the organizing group or project.
-*   **Visual:** A compelling image in **.svg or .png** and ideally **square format**.
+*   **Visual:** A compelling image, ideally in **16:9 landscape format** (see the image notes below).
 
 ## Core Content Standards
 
@@ -68,11 +92,7 @@ All content on the event page must be professional and respectful. The following
 
 ## Edit the JSON file
 
-Edit the `events.json` file for the Event Highlights in the `src/data/` directory. Add a new entry at the end of the file using the specified format.
-
-The images must be saved in the `static/img/events/` folder.
-
-Important Note: The images should not exceed 150 KB per image and must be clearly visible in Dark Mode.
+Edit the `events.json` file in the `src/data/` directory. Add a new entry at the end of the array using the format below. Every existing entry carries all nine fields, so include each one even when it is empty.
 
 ```js title="src/data/events.json"
 [
@@ -80,16 +100,38 @@ Important Note: The images should not exceed 150 KB per image and must be clearl
     "title": "Event Title",
     "description": "Event description",
     "startDate": "YYYY-MM-DD",
-    "endDate": "YYYY-MM-DD" // For single-day events leave the endDate field empty ("").,
-    "location": "Event location",
-    "link": "Link to the event page" // Link to the event page on lu.ma/CardanoEvents.,
-    "image": "image-filename.png",
+    "endDate": "YYYY-MM-DD", // For single-day events leave the endDate field empty ("").
+    "location": "City, Country",
+    "link": "https://...", // Registration or event page, or the event on lu.ma/CardanoEvents.
+    "image": "image-filename.jpg", // File in static/img/events/, or "" for the Cardano logo fallback.
     "organizer": "Organizer name",
-    "recapVideo": "YouTube video ID (Optional)" // Only events with a video ID will be shown in the "Past Events" section.
-  },
-  
+    "recapVideo": "" // YouTube video ID, filled in after the event to show it under "Recent event recaps".
+  }
 ]
-
 ```
 
+| Field | Required | Notes |
+|-------|----------|-------|
+| `title` | Yes | Shown on the card. Also the key for de-duplication against Luma and for collapsing recurring series. |
+| `description` | Yes | Max 400 characters. The current cards do not render it, it is kept as the record of the submission. |
+| `startDate` | Yes | `YYYY-MM-DD`. Decides whether the event is upcoming, past, or featured. |
+| `endDate` | Yes | `YYYY-MM-DD`, or `""` for single-day events. Multi-day events span the calendar view. |
+| `location` | Yes | Free text, usually city and country. Used by the location label and the search. |
+| `link` | Yes | Registration or event page. The card's "View event" link. |
+| `image` | Yes | Bare filename under `static/img/events/`. Leave `""` to fall back to the Cardano logo. |
+| `organizer` | Yes | Shown on the card and searchable. |
+| `recapVideo` | Yes | YouTube video ID (the part after `v=`), or `""`. Only past entries with an ID appear in the recaps row. |
 
+The page also accepts two optional fields that no current entry uses: `category` overrides the derived topic (one of `Conference`, `Meetup`, `Governance`, `Hackathon`, `Workshop`, `Developers`, `Community`, `Other`, the default is `Conference`, or `Hackathon` when the title contains "hackathon"), and `online: true` marks a virtual event for the "Online" filter.
+
+The merge and normalization logic is covered by `yarn test:events` (`scripts/test-events-model.js`). Run `yarn test` before opening a pull request. A JSON syntax error breaks the build, so check that the file still parses after your edit.
+
+### Images
+
+Save the image in the `static/img/events/` folder and reference it by filename only. All event cards render the image in a 16:9 frame: the featured card fits the whole image inside (so logos on a plain background work), the list and recap cards crop it to fill the frame. A landscape image of about 1280 by 720 pixels in JPEG, WebP, or PNG works for all three.
+
+Important Note: The images should not exceed 150 KB per image and must be clearly visible in Dark Mode.
+
+### Adding a recap after the event
+
+Once a recording is published, set `recapVideo` to the YouTube video ID of the existing entry. If the event never had a curated entry (for example a hackathon that was only on Luma), add one now with the dates and location of the past event. The recap card uses the YouTube thumbnail, so the `image` field can stay empty for recap-only entries.

--- a/docs/get-involved/local-copy.md
+++ b/docs/get-involved/local-copy.md
@@ -25,7 +25,7 @@ yarn install
 yarn start
 ```
 
-Open `docs/index.md` (this page) and edit some lines: the site **reloads automatically** and displays your changes http://localhost:3000/docs/ in the moment you save your file.
+Open `docs/get-involved/local-copy.md` (this page) and edit some lines: the site **reloads automatically** and displays your changes at http://localhost:3000/docs/get-involved/local-copy the moment you save your file.
 
 ## Folder structure
 
@@ -40,8 +40,13 @@ cardano-org
 ├── build
 │   └── ...
 ├── docs
-│   ├── index.md (this page)
-│   └── ...
+│   ├── communities.md
+│   ├── get-involved
+│   │   ├── index.md
+│   │   ├── local-copy.md (this page)
+│   │   └── ...
+│   └── use-cases
+│       └── ...
 ├── src
 │   ├── components
 │   │   └── ...
@@ -73,7 +78,7 @@ cardano-org
 ### Folder structure rundown
 
 - `/blog/` - Contains the Markdown files for the news section.
-- `/docs/` - Contains the Markdown files for the documentation of the components (like this page). Customize the order of the docs sidebar in `sidebars.js`.
+- `/docs/` - Contains the Markdown files that Docusaurus renders as documentation: the contributor guides in `docs/get-involved/` (like this page, including the component docs in `docs/get-involved/components/`), the use case pages in `docs/use-cases/`, and the community channel list in `docs/communities.md`. Customize the order of the docs sidebars in `sidebars.js`.
 - `/src/` - Non-documentation files like pages, custom React components, data and css files.
   - `/src/data/ambassadorsData.json` - Ambassador data for https://cardano.org/ambassadors/.
   - `/src/data/delegationFAQ.json` - FAQ data for https://cardano.org/stake-pool-delegation/.
@@ -88,7 +93,7 @@ cardano-org
   - `/static/img` - All kinds of images. To highlight a few: `authors` are logos for `authors.yml`, `logos` are entity and company logos, `og` are open graph images.
 - `/docusaurus.config.js` - A config file containing the site configuration.
 - `/package.json` - A Docusaurus website is a React app. You can install and use any npm packages you like in them.
-- `/sidebar.js` - Used by the documentation to specify the order of documents in the sidebar.
+- `/sidebars.js` - Used by the documentation to specify the order of documents in the sidebar.
 
 
 ## Known problems that may arise


### PR DESCRIPTION
- Points README and the local-copy guide at the contributor guides instead of a docs index that does not exist, and lists all five locales
- Rewrites the events guide around how the page works today: the Luma calendar is the source, the JSON holds curated highlights and recap videos, with the merge rules, the field table and when to add a JSON entry
- Part of #833