### PR TITLE
docs: drop date openers from the news summary prompt

### DIFF
--- a/docs/get-involved/create-a-news-article.md
+++ b/docs/get-involved/create-a-news-article.md
@@ -256,7 +256,7 @@ PRIMARY DIRECTIVE: Follow all rules precisely. The goal is to create summaries t
 require zero re-correction.
 
 1. SUMMARY RULES
-Word Count: Each summary must be a maximum of 70 words. The ideal length is 60–70 words. 
+Word Count: Each summary must be a maximum of 70 words. The ideal length is 60 to 70 words. 
 This is a strict limit.
 Paragraph: Write in one single paragraph. Do not use line breaks.
 Formatting: Do not include any links, bold, italics, or other markdown formatting.
@@ -266,14 +266,14 @@ a sentence or when using the ticker symbol (ADA).
 Tone: Maintain a neutral, objective, and factual tone.
 
 2. FORMATTING & TEMPLATES
-For development reports:
-Start with: The [Month] [Day], [Year], development report highlights...
-Avoid starting with generic phrases like “This week…”
-For forum community digests:
-Start with: The [Month] [Day], [Year], Cardano Community Digest highlights...
+For development reports and forum community digests:
+Open with the most important fact of the article. Do not open with the publication 
+date, it is already displayed above the summary on the website.
+Avoid starting with generic phrases like “This week…”, “In this edition…” or 
+similar filler.
 For all other content (blogs, videos, etc.):
-Start with a natural, informative sentence. If an author and date are available, you 
-may incorporate them.
+Start with a natural, informative sentence. If an author is available, you may 
+incorporate them.
 
 3. PROCEDURE FOR HANDLING CONTENT
 Step 1: Access Link. Attempt to access the content from the provided URL.
@@ -291,11 +291,11 @@ https://cardano.org/glossary/
 Input Link: 
 https://www.essentialcardano.io/development-update/weekly-development-report-as-of-2025-06-06
 
-Perfect Output: The June 06, 2025, development report highlights the release of 
-Lace wallet v.1.23, which features a more accurate pricing feed for Cardano native tokens 
-in response to community feedback. On the scaling front, the Mithril team delivered support 
-for node v.10.4.1 and UTXO-HD in their tools and advanced the development of the DMQ node. 
-The Leios team finalized an analysis of overcollateralization models.
+Perfect Output: Lace wallet v.1.23 is out, featuring a more accurate pricing feed for 
+Cardano native tokens in response to community feedback. On the scaling front, the Mithril 
+team delivered support for node v.10.4.1 and UTXO-HD in their tools and advanced the 
+development of the DMQ node. The Leios team finalized an analysis of overcollateralization 
+models, according to the weekly development report.
 
 6. PURPOSE
 These summaries are for public-facing updates. Your objective is to capture the most 


### PR DESCRIPTION
- News summaries now open on the article's key fact instead of repeating the publication date that is already shown above them
- Updated the example summary and widened the ban on generic openers to phrases like "In this edition"