### PR TITLE
docs: document seventeen reusable components

### DIFF
--- a/docs/get-involved/components/app-icon.md
+++ b/docs/get-involved/components/app-icon.md
@@ -1,0 +1,51 @@
+---
+title: App Icon
+description: Render an app's icon with a letter avatar fallback using the AppIcon component on cardano.org.
+---
+
+import AppIcon from '@site/src/components/AppIcon';
+import { Showcases } from '@site/src/data/apps';
+
+## AppIcon
+
+The icon of one showcase entry, sized for a tile or a row. It renders `app.icon` through `useBaseUrl`, so the path works in every locale. When the entry has no `icon` or the image fails to load, it falls back to a colored letter avatar: the first letter of the title on the category color from `Categories`.
+
+It exists to be used inside [App Tile](./app-tile.md) and [App Row](./app-row.md). Use it on its own only when you build a new app-related component and need the same icon treatment.
+
+## Basic Usage
+
+From `src/components/AppRow/index.js`:
+
+```jsx
+import AppIcon from '@site/src/components/AppIcon';
+
+<AppIcon app={app} size="row" className={styles.icon} />
+```
+
+From `src/components/AppTile/index.js`:
+
+```jsx
+<AppIcon app={app} size="tile" />
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `app` | `object` | - | One showcase entry. Reads `icon`, `title`, and `category`. Required. |
+| `size` | `'tile' \| 'row'` | `'tile'` | Picks the tile or the smaller row size class. Any value other than `'row'` uses the tile size. |
+| `className` | `string` | - | Additional class name on the outer `<span>`. |
+
+## Live Preview
+
+<div style={{display: 'flex', gap: '1rem', alignItems: 'center'}}>
+  <AppIcon app={Showcases[0]} />
+  <AppIcon app={Showcases[0]} size="row" />
+  <AppIcon app={{ title: 'Fallback', category: 'wallet' }} />
+</div>
+
+## Notes
+
+- The element is `aria-hidden` and the image has an empty `alt`. The app title must be visible next to it, which the tile and row components guarantee.
+- The image loads lazily.
+- New showcase submissions must include an `icon`, see [Add an App](../add-app.md). The fallback stays for older entries and broken images.

--- a/docs/get-involved/components/app-row.md
+++ b/docs/get-involved/components/app-row.md
@@ -1,0 +1,56 @@
+---
+title: App Row
+description: Render one app from the showcase as a compact linked row with icon, blurb, activity, and category using the AppRow component on cardano.org.
+---
+
+import AppRow from '@site/src/components/AppRow';
+import { Showcases } from '@site/src/data/apps';
+
+## AppRow
+
+The list-style counterpart of [App Tile](./app-tile.md). One horizontal row that links to `/apps/<slug>` and shows the [App Icon](./app-icon.md) at row size, the title with inline markers (a star for maintainer picks, a dot for apps with activity, a NEW badge for the newest entries), the blurb, and on the right the compact transaction count and the category label.
+
+It is used for the rows inside the category panels on `/apps` (`CategoryPanelsCarousel`) and for the flat list further down the same page. The component is memoized.
+
+## Basic Usage
+
+Inside a category panel, where the category is already the panel heading, from `src/components/CategoryPanelsCarousel/index.js`:
+
+```jsx
+import AppRow from '@site/src/components/AppRow';
+
+<ul className={styles.panelList}>
+  {apps.map((app) => (
+    <li key={app.slug}>
+      <AppRow app={app} hideCategory />
+    </li>
+  ))}
+</ul>
+```
+
+In the mixed list on `/apps`, where the category label is useful:
+
+```jsx
+<AppRow app={app} />
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `app` | `object` | - | One showcase entry from `Showcases`. Needs `slug`, `title`, and `category`. `icon`, `tagline`, `description`, and `maintainerPick` are optional. Required. |
+| `hideCategory` | `boolean` | `false` | Hides the category label on the right. Use it when the row sits under a heading that already names the category. |
+
+## Live Preview
+
+<ul style={{listStyle: 'none', padding: 0, maxWidth: '40rem'}}>
+  <li><AppRow app={Showcases[0]} /></li>
+  <li><AppRow app={Showcases[1]} hideCategory /></li>
+</ul>
+
+## Notes
+
+- The NEW badge marks the last `RECENT_APPS_COUNT` entries of the `Showcases` array (five at the time of writing), so the order of `src/data/apps.js` matters.
+- The activity dot and count only appear for categories marked `trackable` in `Categories` and with a transaction count above zero.
+- The component translates its own labels (`apps.activity.unit`, `apps.new`, `apps.maintainerPick`). Consumers pass no text.
+- For a card layout, use [App Tile](./app-tile.md).

--- a/docs/get-involved/components/app-tile.md
+++ b/docs/get-involved/components/app-tile.md
@@ -1,0 +1,69 @@
+---
+title: App Tile
+description: Render one app from the showcase as a linked card with icon, blurb, activity, and category using the AppTile component on cardano.org.
+---
+
+import AppTile, { StarBadge, RankBadge } from '@site/src/components/AppTile';
+import { Showcases } from '@site/src/data/apps';
+
+## AppTile
+
+A card for one entry of the app showcase in `src/data/apps.js`. It links to `/apps/<slug>` and shows the [App Icon](./app-icon.md), an optional badge in the top right, the title, the blurb (`tagline`, falling back to `description`), the compact transaction count when the app's category is trackable and has activity, the category label, and up to two property labels.
+
+The card is the unit inside [App Grid](./app-grid.md), the `AppTileCarousel`, the related apps on an app detail page, and the tool lists on `/governance` and `/governance/delegate`. The component is memoized.
+
+Two badge helpers are exported alongside the default: `StarBadge` (a star, "Maintainer pick") and `RankBadge` (a `#n` rank).
+
+## Basic Usage
+
+From `src/pages/governance/delegate.js`:
+
+```jsx
+import AppTile, { StarBadge } from '@site/src/components/AppTile';
+import { Showcases } from '@site/src/data/apps';
+
+const DELEGATION_APPS = Showcases.filter((app) => app.properties.includes('drepdelegation'));
+
+<div className={styles.altGrid}>
+  {DELEGATION_APPS.map((app) => (
+    <AppTile key={app.slug} app={app} badge={app.maintainerPick ? <StarBadge /> : null} />
+  ))}
+</div>
+```
+
+A rank badge, as `AppTileCarousel` receives it through `renderBadge`:
+
+```jsx
+<AppTile app={app} badge={<RankBadge rank={index + 1} />} />
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `app` | `object` | - | One showcase entry. Needs at least `slug`, `title`, `category`, and `properties` (an array). `icon`, `tagline`, and `description` are optional. Required. |
+| `badge` | `ReactNode` | `null` | Rendered in the header next to the icon. Use `<StarBadge />`, `<RankBadge rank={n} />`, or any small element. |
+
+### StarBadge
+
+No props. Renders a star with `aria-label="Maintainer pick"`.
+
+### RankBadge
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `rank` | `number` | - | Shown as `#rank` with a matching `aria-label`. |
+
+## Live Preview
+
+<div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '1rem'}}>
+  <AppTile app={Showcases[0]} badge={<StarBadge />} />
+  <AppTile app={Showcases[1]} badge={<RankBadge rank={2} />} />
+</div>
+
+## Notes
+
+- Always pass entries from `Showcases`. The `slug` is derived from the title at load time, and `app.properties.slice` throws when `properties` is missing.
+- The transaction count comes from `getAppStats` in `src/utils/appStats.js` and only shows for categories marked `trackable` in `Categories`. See [Transaction Rankings](../tx-rankings.md) for how the stats are produced.
+- The only text inside the component is the activity unit ("tx"), translated as `apps.activity.unit`. Category and property labels come from `Categories` and `Properties`.
+- For a compact horizontal list, use [App Row](./app-row.md) instead.

--- a/docs/get-involved/components/cta-one-column.md
+++ b/docs/get-involved/components/cta-one-column.md
@@ -1,0 +1,65 @@
+---
+title: CTA One Column
+description: Render a centered call to action with an optional title, text, and a white button using the CtaOneColumn component on cardano.org.
+---
+
+import BackgroundWrapper from '@site/src/components/Layout/BackgroundWrapper';
+import BoundaryBox from '@site/src/components/Layout/BoundaryBox';
+import CtaOneColumn from '@site/src/components/Layout/CtaOneColumn';
+
+## CtaOneColumn
+
+A single centered column with an optional heading, an optional paragraph, and one large white button below. The wrapper sets white text, so it is meant to sit inside a dark or colored [Background Wrapper](./background-wrapper.md) such as `solidBlue`, `ada`, or `gradientDark`. On a light background the title and text are invisible.
+
+`ExplainerPage` uses this component for its closing call-to-action band, and pages such as `/learn`, `/exchanges`, `/developers`, `/solutions`, `/ouroboros`, and the stake pool pages use it directly.
+
+## Basic Usage
+
+Taken from `src/pages/learn.js`:
+
+```jsx
+import BackgroundWrapper from '@site/src/components/Layout/BackgroundWrapper';
+import BoundaryBox from '@site/src/components/Layout/BoundaryBox';
+import CtaOneColumn from '@site/src/components/Layout/CtaOneColumn';
+import { ACADEMY_CTA_URL } from '@site/src/data/learningPath';
+import { translate } from '@docusaurus/Translate';
+
+<BackgroundWrapper backgroundType="solidBlue">
+  <BoundaryBox>
+    <CtaOneColumn
+      title={translate({ id: "learn.cta.title", message: "Want a certificate at the end? The Cardano Academy offers free courses on everything above." })}
+      buttonLabel={translate({ id: "learn.cta.button", message: "Explore the Academy" })}
+      buttonLink={ACADEMY_CTA_URL}
+    />
+  </BoundaryBox>
+</BackgroundWrapper>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | - | Optional heading rendered as an `<h1>`. Skipped when empty. |
+| `text` | `string` | - | Optional paragraph below the title, rendered as a plain string (no markdown parsing). Skipped when empty. |
+| `buttonLabel` | `string` | - | Label of the button. The button is always rendered, so always pass a label. |
+| `buttonLink` | `string` | - | Target of the button, passed to the Docusaurus `Link`, so internal paths and external URLs both work. |
+
+## Live Preview
+
+<BackgroundWrapper backgroundType="solidBlue">
+  <BoundaryBox>
+    <CtaOneColumn
+      title="Talk to the Cardano Foundation's Core Integrations team"
+      text="Reach out for tailored support, real-time updates, and integration queries."
+      buttonLabel="Contact the Core Integrations team"
+      buttonLink="/contact"
+    />
+  </BoundaryBox>
+</BackgroundWrapper>
+
+## Notes
+
+- Consumers pass already translated strings (`translate()` calls). The component itself contains no text.
+- `text` is rendered as is. If you need links or bold text inside the paragraph, use [Title With Text](./title-with-text.md) instead, which parses markdown-like syntax.
+- The button uses the white `buttonWhite` style on top of `button button--primary button--lg`, which is why it only looks right on a dark background.
+- For a two-column variant with a button on either side, see [CTA Two Column](./cta-two-column.md).

--- a/docs/get-involved/components/cta-two-column.md
+++ b/docs/get-involved/components/cta-two-column.md
@@ -1,0 +1,90 @@
+---
+title: CTA Two Column
+description: Render a two-column call to action with independent title, text, and white button per column using the CtaTwoColumn component on cardano.org.
+---
+
+import BackgroundWrapper from '@site/src/components/Layout/BackgroundWrapper';
+import BoundaryBox from '@site/src/components/Layout/BoundaryBox';
+import CtaTwoColumn from '@site/src/components/Layout/CtaTwoColumn';
+
+## CtaTwoColumn
+
+Two side-by-side columns, each with an optional heading, optional text, and an optional white button. Every part is controlled separately through `left*` and `right*` props. The wrapper sets white text, so place it inside a dark or colored [Background Wrapper](./background-wrapper.md).
+
+The column split adapts to the content. When the right column has a title or text, both columns are `col--6`. When the right column only holds a button (or nothing), the left column widens to `col--7` and the right narrows to `col--5`.
+
+Used on `/exchanges`, `/stake-pool-delegation`, and `/stake-pool-operation`.
+
+## Basic Usage
+
+Two full columns, from `src/pages/exchanges.js`:
+
+```jsx
+import CtaTwoColumn from '@site/src/components/Layout/CtaTwoColumn';
+import { translate } from '@docusaurus/Translate';
+
+<CtaTwoColumn
+  leftTitle={translate({ id: "exchanges.learnMore.leftTitle", message: "Exchange integration guide" })}
+  leftText={translate({ id: "exchanges.learnMore.leftText", message: "Step-by-step guidance for custodians and listing platforms. Covers the accounting model, transaction handling, native assets, and upgrade practices." })}
+  leftButtonLabel={translate({ id: "exchanges.learnMore.leftButtonLabel", message: "Read the full guide" })}
+  leftButtonLink="https://developers.cardano.org/docs/build/integrate/exchange-integrations/"
+  leftHeadingDot={false}
+  rightTitle={translate({ id: "exchanges.learnMore.rightTitle", message: "Integration components overview" })}
+  rightText={translate({ id: "exchanges.learnMore.rightText", message: "A shorter reference listing the components used to integrate Cardano into websites, services, and back-office systems." })}
+  rightButtonLabel={translate({ id: "exchanges.learnMore.rightButtonLabel", message: "Browse the components" })}
+  rightButtonLink="https://developers.cardano.org/docs/build/integrate/overview/"
+  rightHeadingDot={false}
+/>
+```
+
+Text on the left, a centered button on the right, from `src/pages/stake-pool-delegation.js`:
+
+```jsx
+<CtaTwoColumn
+  leftTitle={translate({ id: 'stakePoolDelegation.walletsCta.title', message: 'Cardano Wallets' })}
+  leftText={translate({ id: 'stakePoolDelegation.walletsCta.text', message: 'Discover a wide variety of wallets designed to facilitate your interaction with the Cardano ecosystem.' })}
+  leftHeadingDot={true}
+  rightButtonLabel={translate({ id: 'stakePoolDelegation.walletsCta.buttonLabel', message: 'Discover Now' })}
+  rightButtonLink="/what-is-ada#wallets"
+  rightButtonAlign="center"
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `leftTitle` | `string` | - | Optional `<h1>` in the left column. |
+| `leftText` | `string` \| `string[]` | - | Optional text in the left column. A string renders one `<p>`, an array renders one `<p>` per entry. Plain strings, no markdown parsing. |
+| `leftButtonLabel` | `string` | - | Optional. When set, a white button renders in the left column. |
+| `leftButtonLink` | `string` | - | Target of the left button. |
+| `leftHeadingDot` | `boolean` | - | Adds the `headingDot` class to the left title. |
+| `leftButtonAlign` | `string` | - | `'center'` centers the left button. Any other value keeps the default left alignment. |
+| `rightTitle` | `string` | - | Optional `<h1>` in the right column. |
+| `rightText` | `string` \| `string[]` | - | Optional text in the right column, same rules as `leftText`. |
+| `rightButtonLabel` | `string` | - | Optional. When set, a white button renders in the right column. |
+| `rightButtonLink` | `string` | - | Target of the right button. |
+| `rightHeadingDot` | `boolean` | - | Adds the `headingDot` class to the right title. |
+| `rightButtonAlign` | `string` | - | `'center'` centers the right button. Any other value keeps the default left alignment. |
+
+## Live Preview
+
+<BackgroundWrapper backgroundType="solidBlue">
+  <BoundaryBox>
+    <CtaTwoColumn
+      leftTitle="Cardano Wallets"
+      leftText="Discover a wide variety of wallets designed to facilitate your interaction with the Cardano ecosystem."
+      leftHeadingDot={true}
+      rightButtonLabel="Discover Now"
+      rightButtonLink="/what-is-ada#wallets"
+      rightButtonAlign="center"
+    />
+  </BoundaryBox>
+</BackgroundWrapper>
+
+## Notes
+
+- Consumers pass already translated strings. The component contains no text of its own.
+- Unlike [Dotted Image With Text](./dotted-image-with-text.md), the text here is rendered as is. Markdown-style links or bold markers appear literally.
+- Both columns stack vertically on narrow screens through the Infima `row` and `col` classes.
+- For a single centered call to action, see [CTA One Column](./cta-one-column.md).

--- a/docs/get-involved/components/dotted-image-with-text.md
+++ b/docs/get-involved/components/dotted-image-with-text.md
@@ -1,0 +1,74 @@
+---
+title: Dotted Image With Text
+description: Render a dotted icon illustration next to a heading and text using the DottedImageWithText component on cardano.org.
+---
+
+import DottedImageWithText from '@site/src/components/Layout/DottedImageWithText';
+
+## DottedImageWithText
+
+An illustration from `static/img/dotted-icons/` on the left with an optional `<h2>` and text on the right. The two stack vertically on screens up to 768px wide. It is the standard block for feature lists on explainer pages: `/what-is-cardano`, `/how-cardano-works`, `/smart-contracts`, `/defi`, `/ouroboros`, `/what-is-a-wallet`, and `/stake-pool-operation` all use it.
+
+Text goes through `parseMarkdownLikeText`, so `[label](url)` links and `**bold**` markers are rendered as links and bold text.
+
+## Basic Usage
+
+From `src/pages/what-is-cardano.js`:
+
+```jsx
+import DottedImageWithText from '@site/src/components/Layout/DottedImageWithText';
+import { translate } from '@docusaurus/Translate';
+
+<DottedImageWithText
+  imageName="proof-of-stake"
+  title={translate({ id: "whatIsCardano.how.consensus.title", message: "Consensus: Ouroboros" })}
+  text={[
+    translate({
+      id: "whatIsCardano.how.consensus.text",
+      message: "Time on Cardano is divided into slots of one second and epochs of five days. Slots are assigned at random to stake pools, weighted by how much ada is delegated to them, and the chosen pool produces the next block.",
+    }),
+  ]}
+  headingDot={true}
+/>
+```
+
+A markdown-style link inside the text, from `src/pages/ouroboros.js`:
+
+```jsx
+<DottedImageWithText
+  imageName="power-arrows"
+  title={translate({ id: 'ouroboros.features.energyEfficient.title', message: 'Energy Efficient' })}
+  text={[
+    translate({ id: 'ouroboros.features.energyEfficient.text1', message: 'Using Ouroboros, Cardano is able to securely, sustainably, and ethically scale, with up to [four million times the energy efficiency of bitcoin](https://developers.cardano.org/docs/operate-a-stake-pool/basics/consensus-staking/#ouroboros-protocol).' }),
+  ]}
+  headingDot={true}
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `imageName` | `string` | - | File name without extension under `static/img/dotted-icons/`. Resolved to `/img/dotted-icons/<imageName>.svg` with the locale base URL. When omitted, no image column renders. |
+| `title` | `string` | - | Optional `<h2>` above the text. |
+| `text` | `string` \| `string[]` \| `{ list: string[] }` | - | The body. A string renders one paragraph. An array renders each entry in turn, where an entry may again be a string or a `{ list: [...] }` object, which renders a `<ul>`. Every string is parsed for markdown-style links and bold text. |
+| `headingDot` | `boolean` | - | Adds the `headingDot` class to the title. |
+
+## Live Preview
+
+<DottedImageWithText
+  imageName="proof-of-stake"
+  title="Consensus: Ouroboros"
+  text={[
+    "Time on Cardano is divided into slots of one second and epochs of five days. Slots are assigned at random to stake pools, weighted by how much ada is delegated to them.",
+    { list: ["Most slots stay empty, so a block appears roughly every **20 seconds**.", "Running the network needs ordinary servers, not warehouses of mining hardware."] },
+  ]}
+  headingDot={true}
+/>
+
+## Notes
+
+- Only `.svg` files are picked up. The folder also contains a few `.png` files, which this component cannot render.
+- The image `alt` text is the `imageName`, so choose descriptive file names.
+- Consumers pass already translated strings. Keep the markdown link syntax inside the `message` so it survives translation.
+- Available icons at the time of writing: `ada-upturned-hand`, `agriculture`, `chains`, `decentralization`, `desireability`, `dots-with-line`, `education`, `finance`, `get-funded`, `government`, `healthcare`, `innovation`, `machine-squares`, `nft`, `opportunity`, `people`, `pledging`, `power-arrows`, `proof-of-stake`, `proof-of-work`, `purpose`, `research`, `retail`, `saturation`, `technology`, `wallet-cold`, `wallet-hot`. Check `static/img/dotted-icons/` for the current list.

--- a/docs/get-involved/components/featured-title-with-text.md
+++ b/docs/get-involved/components/featured-title-with-text.md
@@ -1,0 +1,74 @@
+---
+title: Featured Title With Text
+description: Render a large heading on the left with description, red quote, and button on the right using the FeaturedTitleWithText component on cardano.org.
+---
+
+import FeaturedTitleWithText from '@site/src/components/Layout/FeaturedTitleWithText';
+
+## FeaturedTitleWithText
+
+A two-column feature block. The left column holds a large `<h1>`, the right column holds one or more description paragraphs, a red `<h2>` quote or tagline, and an optional primary button. It is the opening block of the homepage and of `/ouroboros`.
+
+Description paragraphs go through `parseMarkdownLikeText`, so `[label](url)` links and `**bold**` markers are rendered as links and bold text.
+
+## Basic Usage
+
+From `src/pages/ouroboros.js`:
+
+```jsx
+import FeaturedTitleWithText from '@site/src/components/Layout/FeaturedTitleWithText';
+import { translate } from '@docusaurus/Translate';
+
+<FeaturedTitleWithText
+  title={translate({ id: 'ouroboros.whatIs.title', message: 'What Is Ouroboros?' })}
+  description={[
+    translate({ id: 'ouroboros.whatIs.description2', message: 'At the heart of Ouroboros is the concept of infinity. Global networks must be able to grow sustainably and ethically: to provide greater opportunities to the world while also preserving it. This becomes possible with Ouroboros.' }),
+    translate({ id: 'ouroboros.whatIs.description3', message: 'Ouroboros facilitates the creation and fruition of distributed, permissionless networks capable of sustainably supporting new markets.' }),
+  ]}
+  quote={translate({ id: 'ouroboros.whatIs.quote', message: 'Ouroboros exists to define the parameters of the new world: a protocol more secure, scalable, and energy-efficient than anything that has come before.' })}
+  buttonLabel={translate({ id: 'ouroboros.whatIs.buttonLabel', message: 'Explore the research' })}
+  buttonLink="/research#byron"
+  headingDot={false}
+/>
+```
+
+The homepage (`src/pages/index.js`) passes the quote as an array with a `<br />` element to force a line break:
+
+```jsx
+quote={[
+  translate({ id: 'home.featured.quote1', message: 'A History Of Impossible,' }),
+  <br key="line1" />,
+  translate({ id: 'home.featured.quote2', message: 'Made Possible' }),
+]}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | - | The large heading in the left column. Always rendered. |
+| `description` | `string` \| `string[]` | - | One paragraph, or one paragraph per array entry, in the right column. Parsed for markdown-style links and bold text. |
+| `quote` | `string` \| `node[]` | - | Red `<h2>` below the description. Always rendered, so pass a value. An array of strings and elements is allowed. |
+| `buttonLabel` | `string` | - | Label of the primary button. The button only renders when both `buttonLabel` and `buttonLink` are set. |
+| `buttonLink` | `string` | - | Target of the button. |
+| `headingDot` | `boolean` | - | Adds the `headingDot` class to the title. |
+
+## Live Preview
+
+<FeaturedTitleWithText
+  title="What Is Ouroboros?"
+  description={[
+    "Ouroboros is the first provably secure proof-of-stake protocol, and the first blockchain protocol to be based on [peer-reviewed research](/research).",
+    "Ouroboros facilitates the creation and fruition of distributed, permissionless networks capable of sustainably supporting new markets.",
+  ]}
+  quote="A protocol more secure, scalable, and energy-efficient than anything that has come before."
+  buttonLabel="Explore the research"
+  buttonLink="/research"
+  headingDot={true}
+/>
+
+## Notes
+
+- Consumers pass already translated strings. Markdown-style links inside a translated message survive translation, so keep the link syntax in the `message`.
+- The description paragraphs use the `black-text` class and the quote uses `red-text`, both defined in the global CSS.
+- For a lighter heading plus text block without the quote and the two-column split, use [Title With Text](./title-with-text.md).

--- a/docs/get-involved/components/horizontal-scroller.md
+++ b/docs/get-involved/components/horizontal-scroller.md
@@ -1,0 +1,77 @@
+---
+title: Horizontal Scroller
+description: Lay out cards in a horizontal scroll-snap track with arrows on desktop and dots on mobile using the HorizontalScroller component on cardano.org.
+---
+
+import HorizontalScroller from '@site/src/components/HorizontalScroller';
+
+## HorizontalScroller
+
+A generic carousel track. Each child becomes one snap item in a horizontally scrolling `<ul>`. On screens wider than 600px, previous and next arrow buttons scroll by one item and disable at either end. On smaller screens the arrows hide, the track bleeds to the viewport edges with a fade mask, and a row of progress dots shows the position.
+
+It drives the app tile carousel and the category panels on `/apps`, and the featured and recap event rows on `/events`. The component is memoized.
+
+## Basic Usage
+
+From `src/components/Events/FeaturedEvents/index.js`:
+
+```jsx
+import HorizontalScroller from '@site/src/components/HorizontalScroller';
+import { translate } from '@docusaurus/Translate';
+
+<HorizontalScroller
+  ariaLabel={translate({ id: 'events.featured.title', message: 'Featured upcoming events' })}
+  prevLabel={translate({ id: 'events.carousel.prev', message: 'Previous' })}
+  nextLabel={translate({ id: 'events.carousel.next', message: 'Next' })}
+>
+  {events.map((event) => (
+    <FeaturedEventCard key={event.title} event={event} labels={labels} />
+  ))}
+</HorizontalScroller>
+```
+
+With narrower items, from `src/components/AppTileCarousel/index.js`:
+
+```jsx
+<HorizontalScroller
+  ariaLabel={ariaLabel}
+  prevLabel={translate({ id: "apps.carousel.prev", message: "Previous" })}
+  nextLabel={translate({ id: "apps.carousel.next", message: "Next" })}
+  gap="1rem"
+  itemWidth="260px"
+  itemWidthMobile="220px"
+>
+  {apps.map((app) => (
+    <AppTile key={app.slug} app={app} />
+  ))}
+</HorizontalScroller>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | - | The items. Each direct child is wrapped in its own `<li>` snap item and stretched to full height. |
+| `ariaLabel` | `string` | - | `aria-label` of the `role="region"` wrapper. Pass a translated string. |
+| `prevLabel` | `string` | - | `aria-label` of the previous arrow button. Pass a translated string. |
+| `nextLabel` | `string` | - | `aria-label` of the next arrow button. Pass a translated string. |
+| `gap` | `string` | - | Overrides the `--hs-gap` custom property. The CSS falls back to `1.5rem`. |
+| `itemWidth` | `string` | - | Overrides the `--hs-item-width` custom property. The CSS falls back to `300px`. |
+| `itemWidthMobile` | `string` | - | Overrides the `--hs-item-width-mobile` custom property, used up to 600px. The CSS falls back to `260px`. |
+
+## Live Preview
+
+<HorizontalScroller ariaLabel="Example scroller" prevLabel="Previous" nextLabel="Next" itemWidth="220px" itemWidthMobile="180px">
+  {[1, 2, 3, 4, 5, 6].map((n) => (
+    <div key={n} style={{padding: '2rem 1rem', textAlign: 'center', borderRadius: '12px', border: '1px solid var(--ifm-color-emphasis-300)', background: 'var(--ifm-background-surface-color)'}}>
+      Item {n}
+    </div>
+  ))}
+</HorizontalScroller>
+
+## Notes
+
+- The three size props are applied as inline CSS custom properties, so they accept any CSS length.
+- The scroll position resets to the start whenever the number of children changes.
+- Scroll state is measured with a layout effect that only runs in the browser, so the component is safe for server-side rendering.
+- The arrows are real `<button>` elements with focus styles, and the dots are `aria-hidden`, so keyboard users navigate through the items themselves.

--- a/docs/get-involved/components/icon-hero.md
+++ b/docs/get-involved/components/icon-hero.md
@@ -1,0 +1,48 @@
+---
+title: Icon Hero
+description: Frame an icon in a rounded tile with an optional dotted halo using the IconHero component on cardano.org.
+---
+
+import IconHero from '@site/src/components/Layout/IconHero';
+import { FaVoteYea, FaWallet } from 'react-icons/fa';
+
+## IconHero
+
+A decorative 120px circle (90px on screens up to 768px wide) with a dotted halo, holding a 52px rounded tile in which the icon is centered. The whole element is `aria-hidden`, so it is purely visual and must sit next to a real heading or label.
+
+It is used for the step illustrations in `DelegationFlow`, the tab panels in `GovernancePathsSection`, and the icon of `SurveyCard`.
+
+## Basic Usage
+
+From `src/components/GovernancePathsSection/index.js`:
+
+```jsx
+import IconHero from '@site/src/components/Layout/IconHero';
+import { FaVoteYea } from 'react-icons/fa';
+
+<IconHero className={styles.panelHero}>
+  <FaVoteYea />
+</IconHero>
+<h2 className={styles.panelTitle}>{path.title}</h2>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | - | The icon to show, usually a `react-icons` component. Sized by the tile's `font-size` (1.5rem, 1.25rem on small screens). |
+| `withHalo` | `boolean` | `true` | Renders the dotted radial halo behind the tile. Set to `false` for a plain circle of the same size without the dots. |
+| `className` | `string` | - | Additional class name on the outer circle, for positioning within the parent layout. |
+
+## Live Preview
+
+<div style={{display: 'flex', gap: '2rem', alignItems: 'center'}}>
+  <IconHero><FaVoteYea /></IconHero>
+  <IconHero withHalo={false}><FaWallet /></IconHero>
+</div>
+
+## Notes
+
+- The halo, tile background, and icon color are theme aware and switch for dark mode through `[data-theme='dark']` rules.
+- Because the element is `aria-hidden`, never put text or a link inside it.
+- For an icon with a title and description in one card, use [Role Card](./role-card.md) instead.

--- a/docs/get-involved/components/insights-footer.md
+++ b/docs/get-involved/components/insights-footer.md
@@ -1,0 +1,42 @@
+---
+title: Insights Footer
+description: Show the last-updated line at the end of an /insights page using the InsightsFooter component on cardano.org.
+---
+
+import InsightsFooter from '@site/src/components/Layout/InsightsFooter';
+
+## InsightsFooter
+
+A small `<footer>` with a top border and the translated sentence `Last updated: {lastUpdated}. Charts are using real time data.` It is only meaningful as the last child of an [Insights Layout](./insights-layout.md) page and is used on every page under `/insights`.
+
+## Basic Usage
+
+A fixed date from the page's `meta`, as in `src/pages/insights/template/index.js`:
+
+```jsx
+import InsightsFooter from '@site/src/components/Layout/InsightsFooter';
+
+<InsightsFooter lastUpdated={meta.date} />
+```
+
+A live value, as in `src/pages/insights/supply/index.js`, where the date and epoch come from the fetched data:
+
+```jsx
+<InsightsFooter lastUpdated={`${epochDate} (epoch ${displayedEpoch})`} />
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `lastUpdated` | `string` | - | Inserted verbatim into the sentence in place of `{lastUpdated}`. Pass a preformatted date string. |
+
+## Live Preview
+
+<InsightsFooter lastUpdated="2025-03-17" />
+
+## Notes
+
+- The sentence itself is translated inside the component (`insights.footer.text`), so consumers only pass the date value.
+- Any extra props are ignored. Some pages pass an `epoch` prop, which the component does not read.
+- The footer is styled inline with theme tokens (`--ifm-toc-border-color`, `--ifm-color-content-secondary`), so it needs no CSS module and works in dark mode.

--- a/docs/get-involved/components/insights-layout.md
+++ b/docs/get-involved/components/insights-layout.md
@@ -1,0 +1,69 @@
+---
+title: Insights Layout
+description: Page shell for the /insights data pages, with meta driven title, hero, zoom background, and boundary box, using the InsightsLayout component on cardano.org.
+---
+
+## InsightsLayout
+
+The shell shared by every page under `/insights`. It wraps the Docusaurus `Layout`, renders a [Site Hero](./site-hero.md) from the page's `meta` export, and places the children inside a `zoom` [Background Wrapper](./background-wrapper.md) and a [Boundary Box](./boundary-box.md), followed by a medium [Spacer Box](./spacer-box.md).
+
+Every insights page exports a `meta` object that both this layout and the insights index read. The layout uses four of its fields, the rest (`pageName`, `date`, `og`, `tags`, `indexed`) are for the index and for [Open Graph Info](./open-graph-info.md).
+
+Because it renders a full page, there is no live preview here. `src/pages/insights/template/index.js` is the reference page to copy.
+
+## Basic Usage
+
+From `src/pages/insights/template/index.js`:
+
+```jsx
+import { translate } from '@docusaurus/Translate';
+import InsightsLayout from '@site/src/components/Layout/InsightsLayout';
+import InsightsFooter from '@site/src/components/Layout/InsightsFooter';
+import OpenGraphInfo from '@site/src/components/Layout/OpenGraphInfo';
+
+export const meta = {
+  pageName: 'template',
+  pageTitle: translate({ id: 'insightsTemplate.meta.pageTitle', message: 'Cardano Insights Template' }),
+  pageDescription: translate({ id: 'insightsTemplate.meta.pageDescription', message: 'Insights Template' }),
+  title: translate({ id: 'insightsTemplate.meta.title', message: 'This is just an insights template' }),
+  date: '2025-03-17',
+  og: {
+    title: translate({ id: 'insightsTemplate.og.title', message: 'This is just an insights template | Cardano.org' }),
+    description: translate({ id: 'insightsTemplate.og.description', message: 'Detailed description for open graph pages, and more.' }),
+  },
+  tags: ['governance'],
+  indexed: false,
+};
+
+export default function InsightsTemplate() {
+  return (
+    <InsightsLayout meta={meta}>
+      <OpenGraphInfo pageName={meta.pageName} title={meta.og.title} description={meta.og.description} />
+      <p>Page content, charts, and text go here.</p>
+      <InsightsFooter lastUpdated={meta.date} />
+    </InsightsLayout>
+  );
+}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `meta` | `object` | - | The page's `meta` export. Required. |
+| `children` | `ReactNode` | - | The page content, rendered inside the boundary box. |
+
+### Fields read from `meta`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `meta.pageTitle` | `string` | - | Passed to `Layout` as the document title. |
+| `meta.pageDescription` | `string` | - | Passed to `Layout` as the meta description and reused as the hero description. |
+| `meta.title` | `string` | - | The hero heading. |
+| `meta.bannerType` | `string` | `'braidBlue'` | Optional [Site Hero](./site-hero.md) banner. Falls back to `braidBlue` when missing. |
+
+## Notes
+
+- All `meta` strings are `translate()` calls in the page file so Crowdin can extract them. The layout itself contains no text.
+- Put [Insights Footer](./insights-footer.md) at the end of the children to show the last-updated line.
+- The insights index only lists pages whose `meta.indexed` is not `false`, so set it to `false` for drafts and templates.

--- a/docs/get-involved/components/modal.md
+++ b/docs/get-involved/components/modal.md
@@ -1,0 +1,52 @@
+---
+title: Modal
+description: Open any content in an accessible dialog from a trigger button using the Modal component on cardano.org.
+---
+
+import Modal from '@site/src/components/Modal';
+
+## Modal
+
+The shared dialog shell. It renders a trigger button and, once clicked, an overlay with a `role="dialog"` box, a close button, and whatever you pass as children. The overlay is portaled to `document.body`, so a transformed or clipped ancestor (a hovering card, for example) cannot cut it off.
+
+Scroll lock, focus trap, focus restore, and Escape to close come from the `useModalA11y` hook in `src/utils/useModalA11y.js`. Clicking the backdrop also closes the dialog.
+
+[Quiz Modal](./quiz-modal.md) and `SurveyModal` are thin wrappers around this component. Use `Modal` directly when you need a dialog for something else.
+
+## Basic Usage
+
+From `src/components/SurveyModal/index.js`:
+
+```jsx
+import Modal from '@site/src/components/Modal';
+import Survey from '@site/src/components/Survey';
+
+const SurveyModal = ({ surveyData, buttonText = "Start", questionCount, buttonClassName }) => (
+  <Modal label="Survey" buttonText={buttonText} buttonClassName={buttonClassName}>
+    <Survey surveyData={surveyData} questionCount={questionCount} />
+  </Modal>
+);
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | - | Accessible name of the dialog (`aria-label`). Also lowercased into the close button's label, "Close quiz" for `label="Quiz"`. Required. |
+| `buttonText` | `string` \| `ReactNode` | - | Content of the trigger button. |
+| `buttonClassName` | `string` | - | Class name for the trigger button. When omitted, the built-in blue `startButton` style is used. |
+| `children` | `ReactNode` | - | The dialog content. |
+
+## Live Preview
+
+<Modal label="Example" buttonText="Open the example dialog">
+  <h2>Hello from the modal</h2>
+  <p>Press Escape, click the close button, or click outside the box to close it.</p>
+</Modal>
+
+## Notes
+
+- The dialog state lives inside the component. There is no controlled mode and no `onClose` callback.
+- `label` is used in string operations, so pass a plain string, and pass a translated one, since it is read by screen readers.
+- The close button label is built as `Close ${label.toLowerCase()}` and is not translated separately.
+- The overlay and content box are styled in `src/components/Modal/styles.module.css` and respect `prefers-reduced-motion` by dropping the button transitions.

--- a/docs/get-involved/components/one-column-box.md
+++ b/docs/get-involved/components/one-column-box.md
@@ -1,0 +1,50 @@
+---
+title: One Column Box
+description: Render one or more plain paragraphs in a full-width column using the OneColumnBox component on cardano.org.
+---
+
+import OneColumnBox from '@site/src/components/Layout/OneColumnBox';
+
+## OneColumnBox
+
+A full-width text block. It takes a string or an array of strings and renders each as a paragraph inside an Infima `col--12` column. There is no title, no styling beyond the column, and no markdown parsing. It is the simplest way to place body copy between other layout components.
+
+Used on `/stake-pool-delegation` and `/stake-pool-operation`.
+
+## Basic Usage
+
+From `src/pages/stake-pool-delegation.js`:
+
+```jsx
+import OneColumnBox from '@site/src/components/Layout/OneColumnBox';
+import { translate } from '@docusaurus/Translate';
+
+<OneColumnBox
+  text={[
+    translate({ id: 'stakePoolDelegation.whatIsStake.text1', message: 'Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held. The ability to delegate or pledge a stake is fundamental to how Cardano works.' }),
+    translate({ id: 'stakePoolDelegation.whatIsStake.text2', message: 'There are two ways an ada holder can earn rewards: by delegating their stake to a stake pool run by someone else, or running their own stake pool.' }),
+  ]}
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `text` | `string` \| `string[]` | - | The paragraph text. A string renders one `<p>`, an array renders one `<p>` per entry. Plain strings, no markdown parsing. |
+
+## Live Preview
+
+<OneColumnBox
+  text={[
+    "Ada held on the Cardano network represents a stake in the network, with the size of the stake proportional to the amount of ada held.",
+    "There are two ways an ada holder can earn rewards: by delegating their stake to a stake pool run by someone else, or running their own stake pool.",
+  ]}
+/>
+
+## Notes
+
+- Consumers pass already translated strings.
+- The text color is inherited, so the box works on light and dark backgrounds alike.
+- For links or bold text inside the copy, use [Title With Text](./title-with-text.md), which parses markdown-like syntax.
+- For two columns of text, see [Two Column Box](./two-column-box.md).

--- a/docs/get-involved/components/proof-points-list.md
+++ b/docs/get-involved/components/proof-points-list.md
@@ -1,0 +1,83 @@
+---
+title: Proof Points List
+description: Render alternating rows of icon, title, tagline, and text with an optional closing button using the ProofPointsList component on cardano.org.
+---
+
+import ProofPointsList from '@site/src/components/ProofPointsList';
+import { FaLock, FaCalculator } from 'react-icons/fa';
+
+## ProofPointsList
+
+A `<section>` with a `<ul>` of proof points. Each row has an icon on one side and a title (`<h2>`), a short tagline, and a paragraph on the other, alternating sides row by row. An optional primary button closes the list.
+
+The rows are data driven. `src/data/whatIsCardanoProofPoints.js` exports `getProofPoints()`, the single source for the seven points. `/what-is-cardano` renders all of them, the homepage (`HomeProofPointsSection`) renders four of them plus a button into the full page. The section heading is not part of this component, callers render it through [Title With Text](./title-with-text.md).
+
+## Basic Usage
+
+From `src/components/HomeProofPointsSection/index.js`:
+
+```jsx
+import { translate } from '@docusaurus/Translate';
+import TitleWithText from '@site/src/components/Layout/TitleWithText';
+import ProofPointsList from '@site/src/components/ProofPointsList';
+import { getProofPoints } from '@site/src/data/whatIsCardanoProofPoints';
+
+const HOME_KEYS = ["staking", "fees", "governance", "research"];
+const allPoints = getProofPoints();
+const points = HOME_KEYS.map((key) => allPoints.find((point) => point.key === key)).filter(Boolean);
+
+<TitleWithText
+  title={translate({ id: "home.proofPoints.title", message: "What makes Cardano different?" })}
+  headingDot={true}
+  titleType="black"
+/>
+<ProofPointsList
+  points={points}
+  cta={{
+    label: translate({ id: "home.proofPoints.cta", message: "See all differences" }),
+    to: "/what-is-cardano",
+  }}
+/>
+```
+
+The full list without a button, from `src/pages/what-is-cardano.js`:
+
+```jsx
+<ProofPointsList points={getProofPoints()} />
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `points` | `Array<{ key, icon, title, tagline, text }>` | - | The rows. `key` must be unique, `icon` is a React element, the three strings are rendered as plain text. Required. |
+| `cta` | `{ label, to }` | - | Optional. When passed, a primary button with `label` linking to `to` renders below the list. |
+
+## Live Preview
+
+<ProofPointsList
+  points={[
+    {
+      key: "staking",
+      icon: <FaLock />,
+      title: "Staking without strings",
+      tagline: "Non-custodial, liquid staking",
+      text: "Delegating ada to a stake pool never moves it out of your wallet. There is no lock-up period and no slashing. You can spend or re-delegate at any time.",
+    },
+    {
+      key: "fees",
+      icon: <FaCalculator />,
+      title: "Fees you can predict",
+      tagline: "Deterministic transactions",
+      text: "A fee on Cardano is a simple formula of a fixed part plus the transaction size, set by protocol parameters rather than an auction.",
+    },
+  ]}
+  cta={{ label: "See all differences", to: "/what-is-cardano" }}
+/>
+
+## Notes
+
+- Strings are rendered as is, there is no markdown parsing. Keep links out of the text or add them to the surrounding page.
+- The data file builds each point with literal `translate()` calls so Crowdin can extract them. Do the same when you add a point.
+- Titles are `<h2>` through the theme `Heading`, so they take part in the page outline. Place the list under an `<h1>` or a titled section.
+- The icon wrapper is `aria-hidden`, the icons are decorative.

--- a/docs/get-involved/components/quiz-modal.md
+++ b/docs/get-involved/components/quiz-modal.md
@@ -1,0 +1,67 @@
+---
+title: Quiz Modal
+description: Launch a Quiz inside a Modal from a single button using the QuizModal component on cardano.org.
+---
+
+import QuizModal from '@site/src/components/QuizModal';
+import quizData from '@site/src/data/quiz-demo.json';
+
+## QuizModal
+
+A one-line composition of [Modal](./modal.md) and [Quiz](./quiz.md): a trigger button that opens the quiz in a dialog labeled "Quiz". All quiz behavior belongs to `Quiz`, all dialog behavior to `Modal`. This component only forwards props.
+
+[Quiz Card](./quiz-card.md) wraps it in a styled card, and `QuizHub` uses it for every quiz on `/quiz`.
+
+## Basic Usage
+
+Classic usage, as [Quiz Card](./quiz-card.md) does it:
+
+```jsx
+import QuizModal from '@site/src/components/QuizModal';
+import quizData from '@site/src/data/quiz-demo.json';
+
+<QuizModal
+  quizData={quizData}
+  buttonText="Test Your Knowledge"
+  questionCount={5}
+  passingScore={60}
+  allowRetry={true}
+/>
+```
+
+Hub mode, from `src/components/QuizHub/index.js`:
+
+```jsx
+<QuizModal
+  quizData={data}
+  questionCount={data.questionCount}
+  allowRetry={false}
+  onRecord={onRecord}
+  academyCta={getAcademyCta(entry.academyKey, entry.id)}
+  buttonText={translate({ id: 'quiz.hub.start', message: 'Start quiz' })}
+  buttonClassName={styles.cardCta}
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `quizData` | `object` | - | The quiz JSON, see the [Quiz data format](./quiz.md#quiz-data-format). Required. |
+| `buttonText` | `string` | `"Test Your Knowledge"` | Content of the trigger button. Pass a translated string, the default is English only. |
+| `questionCount` | `number` | `5` | Forwarded to `Quiz`. Number of questions sampled per run. |
+| `allowRetry` | `boolean` | `true` | Forwarded to `Quiz`. Whether a retry button appears after a failed run. |
+| `passingScore` | `number` | `60` | Forwarded to `Quiz`. Minimum percentage to pass. |
+| `onRecord` | `function` | `null` | Forwarded to `Quiz`. `(correct, total) => void`, switches the quiz into hub mode. |
+| `academyCta` | `object` | `null` | Forwarded to `Quiz`. Follow-up link shown on the hub mode result screen. |
+| `buttonClassName` | `string` | - | Forwarded to `Modal`. Replaces the default trigger button style. |
+
+## Live Preview
+
+<QuizModal quizData={quizData} buttonText="Try the demo quiz" questionCount={3} />
+
+## Notes
+
+- The dialog label is hardcoded to `"Quiz"`, which also yields the close button label "Close quiz".
+- The [Two Column Layout](./two-column-layout.md) example on the common scams page uses [Quiz Card](./quiz-card.md), not this component directly.
+- For the full list of quiz props, hub mode, and the data format, read [Quiz](./quiz.md).

--- a/docs/get-involved/components/term-explainer.md
+++ b/docs/get-involved/components/term-explainer.md
@@ -1,0 +1,51 @@
+---
+title: Term Explainer
+description: Show two random glossary terms from a category under a divider using the TermExplainer component on cardano.org.
+---
+
+import BackgroundWrapper from '@site/src/components/Layout/BackgroundWrapper';
+import BoundaryBox from '@site/src/components/Layout/BoundaryBox';
+import TermExplainer from '@site/src/components/TermExplainer';
+
+## TermExplainer
+
+A "terms you should know" section. It renders a white [Divider](./divider.md) with the category name, then picks two random terms from that category in `src/data/termsForTermExplainer.json` and shows each with its title and description side by side. The random pick happens on the client after hydration, so the server-rendered page starts with no terms and fills in on load.
+
+Used on `/governance`, `/governance/accountability`, and `/constitution`, always inside a `gradientLight` [Background Wrapper](./background-wrapper.md).
+
+## Basic Usage
+
+From `src/pages/constitution.js`:
+
+```jsx
+import BackgroundWrapper from '@site/src/components/Layout/BackgroundWrapper';
+import BoundaryBox from '@site/src/components/Layout/BoundaryBox';
+import TermExplainer from '@site/src/components/TermExplainer';
+
+<BackgroundWrapper backgroundType="gradientLight">
+  <BoundaryBox>
+    <TermExplainer category="governance" />
+  </BoundaryBox>
+</BackgroundWrapper>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `category` | `string` | - | Key under `categories` in `src/data/termsForTermExplainer.json`. Currently `staking`, `catalyst`, `governance`, or `cip`. An unknown key renders the divider with no terms. |
+
+## Live Preview
+
+<BackgroundWrapper backgroundType="gradientLight">
+  <BoundaryBox>
+    <TermExplainer category="staking" />
+  </BoundaryBox>
+</BackgroundWrapper>
+
+## Notes
+
+- The divider text is translated inside the component (`termExplainer.divider`, `{category} Terms you should know`). The raw category key is inserted, so it appears as written in the JSON, for example "governance Terms you should know".
+- Term descriptions go through `parseMarkdownLikeText`, so `[label](url)` links and `**bold**` markers in the JSON render as links and bold text.
+- The terms in the JSON file are English only and are not part of the Crowdin flow. Add a term to the JSON to make it eligible for the random pick.
+- Each reload shows a different pair, which is intended.

--- a/docs/get-involved/components/two-column-box.md
+++ b/docs/get-involved/components/two-column-box.md
@@ -1,0 +1,53 @@
+---
+title: Two Column Box
+description: Render two columns of plain paragraphs that collapse to one on small screens using the TwoColumnBox component on cardano.org.
+---
+
+import TwoColumnBox from '@site/src/components/Layout/TwoColumnBox';
+
+## TwoColumnBox
+
+Two equal text columns (`col--6` each) that stack into one column on narrow screens. Each side takes a string or an array of strings and renders one paragraph per entry. No title, no markdown parsing.
+
+Used on `/stake-pool-delegation` and `/stake-pool-operation`, usually right after a [Divider](./divider.md).
+
+## Basic Usage
+
+From `src/pages/stake-pool-delegation.js`. The page only fills the left column, which leaves the right half empty and keeps the paragraph at reading width:
+
+```jsx
+import Divider from '@site/src/components/Layout/Divider';
+import TwoColumnBox from '@site/src/components/Layout/TwoColumnBox';
+import { translate } from '@docusaurus/Translate';
+
+<Divider text={translate({ id: 'stakePoolDelegation.whatIsDelegation.divider', message: 'What is stake delegation?' })} />
+<TwoColumnBox
+  leftText={[
+    translate({ id: 'stakePoolDelegation.whatIsDelegation.text', message: 'Delegation is the process by which ada holders delegate the stake associated with their ada to a stake pool. It allows ada holders that do not have the skills or desire to run a node to participate in the network and be rewarded in proportion to the amount of stake delegated.' }),
+  ]}
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `leftText` | `string` \| `string[]` | - | Text for the left column. A string renders one `<p>`, an array renders one `<p>` per entry. Plain strings, no markdown parsing. |
+| `rightText` | `string` \| `string[]` | - | Text for the right column, same rules as `leftText`. |
+
+## Live Preview
+
+<TwoColumnBox
+  leftText="Delegation is the process by which ada holders delegate the stake associated with their ada to a stake pool."
+  rightText={[
+    "It allows ada holders that do not have the skills or desire to run a node to participate in the network.",
+    "They are rewarded in proportion to the amount of stake delegated.",
+  ]}
+/>
+
+## Notes
+
+- Consumers pass already translated strings.
+- An omitted side still renders an empty `<p>` inside its column, which is harmless but means the layout stays two columns wide.
+- The text color is inherited, so the box works on light and dark backgrounds.
+- For a single full-width column, see [One Column Box](./one-column-box.md).


### PR DESCRIPTION
- Adds doc pages for the layout primitives CtaOneColumn, CtaTwoColumn, OneColumnBox, TwoColumnBox, FeaturedTitleWithText, DottedImageWithText and IconHero
- Adds doc pages for the insights page shell and footer
- Adds doc pages for AppTile, AppRow, AppIcon and HorizontalScroller
- Adds doc pages for Modal, QuizModal, TermExplainer and ProofPointsList
- Part of #833