### PR TITLE
docs: cross-link hardforks and wallets to the new explainer pages

### DIFF
--- a/src/pages/hardforks.js
+++ b/src/pages/hardforks.js
@@ -254,7 +254,7 @@ export default function Home() {
             description={translate({
               id: "hardforks.content.description",
               message:
-                "Hard forks in Cardano do not signify division and differences within the ecosystem. On the contrary, they define a specific and collectively agreed-upon exact time (slot) when all nodes switch from the current era to a new one, applying new functions, validation rules, or parameter values. All stake pool operators need to install the upgrade, and they also have a say and must agree to it. A Cardano hard fork is, therefore, not a separation but a precise collective evolution.",
+                "Hard forks in Cardano do not signify division and differences within the ecosystem. On the contrary, they define a specific and collectively agreed-upon exact time (slot) when all nodes switch from the current era to a new one, applying new functions, validation rules, or parameter values. All stake pool operators need to install the upgrade, and they also have a say and must agree to it. A Cardano hard fork is, therefore, not a separation but a precise collective evolution. See [how network upgrades fit into the protocol](/how-cardano-works#upgrades) for more detail.",
             })}
             headingDot={true}
           />

--- a/src/pages/wallets/index.js
+++ b/src/pages/wallets/index.js
@@ -307,6 +307,20 @@ export default function WalletFinder() {
             </Link>
           </div>
         </BoundaryBox>
+
+        <BoundaryBox>
+          <div className={styles.learnTeaser}>
+            <p className={styles.learnTeaserText}>
+              {translate({
+                id: "walletFinder.getAdaTeaser.text",
+                message: "Got a wallet set up? Here's how to get some ada into it.",
+              })}
+            </p>
+            <Link className="button button--primary" to="/where-to-get-ada">
+              {translate({ id: "walletFinder.getAdaTeaser.cta", message: "Where to Get ADA" })}
+            </Link>
+          </div>
+        </BoundaryBox>
         <SpacerBox size="medium" />
       </main>
     </Layout>


### PR DESCRIPTION
## Problem
Part of #831: `/hardforks` and `/wallets` are among the older pages that currently link to none of the new explainer set (`/what-is-cardano`, `/how-cardano-works`, `/smart-contracts`, `/defi`), so a visitor arriving there from search never discovers them.

## Approach
Scoped down to two pages, per the issue's own "one PR per page is fine" note:
- `/hardforks`: added a sentence linking to `/how-cardano-works#upgrades` in the existing intro copy, using the `[text](url)` markdown-link convention `parseMarkdownLikeText`/`TitleWithText` already render as a real `Link`.
- `/wallets`: added a second CTA box (mirroring the existing "What is a Wallet?" teaser) pointing to `/where-to-get-ada`, since the issue notes the newcomer path currently stops at `/what-is-a-wallet`.

Note on anchors: while checking the issue's suggested targets against the live pages, I found `/what-is-cardano` has no `#start` Divider id (it's actually `#get-started`) and no `#who-runs-cardano` id at all — flagged in a comment on #831 in case that affects the remaining `/where-to-get-ada`, `/what-is-a-wallet`, and `/governance` links from the issue.

## How to test
Visit `/hardforks` and `/wallets`, confirm the new links render and resolve correctly.

## Validation
- `yarn lint` — clean (1 pre-existing warning in an unrelated file, `src/theme/NavbarItem/DropdownNavbarItem/index.js`, not touched here)
- `yarn test` — `test:sitemap` (148), `test:constitution` (7), `test:events` (8), `test:quiz-logic` (6), `test:get-started` (32) all pass. `test:css` and `test:docs-style` fail locally only due to a Windows-specific `find.exe` PATH-resolution issue in my sandbox (confirmed the same `find` invocation works correctly against the real GNU find binary directly); `test:quiz-data` failure is a pre-existing generated-file sync gap unrelated to these two files. None of these are affected by this change, and CI runs on `ubuntu-latest`.
- `yarn build --locale en` — succeeds, "Generated static files in build". (Build regenerates `src/data/authors.json` and `src/data/quiz/generated/*.js` as a side effect of `yarn build`'s script chain — reverted those before committing since they're unrelated to this change.)

Docs updated: No (content-only change, no docs/get-involved update needed for a two-line content addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)