### PR TITLE
chore: update blog post titles for improved descriptive clarity

### DIFF
--- a/blog/2026-01-06-community-digest/index.md
+++ b/blog/2026-01-06-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-01-06-community-digest
-title: "Buidler Fest 3 heads to Buenos Aires; Critical Integrations Budget executes"
+title: "Buidler Fest 3 heads to Buenos Aires as the Critical Integrations Budget executes"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-01-06-community-digest/index.md
+++ b/blog/2026-01-06-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-01-06-community-digest
-title: "Community Digest"
+title: "Buidler Fest 3 heads to Buenos Aires; Critical Integrations Budget executes"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-01-19-community-digest/index.md
+++ b/blog/2026-01-19-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-01-19-community-digest
-title: "Community Digest"
+title: "Amplify Cardano funding; van Rossem hard fork announced"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-01-19-community-digest/index.md
+++ b/blog/2026-01-19-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-01-19-community-digest
-title: "Amplify Cardano funding; van Rossem hard fork announced"
+title: "Amplify Cardano funding and van Rossem hard fork announced"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-01-23-weekly-development-report/index.md
+++ b/blog/2026-01-23-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-01-23-weekly-development-report
-title: "Weekly Development Report"
+title: "Constitution takes effect; nested transactions and Mithril SNARK work advance"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-01-23-weekly-development-report/index.md
+++ b/blog/2026-01-23-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-01-23-weekly-development-report
-title: "Constitution takes effect; nested transactions and Mithril SNARK work advance"
+title: "Constitution takes effect as nested transactions and Mithril SNARK work advance"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-01-30-weekly-development-report/index.md
+++ b/blog/2026-01-30-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-01-30-weekly-development-report
-title: "Weekly Development Report"
+title: "Node v10.7 and Leios endorser-block prototyping make progress"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-02-02-community-digest/index.md
+++ b/blog/2026-02-02-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-02-02-community-digest
-title: "Community Digest"
+title: "USDCx partner integration; Mesh launches CGOV governance platform"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-02-02-community-digest/index.md
+++ b/blog/2026-02-02-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-02-02-community-digest
-title: "USDCx partner integration; Mesh launches CGOV governance platform"
+title: "USDCx partner integration and Mesh's new CGOV governance platform"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-02-06-weekly-development-report/index.md
+++ b/blog/2026-02-06-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-02-06-weekly-development-report
-title: "Weekly Development Report"
+title: "High-assurance verification tool enters early access"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-02-13-weekly-development-report/index.md
+++ b/blog/2026-02-13-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-02-13-weekly-development-report
-title: "Weekly Development Report"
+title: "Node v10.5.4 patch release and Leios parameter research"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-02-17-community-digest/index.md
+++ b/blog/2026-02-17-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-02-17-community-digest
-title: "Community Digest"
+title: "LayerZero integration approved; Midnight mainnet launch approaches"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-02-17-community-digest/index.md
+++ b/blog/2026-02-17-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-02-17-community-digest
-title: "LayerZero integration approved; Midnight mainnet launch approaches"
+title: "LayerZero integration approved as Midnight mainnet launch approaches"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-02-20-weekly-development-report/index.md
+++ b/blog/2026-02-20-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-02-20-weekly-development-report
-title: "Weekly Development Report"
+title: "Node v10.6.2 readies the network for the v11 hard fork"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-02-27-weekly-development-report/index.md
+++ b/blog/2026-02-27-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-02-27-weekly-development-report
-title: "Weekly Development Report"
+title: "MoneyGram joins Midnight as a federated node operator"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-03-03-community-digest/index.md
+++ b/blog/2026-03-03-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-03-community-digest
-title: "Community Digest"
+title: "USDCx live on mainnet; Foundation takes on Project Catalyst"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-03-03-community-digest/index.md
+++ b/blog/2026-03-03-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-03-community-digest
-title: "USDCx live on mainnet; Foundation takes on Project Catalyst"
+title: "USDCx live on mainnet as the Foundation takes on Project Catalyst"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-03-06-weekly-development-report/index.md
+++ b/blog/2026-03-06-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-06-weekly-development-report
-title: "Weekly Development Report"
+title: "Leios scaling testnet and Dijkstra era preparations"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-03-06-weekly-development-report/index.md
+++ b/blog/2026-03-06-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-06-weekly-development-report
-title: "Leios scaling testnet and Dijkstra era preparations"
+title: "Ada payments reach 137 SPAR stores as nested transactions advance"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-03-13-weekly-development-report/index.md
+++ b/blog/2026-03-13-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-13-weekly-development-report
-title: "Hydra, Mithril and node work feed the Dijkstra roadmap"
+title: "Binance lists NIGHT as Sandstone ships the Torsten Rust node"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-03-13-weekly-development-report/index.md
+++ b/blog/2026-03-13-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-13-weekly-development-report
-title: "Weekly Development Report"
+title: "Hydra, Mithril and node work feed the Dijkstra roadmap"
 authors: [iog]
 tags: [development]
 ---

--- a/blog/2026-03-16-community-digest/index.md
+++ b/blog/2026-03-16-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-16-community-digest
-title: "Community readies for the van Rossem upgrade"
+title: "Programmable Tokens go live as cardano.org adds Spanish support"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-03-16-community-digest/index.md
+++ b/blog/2026-03-16-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-16-community-digest
-title: "Community Digest"
+title: "Community readies for the van Rossem upgrade"
 authors: [cf]
 tags: [community]
 ---

--- a/blog/2026-03-20-weekly-development-report/index.md
+++ b/blog/2026-03-20-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-20-weekly-development-report
-title: "Weekly Development Report"
+title: "Node v10.7 packages ready for the protocol v11 hard fork"
 description: "Cardano Node v10.7 packages ready for the intra-era hard fork to protocol v11. Hydra v1.3.0 ships partial fanout work; team prepares for the Dijkstra era."
 authors: [iog]
 tags: [development]

--- a/blog/2026-03-27-weekly-development-report/index.md
+++ b/blog/2026-03-27-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-27-weekly-development-report
-title: "Weekly Development Report"
+title: "Node v10.7.0, Peras certificates and Mithril Halo2 SNARKs ship"
 description: "Node v10.7.0 ships, Peras adds on-chain certificate tracking, Mithril completes Halo2 SNARK primitives, Aggelos Kiayias named 2026 IACR Fellow."
 authors: [iog]
 tags: [development]

--- a/blog/2026-03-31-community-digest/index.md
+++ b/blog/2026-03-31-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-31-community-digest
-title: "Midnight mainnet launches ZK apps; first Bitcoin-Cardano atomic swap"
+title: "Midnight mainnet launches ZK apps and the first Bitcoin-Cardano atomic swap"
 description: "Midnight mainnet launches ZK apps, FluidTokens runs the first native Bitcoin to Cardano atomic swap, Cardano Node 10.7.0 cuts RAM use from 24 GB to 8 GB."
 authors: [cf]
 tags: [community]

--- a/blog/2026-03-31-community-digest/index.md
+++ b/blog/2026-03-31-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-03-31-community-digest
-title: "Community Digest"
+title: "Midnight mainnet launches ZK apps; first Bitcoin-Cardano atomic swap"
 description: "Midnight mainnet launches ZK apps, FluidTokens runs the first native Bitcoin to Cardano atomic swap, Cardano Node 10.7.0 cuts RAM use from 24 GB to 8 GB."
 authors: [cf]
 tags: [community]

--- a/blog/2026-04-03-weekly-development-report/index.md
+++ b/blog/2026-04-03-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-04-03-weekly-development-report
-title: "Weekly Development Report"
+title: "Lace integrates Midnight mainnet; Mithril activates SNARK prover"
 description: "Lace integrates Midnight mainnet for private assets, Mithril activates SNARK prover on devnet, tx-centrifuge benchmarks land for node v10.6.2."
 authors: [iog]
 tags: [development]

--- a/blog/2026-04-03-weekly-development-report/index.md
+++ b/blog/2026-04-03-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-04-03-weekly-development-report
-title: "Lace integrates Midnight mainnet; Mithril activates SNARK prover"
+title: "Lace integrates Midnight mainnet as Mithril activates the SNARK prover"
 description: "Lace integrates Midnight mainnet for private assets, Mithril activates SNARK prover on devnet, tx-centrifuge benchmarks land for node v10.6.2."
 authors: [iog]
 tags: [development]

--- a/blog/2026-04-10-weekly-development-report/index.md
+++ b/blog/2026-04-10-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-04-10-weekly-development-report
-title: "Weekly Development Report"
+title: "PlutusCoreBlaster brings Plutus Core to Lean 4"
 description: "PlutusCoreBlaster brings Plutus Core into Lean 4. Plutus UPLC optimizations, Mithril SNARK CLI for Cardano blocks, Intersect committee deadline April 17."
 authors: [iog]
 tags: [development]

--- a/blog/2026-04-14-community-digest/index.md
+++ b/blog/2026-04-14-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-04-14-community-digest
-title: "Community Digest"
+title: "Gerolamo TypeScript node debuts; network hits 120M transactions"
 description: "Pragma opens infrastructure project applications, Gerolamo TypeScript node debuts, Cardano hits 120M transactions, Van Rossem hard fork on track for June."
 authors: [cf]
 tags: [community]

--- a/blog/2026-04-14-community-digest/index.md
+++ b/blog/2026-04-14-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-04-14-community-digest
-title: "Gerolamo TypeScript node debuts; network hits 120M transactions"
+title: "Gerolamo TypeScript node debuts as the network hits 120M transactions"
 description: "Pragma opens infrastructure project applications, Gerolamo TypeScript node debuts, Cardano hits 120M transactions, Van Rossem hard fork on track for June."
 authors: [cf]
 tags: [community]

--- a/blog/2026-04-17-weekly-development-report/index.md
+++ b/blog/2026-04-17-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-04-17-weekly-development-report
-title: "Weekly Development Report"
+title: "Treasury proposals finalized ahead of committee voting"
 description: "Treasury proposals finalized; Leios & Node v10.7 updates; new decentralized AI research lab in Greece; Intersect committee voting starts April 20."
 authors: [iog]
 tags: [development]

--- a/blog/2026-04-24-weekly-development-report/index.md
+++ b/blog/2026-04-24-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-04-24-weekly-development-report
-title: "Treasury proposals live; Plutus UPLC cuts costs by 10%"
+title: "Treasury proposals live, Plutus UPLC cuts costs by 10%"
 description: "2026 Treasury proposals live; Leios & Mithril SNARK progress; Plutus UPLC reduces costs by 10%; Intersect committee voting open with 105 candidates."
 authors: [iog]
 tags: [development]

--- a/blog/2026-04-24-weekly-development-report/index.md
+++ b/blog/2026-04-24-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-04-24-weekly-development-report
-title: "Weekly Development Report"
+title: "Treasury proposals live; Plutus UPLC cuts costs by 10%"
 description: "2026 Treasury proposals live; Leios & Mithril SNARK progress; Plutus UPLC reduces costs by 10%; Intersect committee voting open with 105 candidates."
 authors: [iog]
 tags: [development]

--- a/blog/2026-04-28-community-digest/index.md
+++ b/blog/2026-04-28-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-04-28-community-digest
-title: "Community Digest"
+title: "Cardano joins x402 for AI; Blockfrost adds Filecoin"
 description: "Cardano joins x402 for AI; Blockfrost adds Filecoin; Van Rossem upgrade nears; JuLC for Java devs; new 21M ADA marketing proposal for enterprise growth."
 authors: [cf]
 tags: [community]

--- a/blog/2026-04-28-community-digest/index.md
+++ b/blog/2026-04-28-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-04-28-community-digest
-title: "Cardano joins x402 for AI; Blockfrost adds Filecoin"
+title: "Cardano joins x402 for AI while Blockfrost adds Filecoin"
 description: "Cardano joins x402 for AI; Blockfrost adds Filecoin; Van Rossem upgrade nears; JuLC for Java devs; new 21M ADA marketing proposal for enterprise growth."
 authors: [cf]
 tags: [community]

--- a/blog/2026-05-01-weekly-development-report/index.md
+++ b/blog/2026-05-01-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-01-weekly-development-report
-title: "Weekly Development Report"
+title: "IO treasury proposals live; Q4/Q1 delivery report published"
 description: "IO’s 2026 treasury proposals live; Q4/Q1 delivery report published; Leios & Mithril SNARK progress; Intersect committee voting concludes today."
 authors: [iog]
 tags: [development]

--- a/blog/2026-05-01-weekly-development-report/index.md
+++ b/blog/2026-05-01-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-01-weekly-development-report
-title: "IO treasury proposals live; Q4/Q1 delivery report published"
+title: "IO treasury proposals live with Q4/Q1 delivery report published"
 description: "IO’s 2026 treasury proposals live; Q4/Q1 delivery report published; Leios & Mithril SNARK progress; Intersect committee voting concludes today."
 authors: [iog]
 tags: [development]

--- a/blog/2026-05-08-weekly-development-report/index.md
+++ b/blog/2026-05-08-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-08-weekly-development-report
-title: "Weekly Development Report"
+title: "Leios testnet active; Node v11.0 pre-released"
 description: "Leios testnet active & Node v11.0 pre-released; Hydra optimizes high-volume benchmarks; Mithril SNARK tests finish; research proposal goes on-chain."
 authors: [iog]
 tags: [development]

--- a/blog/2026-05-08-weekly-development-report/index.md
+++ b/blog/2026-05-08-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-08-weekly-development-report
-title: "Leios testnet active; Node v11.0 pre-released"
+title: "Leios testnet active and Node v11.0 pre-released"
 description: "Leios testnet active & Node v11.0 pre-released; Hydra optimizes high-volume benchmarks; Mithril SNARK tests finish; research proposal goes on-chain."
 authors: [iog]
 tags: [development]

--- a/blog/2026-05-11-community-digest/index.md
+++ b/blog/2026-05-11-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-11-community-digest
-title: "Pyth Pro feeds live; Yoroi rebrands to SecondFi"
+title: "Pyth Pro feeds live as Yoroi rebrands to SecondFi"
 description: "Pyth Pro feeds live; Yoroi rebrands to SecondFi; Intersect confirms elections and Node v11.0.1 readiness; Cardano Foundation launches Brazil lab."
 authors: [cf]
 tags: [community]

--- a/blog/2026-05-11-community-digest/index.md
+++ b/blog/2026-05-11-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-11-community-digest
-title: "Community Digest"
+title: "Pyth Pro feeds live; Yoroi rebrands to SecondFi"
 description: "Pyth Pro feeds live; Yoroi rebrands to SecondFi; Intersect confirms elections and Node v11.0.1 readiness; Cardano Foundation launches Brazil lab."
 authors: [cf]
 tags: [community]

--- a/blog/2026-05-15-weekly-development-report/index.md
+++ b/blog/2026-05-15-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-15-weekly-development-report
-title: "Weekly Development Report"
+title: "Node v11.0.1 ready for the v11 hard fork"
 description: "Node v11.0.1 live for v11 hard fork; Dijkstra era prep continues; Plutus UPLC cuts costs by 10%; Hydra v2.1.0 lowers latency; Mithril finishes SNARK validations."
 authors: [iog]
 tags: [development]

--- a/blog/2026-05-22-weekly-development-report/index.md
+++ b/blog/2026-05-22-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-22-weekly-development-report
-title: "Leios prototype adds voting; Lace launches on iOS"
+title: "Leios prototype adds voting and Lace launches on iOS"
 description: "Leios prototype adds first voting features; Lace launches on iOS; Mithril completes SNARK circuit refactoring; legacy V1 LedgerDB removed."
 authors: [iog]
 tags: [development]

--- a/blog/2026-05-22-weekly-development-report/index.md
+++ b/blog/2026-05-22-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-22-weekly-development-report
-title: "Weekly Development Report"
+title: "Leios prototype adds voting; Lace launches on iOS"
 description: "Leios prototype adds first voting features; Lace launches on iOS; Mithril completes SNARK circuit refactoring; legacy V1 LedgerDB removed."
 authors: [iog]
 tags: [development]

--- a/blog/2026-05-26-community-digest/index.md
+++ b/blog/2026-05-26-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-26-community-digest
-title: "Gimbalabs hackathon; revised Summit 2026 proposal with 22% budget cut"
+title: "Gimbalabs hackathon and revised Summit 2026 proposal with 22% budget cut"
 description: "Gimbalabs hosts public hackathon; Aiken v1.1.22 delivers compiler upgrades; revised Cardano Summit 2026 proposal features a 22% budget cut; new CIPs target mobile deep-linking."
 authors: [cf]
 tags: [community]

--- a/blog/2026-05-26-community-digest/index.md
+++ b/blog/2026-05-26-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-26-community-digest
-title: "Community Digest"
+title: "Gimbalabs hackathon; revised Summit 2026 proposal with 22% budget cut"
 description: "Gimbalabs hosts public hackathon; Aiken v1.1.22 delivers compiler upgrades; revised Cardano Summit 2026 proposal features a 22% budget cut; new CIPs target mobile deep-linking."
 authors: [cf]
 tags: [community]

--- a/blog/2026-05-29-weekly-development-report/index.md
+++ b/blog/2026-05-29-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-29-weekly-development-report
-title: "Leios funding approved; Constitutional Committee registration opens"
+title: "Leios funding approved and Constitutional Committee registration opens"
 description: "Leios funding approved with 88% support and certificate size reduced 40x; Plutus optimizations completed; Constitutional Committee registration opens."
 authors: [iog]
 tags: [development]

--- a/blog/2026-05-29-weekly-development-report/index.md
+++ b/blog/2026-05-29-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-05-29-weekly-development-report
-title: "Weekly Development Report"
+title: "Leios funding approved; Constitutional Committee registration opens"
 description: "Leios funding approved with 88% support and certificate size reduced 40x; Plutus optimizations completed; Constitutional Committee registration opens."
 authors: [iog]
 tags: [development]

--- a/blog/2026-06-05-weekly-development-report/index.md
+++ b/blog/2026-06-05-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-06-05-weekly-development-report
-title: "Weekly Development Report"
+title: "Lace 2.0.6 and Leios prototype advance into the Dijkstra era"
 description: "Lace 2.0.6 fixes DRep signing; Leios prototype advances to the Dijkstra era; Hydra removes UTXO head limits via partial fanout; Mithril optimizes SNARK circuit caching."
 authors: [iog]
 tags: [development]

--- a/blog/2026-06-10-community-digest/index.md
+++ b/blog/2026-06-10-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-06-10-community-digest
-title: "Budget voting live via Hydra; van Rossem active on PreProd"
+title: "Budget voting live via Hydra, van Rossem active on PreProd"
 description: "Budget voting is live via Hydra; the Van Rossem hard fork is active on PreProd; new CIPs target pool pledges and L2 voting; the Cardano Foundation partners with the Brazilian Olympic Committee."
 authors: [cf]
 tags: [community]

--- a/blog/2026-06-10-community-digest/index.md
+++ b/blog/2026-06-10-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-06-10-community-digest
-title: "Community Digest"
+title: "Budget voting live via Hydra; van Rossem active on PreProd"
 description: "Budget voting is live via Hydra; the Van Rossem hard fork is active on PreProd; new CIPs target pool pledges and L2 voting; the Cardano Foundation partners with the Brazilian Olympic Committee."
 authors: [cf]
 tags: [community]

--- a/blog/2026-06-12-weekly-development-report/index.md
+++ b/blog/2026-06-12-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-06-12-weekly-development-report
-title: "Weekly Development Report"
+title: "Smart-contract testing beta and Mithril SNARK genesis certificate"
 description: "A smart contract testing beta was launched, Mithril finalized its SNARK genesis certificate, the Constitutional Committee called for more election candidates, and the Cardano Vision 2026 proposal passed."
 authors: [iog]
 tags: [development]

--- a/blog/2026-06-19-weekly-development-report/index.md
+++ b/blog/2026-06-19-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-06-19-weekly-development-report
-title: "Weekly Development Report"
+title: "Lace Carbon testing and Hydra v2.2.0"
 description: "Lace Carbon entered internal testing, Hydra v2.2.0 launched, Mithril advanced recursive SNARKs, and the Constitutional Committee election officially became competitive with five candidates."
 authors: [iog]
 tags: [development]

--- a/blog/2026-06-24-community-digest/index.md
+++ b/blog/2026-06-24-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-06-24-community-digest
-title: "Ouroboros Leios testnet launches; Orion Fund applications open"
+title: "Ouroboros Leios testnet launches and Orion Fund applications open"
 description: "The Ouroboros Leios scaling testnet (Musashi Dojo) has launched; applications are opening for the $80M Orion Fund cohort and a board seat; Pyth Network oracles are live; and Fortune recognized the Cardano Foundation."
 authors: [cf]
 tags: [community]

--- a/blog/2026-06-24-community-digest/index.md
+++ b/blog/2026-06-24-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-06-24-community-digest
-title: "Community Digest"
+title: "Ouroboros Leios testnet launches; Orion Fund applications open"
 description: "The Ouroboros Leios scaling testnet (Musashi Dojo) has launched; applications are opening for the $80M Orion Fund cohort and a board seat; Pyth Network oracles are live; and Fortune recognized the Cardano Foundation."
 authors: [cf]
 tags: [community]

--- a/blog/2026-07-08-community-digest/index.md
+++ b/blog/2026-07-08-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-08-community-digest
-title: "Community Digest"
+title: "Genesis Hacker House opens; RealFi Phase 1 testnet live"
 description: "Genesis Hacker House applications opened for Cardano builders, the State of Cardano Governance 2026 report was released, RealFi launched its Phase 1 testnet, and several CIPs advanced through review."
 authors: [community]
 tags: [community]

--- a/blog/2026-07-08-community-digest/index.md
+++ b/blog/2026-07-08-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-08-community-digest
-title: "Genesis Hacker House opens; RealFi Phase 1 testnet live"
+title: "Genesis Hacker House opens and RealFi Phase 1 testnet goes live"
 description: "Genesis Hacker House applications opened for Cardano builders, the State of Cardano Governance 2026 report was released, RealFi launched its Phase 1 testnet, and several CIPs advanced through review."
 authors: [community]
 tags: [community]

--- a/blog/2026-07-10-weekly-development-report/index.md
+++ b/blog/2026-07-10-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-10-weekly-development-report
-title: "Legacy tracing backend removed; Lace 2.1 ships security check"
+title: "Legacy tracing backend removed and Lace 2.1 ships a wallet security check"
 description: "The legacy iohk-monitoring tracing backend and RTView were removed from cardano-node, Lace shipped browser extension 2.1 with a wallet security check, and DRep voting opened in the Constitutional Committee election."
 authors: [iog]
 tags: [development]

--- a/blog/2026-07-10-weekly-development-report/index.md
+++ b/blog/2026-07-10-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-10-weekly-development-report
-title: "Weekly Development Report"
+title: "Legacy tracing backend removed; Lace 2.1 ships security check"
 description: "The legacy iohk-monitoring tracing backend and RTView were removed from cardano-node, Lace shipped browser extension 2.1 with a wallet security check, and DRep voting opened in the Constitutional Committee election."
 authors: [iog]
 tags: [development]

--- a/blog/2026-07-17-weekly-development-report/index.md
+++ b/blog/2026-07-17-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-17-weekly-development-report
-title: "Weekly Development Report"
+title: "Leios testnet stabilizes; Plinth Static Analyzer launches"
 description: "The Leios testnet was stabilized with two prototype builds and a voting dashboard, the Plinth Static Analyzer launched, Mithril advanced its SNARK circuit, and the van Rossem hard fork passed ratification ahead of the Dijkstra era."
 authors: [iog]
 tags: [development]

--- a/blog/2026-07-17-weekly-development-report/index.md
+++ b/blog/2026-07-17-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-17-weekly-development-report
-title: "Leios testnet stabilizes; Plinth Static Analyzer launches"
+title: "Leios testnet stabilizes and the Plinth Static Analyzer launches"
 description: "The Leios testnet was stabilized with two prototype builds and a voting dashboard, the Plinth Static Analyzer launched, Mithril advanced its SNARK circuit, and the van Rossem hard fork passed ratification ahead of the Dijkstra era."
 authors: [iog]
 tags: [development]

--- a/blog/2026-07-22-community-digest/index.md
+++ b/blog/2026-07-22-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-22-community-digest
-title: Community Digest
+title: "Van Rossem activates as first community-governed upgrade"
 description: The Van Rossem hard fork activated as Cardano's first fully community-governed protocol upgrade, the Constitutional Committee election entered its final voting days, and new CIPs entered review.
 authors: [community]
 tags: [community]

--- a/blog/2026-07-24-weekly-development-report/index.md
+++ b/blog/2026-07-24-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-24-weekly-development-report
-title: Weekly Development Report
+title: "Leios integration advances; Lace adds in-app swaps; treasury withdrawal ratified"
 description: The ledger team advanced Leios integration, Lace added in-app swaps with hardware wallet support, and an Intersect treasury withdrawal of ₳25.4M was ratified.
 authors: [iog]
 tags: [development]

--- a/blog/2026-07-24-weekly-development-report/index.md
+++ b/blog/2026-07-24-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-24-weekly-development-report
-title: "Leios integration advances; Lace adds in-app swaps; treasury withdrawal ratified"
+title: "Leios integration advances, Lace adds in-app swaps and a treasury withdrawal is ratified"
 description: The ledger team advanced Leios integration, Lace added in-app swaps with hardware wallet support, and an Intersect treasury withdrawal of ₳25.4M was ratified.
 authors: [iog]
 tags: [development]

--- a/blog/2026-07-31-weekly-development-report/index.md
+++ b/blog/2026-07-31-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-31-weekly-development-report
-title: Weekly Development Report
+title: "New Leios prototype; Lace 2.2 adds Bitcoin hardware wallet support"
 description: A new Leios prototype enables endorser block certification, Lace 2.2 adds Bitcoin hardware wallet support, and Plutus work continued on new built-ins.
 authors: [iog]
 tags: [development]

--- a/blog/2026-07-31-weekly-development-report/index.md
+++ b/blog/2026-07-31-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-07-31-weekly-development-report
-title: "New Leios prototype; Lace 2.2 adds Bitcoin hardware wallet support"
+title: "New Leios prototype and Lace 2.2 adds Bitcoin hardware wallet support"
 description: A new Leios prototype enables endorser block certification, Lace 2.2 adds Bitcoin hardware wallet support, and Plutus work continued on new built-ins.
 authors: [iog]
 tags: [development]

--- a/blog/2026-08-05-community-digest/index.md
+++ b/blog/2026-08-05-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-08-05-community-digest
-title: "Cardano and Injective connect via IBC; CC election concludes"
+title: "Cardano and Injective connect via IBC and the CC election concludes"
 description: Cardano and Injective connected via IBC on testnet, the Constitutional Committee election concluded, and Musashi Dojo prepared for its water phase.
 authors: [community]
 tags: [community]

--- a/blog/2026-08-05-community-digest/index.md
+++ b/blog/2026-08-05-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-08-05-community-digest
-title: Community Digest
+title: "Cardano and Injective connect via IBC; CC election concludes"
 description: Cardano and Injective connected via IBC on testnet, the Constitutional Committee election concluded, and Musashi Dojo prepared for its water phase.
 authors: [community]
 tags: [community]

--- a/blog/2026-08-07-weekly-development-report/index.md
+++ b/blog/2026-08-07-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-08-07-weekly-development-report
-title: Weekly Development Report
+title: "Hydra 2.3.0 and Dijkstra nested transactions advance"
 description: Hydra released 2.3.0 with snapshot-processing speedups, the ledger advanced Dijkstra nested transactions, and Van Rossem benchmarks completed.
 authors: [iog]
 tags: [development]

--- a/blog/2026-08-14-weekly-development-report/index.md
+++ b/blog/2026-08-14-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-08-14-weekly-development-report
-title: "Consensus enables the Dijkstra hard fork; Plutus opens CIP-0194"
+title: "Consensus enables the Dijkstra hard fork and Plutus opens CIP-0194"
 description: Consensus released prototype-2026w32 with endorser-block announcements, ouroboros-consensus enabled the Dijkstra hard fork, and Plutus opened CIP-0194.
 authors: [iog]
 tags: [development]

--- a/blog/2026-08-14-weekly-development-report/index.md
+++ b/blog/2026-08-14-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-08-14-weekly-development-report
-title: Weekly Development Report
+title: "Consensus enables the Dijkstra hard fork; Plutus opens CIP-0194"
 description: Consensus released prototype-2026w32 with endorser-block announcements, ouroboros-consensus enabled the Dijkstra hard fork, and Plutus opened CIP-0194.
 authors: [iog]
 tags: [development]

--- a/blog/2026-08-19-community-digest/index.md
+++ b/blog/2026-08-19-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-08-19-community-digest
-title: Community Digest
+title: "TOKEN2049 applications open; two votes due before September 1"
 description: Cardano opened applications for its TOKEN2049 booth, two on-chain votes needed action before September 1, and a Catalyst pilot awards usage-based grants.
 authors: [community]
 tags: [community]

--- a/blog/2026-08-19-community-digest/index.md
+++ b/blog/2026-08-19-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-08-19-community-digest
-title: "TOKEN2049 applications open; two votes due before September 1"
+title: "TOKEN2049 applications open and two votes are due before September 1"
 description: Cardano opened applications for its TOKEN2049 booth, two on-chain votes needed action before September 1, and a Catalyst pilot awards usage-based grants.
 authors: [community]
 tags: [community]

--- a/blog/2026-08-21-weekly-development-report/index.md
+++ b/blog/2026-08-21-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-08-21-weekly-development-report
-title: Weekly Development Report
+title: "MusashiNet testnet Earth phase closes after 41 days"
 description: The Leios team closed the Earth phase of the MusashiNet testnet after 41 days, 127,000 blocks and pool participation growing from three to 63.
 authors: [iog]
 tags: [development]

--- a/blog/2026-08-28-weekly-development-report/index.md
+++ b/blog/2026-08-28-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-08-28-weekly-development-report
-title: Weekly Development Report
+title: "Lace adds Keystone support; Plutus releases v1.68.0.0"
 description: Lace added Keystone hardware wallet support, Plutus published release 1.68.0.0 with V4 ledger API types, and Hydra moved persisted payloads to CBOR.
 authors: [iog]
 tags: [development]

--- a/blog/2026-08-28-weekly-development-report/index.md
+++ b/blog/2026-08-28-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-08-28-weekly-development-report
-title: "Lace adds Keystone support; Plutus releases v1.68.0.0"
+title: "Lace adds Keystone support and Plutus releases v1.68.0.0"
 description: Lace added Keystone hardware wallet support, Plutus published release 1.68.0.0 with V4 ledger API types, and Hydra moved persisted payloads to CBOR.
 authors: [iog]
 tags: [development]

--- a/blog/2026-09-02-community-digest/index.md
+++ b/blog/2026-09-02-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-09-02-community-digest
-title: Community Digest
+title: "Board seat applications open; Constitutional Amendment Portal enters alpha"
 description: Intersect opened applications for two Board seats, the Constitutional Amendment Portal entered alpha, and Daedalus 11.3.0 added a DRep directory.
 authors: [community]
 tags: [community]

--- a/blog/2026-09-02-community-digest/index.md
+++ b/blog/2026-09-02-community-digest/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-09-02-community-digest
-title: "Board seat applications open; Constitutional Amendment Portal enters alpha"
+title: "Board seat applications open and the Constitutional Amendment Portal enters alpha"
 description: Intersect opened applications for two Board seats, the Constitutional Amendment Portal entered alpha, and Daedalus 11.3.0 added a DRep directory.
 authors: [community]
 tags: [community]

--- a/blog/2026-09-04-weekly-development-report/index.md
+++ b/blog/2026-09-04-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-09-04-weekly-development-report
-title: Weekly Development Report
+title: "Node v11.1.0 benchmarks; Hydra formalized in Agda"
 description: Benchmarks of Cardano node v.11.1.0 showed lower CPU usage, Hydra formalized its specification in Agda, and research held a data availability workshop.
 authors: [iog]
 tags: [development]

--- a/blog/2026-09-04-weekly-development-report/index.md
+++ b/blog/2026-09-04-weekly-development-report/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 2026-09-04-weekly-development-report
-title: "Node v11.1.0 benchmarks; Hydra formalized in Agda"
+title: "Node v11.1.0 benchmarks and Hydra formalized in Agda"
 description: Benchmarks of Cardano node v.11.1.0 showed lower CPU usage, Hydra formalized its specification in Agda, and research held a data availability workshop.
 authors: [iog]
 tags: [development]


### PR DESCRIPTION
This PR replaces the previously repeating titles on recurring blog posts with descriptive, content-specific headlines. 

**What changed:**
- 31 x Weekly Development Report 
- 18 x Community Digest 


